### PR TITLE
ci: add code quality tooling (codecov, govulncheck, gosec, scorecard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,17 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test -v -race -coverprofile=coverage.out ./...
+      - uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
       - run: go build ./cmd/schwab-agent/
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,4 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: go.mod
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,33 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Weekly Monday 6am UTC (1am CT)
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - bodyclose
     - errorlint
     - gocritic
+    - gosec
     - misspell
     - nolintlint
     - revive
@@ -48,6 +49,7 @@ linters:
         linters:
           - bodyclose
           - goconst
+          - gosec
           - unparam
 
 run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ internal/
   auth/                 OAuth2 flow, token lifecycle, config (JSON + env vars)
   client/               Schwab API HTTP client (see internal/client/AGENTS.md)
   commands/             CLI command handlers (see internal/commands/AGENTS.md)
-  errors/               Typed error hierarchy with exit codes
+  apperr/               Typed error hierarchy with exit codes
   models/               Data structures/schemas for API payloads
   orderbuilder/         Order construction/validation (equity, option, bracket, OCO) + OCC symbol build/parse
   output/               JSON envelope writers (success, error, partial)
@@ -48,7 +48,7 @@ golangci-lint v2 config (`.golangci.yml`). Active linters: bodyclose, errorlint,
 
 ## Error Hierarchy
 
-All errors in `internal/errors/errors.go`. Base type `SchwabError` with typed subtypes:
+All errors in `internal/apperr/errors.go`. Base type `SchwabError` with typed subtypes:
 
 | Error Type | Exit Code | When |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/major/schwab-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/major/schwab-agent/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/github/go-mod/go-version/major/schwab-agent)](https://go.dev/)
+[![codecov](https://codecov.io/gh/major/schwab-agent/branch/main/graph/badge.svg)](https://codecov.io/gh/major/schwab-agent)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/major/schwab-agent/badge)](https://scorecard.dev/viewer/?uri=github.com/major/schwab-agent)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 CLI tool for AI agents to trade via the Charles Schwab API. Single binary, JSON-first output, built-in safety guards.

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/major/schwab-agent/internal/auth"
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/commands"
-	"github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -44,7 +44,7 @@ func main() {
 
 	if err := app.Run(ctx, os.Args); err != nil {
 		_ = output.WriteError(os.Stdout, err)
-		os.Exit(errors.ExitCodeFor(err))
+		os.Exit(apperr.ExitCodeFor(err))
 	}
 }
 
@@ -118,20 +118,20 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 
 			cfg, err := auth.LoadConfig(resolvedConfigPath)
 			if err != nil {
-			authErr := errors.NewAuthRequiredError("Missing required credentials: set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add client_id and client_secret to the config file", err)
+			authErr := apperr.NewAuthRequiredError("Missing required credentials: set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add client_id and client_secret to the config file", err)
 			authErr.Details = "Run `schwab-agent auth login` to authenticate"
 				return ctx, authErr
 			}
 
 			token, err := auth.LoadToken(resolvedTokenPath)
 			if err != nil {
-				authErr := errors.NewAuthRequiredError("No authentication token found", err)
+				authErr := apperr.NewAuthRequiredError("No authentication token found", err)
 				authErr.Details = "Run `schwab-agent auth login` to authenticate"
 				return ctx, authErr
 			}
 
 			if auth.IsRefreshTokenStale(token) {
-				authErr := errors.NewAuthExpiredError("refresh token expired", nil)
+				authErr := apperr.NewAuthExpiredError("refresh token expired", nil)
 				authErr.Details = "Run `schwab-agent auth login` to re-authenticate"
 				return ctx, authErr
 			}

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/auth"
 	"github.com/major/schwab-agent/internal/client"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // runApp builds and executes the root command without allowing urfave/cli to call os.Exit.
@@ -85,10 +85,10 @@ func TestBeforeHook_SkipsAuthForAuthCommand(t *testing.T) {
 	_, err := runApp(t, "schwab-agent", "auth", "status")
 	require.Error(t, err)
 
-	var authErr *schwabErrors.AuthRequiredError
+	var authErr *apperr.AuthRequiredError
 	require.ErrorAs(t, err, &authErr)
 
-	var validationErr *schwabErrors.ValidationError
+	var validationErr *apperr.ValidationError
 	assert.False(t, stderrors.As(err, &validationErr))
 }
 
@@ -111,12 +111,12 @@ func TestBeforeHook_ReturnsAuthErrorForAPICommand(t *testing.T) {
 	_, err := runApp(t, "schwab-agent", "--config", configPath, "account")
 	require.Error(t, err)
 
-	var authErr *schwabErrors.AuthRequiredError
+	var authErr *apperr.AuthRequiredError
 	require.ErrorAs(t, err, &authErr)
-	assert.Equal(t, "AUTH_REQUIRED", schwabErrors.ErrorCode(err))
+	assert.Equal(t, "AUTH_REQUIRED", apperr.ErrorCode(err))
 	assert.Equal(t, "No authentication token found", authErr.Message)
 	assert.Equal(t, "Run `schwab-agent auth login` to authenticate", authErr.Details)
-	assert.Equal(t, 3, schwabErrors.ExitCodeFor(err))
+	assert.Equal(t, 3, apperr.ExitCodeFor(err))
 }
 
 func TestBeforeHook_ReturnsAuthRequiredErrorForMissingConfig(t *testing.T) {
@@ -128,12 +128,12 @@ func TestBeforeHook_ReturnsAuthRequiredErrorForMissingConfig(t *testing.T) {
 	_, err := runApp(t, "schwab-agent", "--config", missingConfigPath, "account")
 	require.Error(t, err)
 
-	var authErr *schwabErrors.AuthRequiredError
+	var authErr *apperr.AuthRequiredError
 	require.ErrorAs(t, err, &authErr)
-	assert.Equal(t, "AUTH_REQUIRED", schwabErrors.ErrorCode(err))
+	assert.Equal(t, "AUTH_REQUIRED", apperr.ErrorCode(err))
 	assert.Equal(t, "Missing required credentials: set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add client_id and client_secret to the config file", authErr.Message)
 	assert.Equal(t, "Run `schwab-agent auth login` to authenticate", authErr.Details)
-	assert.Equal(t, 3, schwabErrors.ExitCodeFor(err))
+	assert.Equal(t, 3, apperr.ExitCodeFor(err))
 }
 
 func TestBeforeHook_ReturnsAuthExpiredErrorForStaleRefreshToken(t *testing.T) {
@@ -156,10 +156,10 @@ func TestBeforeHook_ReturnsAuthExpiredErrorForStaleRefreshToken(t *testing.T) {
 	_, err := runApp(t, "schwab-agent", "--config", configPath, "--token", tokenPath, "account")
 	require.Error(t, err)
 
-	var authErr *schwabErrors.AuthExpiredError
+	var authErr *apperr.AuthExpiredError
 	require.ErrorAs(t, err, &authErr)
 	assert.Equal(t, "Run `schwab-agent auth login` to re-authenticate", authErr.Details)
-	assert.Equal(t, 3, schwabErrors.ExitCodeFor(err))
+	assert.Equal(t, 3, apperr.ExitCodeFor(err))
 }
 
 func TestBeforeHook_RefreshesExpiredToken(t *testing.T) {

--- a/internal/apperr/errors.go
+++ b/internal/apperr/errors.go
@@ -1,5 +1,5 @@
-// Package errors defines the error hierarchy and exit code mapping for schwab-agent.
-package errors
+// Package apperr defines the error hierarchy and exit code mapping for schwab-agent.
+package apperr
 
 import (
 	"errors"

--- a/internal/apperr/errors_test.go
+++ b/internal/apperr/errors_test.go
@@ -1,4 +1,4 @@
-package errors
+package apperr
 
 import (
 	"errors"

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // Config holds Schwab API credentials and settings.
@@ -62,7 +62,7 @@ func LoadConfig(configPath string) (*Config, error) {
 
 	// Validate required fields
 	if cfg.ClientID == "" || cfg.ClientSecret == "" {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			"Missing required credentials: set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add client_id and client_secret to the config file",
 			nil,
 		)
@@ -100,7 +100,7 @@ func SetDefaultAccount(configPath, hash string) error {
 	cfg, err := LoadConfig(configPath)
 	if err != nil {
 		// If validation error (missing credentials) or file doesn't exist, create a minimal config
-		var valErr *schwabErrors.ValidationError
+		var valErr *apperr.ValidationError
 		if errors.As(err, &valErr) || os.IsNotExist(err) {
 			// For validation errors or missing file, create empty config
 			cfg = &Config{}

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -81,7 +81,7 @@ func SaveConfig(configPath string, cfg *Config) error {
 	}
 
 	// Marshal config to JSON
-	data, err := json.MarshalIndent(cfg, "", "  ")
+	data, err := json.MarshalIndent(cfg, "", "  ") //nolint:gosec // G117: config file intentionally stores client_secret with 0600 perms
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestLoadConfig_MissingFile_ReturnsValidationError(t *testing.T) {
@@ -23,7 +23,7 @@ func TestLoadConfig_MissingFile_ReturnsValidationError(t *testing.T) {
 	assert.Nil(t, cfg)
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Contains(t, err.Error(), "SCHWAB_CLIENT_ID")
 	assert.Contains(t, err.Error(), "SCHWAB_CLIENT_SECRET")
@@ -173,7 +173,7 @@ func TestLoadConfig_MissingClientID_ReturnsValidationError(t *testing.T) {
 	assert.Nil(t, cfg)
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Contains(t, err.Error(), "SCHWAB_CLIENT_ID")
 	assert.Contains(t, err.Error(), "config file")
@@ -199,7 +199,7 @@ func TestLoadConfig_MissingClientSecret_ReturnsValidationError(t *testing.T) {
 	assert.Nil(t, cfg)
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Contains(t, err.Error(), "SCHWAB_CLIENT_SECRET")
 	assert.Contains(t, err.Error(), "config file")
@@ -223,7 +223,7 @@ func TestLoadConfig_BothMissing_ReturnsValidationError(t *testing.T) {
 	assert.Nil(t, cfg)
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -445,7 +445,7 @@ func TestLoadConfig_EmptyFile_ReturnsValidationError(t *testing.T) {
 	assert.Nil(t, cfg)
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -32,7 +32,7 @@ const (
 	authorizeEndpoint = "https://api.schwabapi.com/v1/oauth/authorize"
 
 	// oauthTokenEndpoint is Schwab's OAuth token endpoint.
-	oauthTokenEndpoint = "https://api.schwabapi.com/v1/oauth/token"
+	oauthTokenEndpoint = "https://api.schwabapi.com/v1/oauth/token" //nolint:gosec // G101: API endpoint URL, not a credential
 
 	// defaultCallbackAddr limits the local callback server to loopback.
 	defaultCallbackAddr = "127.0.0.1:8182"
@@ -260,7 +260,10 @@ func startCallbackServer(addr, expectedState string, readyCh chan<- struct{}) (s
 	resultCh := make(chan callbackResult, 1)
 	var once sync.Once
 
-	server := &http.Server{Handler: callbackHandler(expectedState, resultCh, &once)}
+	server := &http.Server{
+		Handler:           callbackHandler(expectedState, resultCh, &once),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 
 	go func() {
 		serveErr := server.Serve(tlsListener)

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pkg/browser"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 const (
@@ -63,7 +63,7 @@ var oauthHTTPClient = &http.Client{
 func AuthorizeURL(cfg *Config) (authURL, state string, err error) {
 	state, err = randomOAuthState()
 	if err != nil {
-		return "", "", schwabErrors.NewAuthCallbackError("failed to generate OAuth state", err)
+		return "", "", apperr.NewAuthCallbackError("failed to generate OAuth state", err)
 	}
 
 	query := url.Values{}
@@ -91,7 +91,7 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 
 	req, err := http.NewRequest(http.MethodPost, tokenEndpoint, strings.NewReader(formData.Encode()))
 	if err != nil {
-		return nil, schwabErrors.NewAuthCallbackError("failed to build token exchange request", err)
+		return nil, apperr.NewAuthCallbackError("failed to build token exchange request", err)
 	}
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -99,17 +99,17 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 
 	resp, err := oauthHTTPClient.Do(req)
 	if err != nil {
-		return nil, schwabErrors.NewAuthCallbackError("token exchange request failed", err)
+		return nil, apperr.NewAuthCallbackError("token exchange request failed", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, schwabErrors.NewAuthCallbackError("failed to read token exchange response", err)
+		return nil, apperr.NewAuthCallbackError("failed to read token exchange response", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, schwabErrors.NewAuthCallbackError(
+		return nil, apperr.NewAuthCallbackError(
 			fmt.Sprintf("token exchange failed with status %d", resp.StatusCode),
 			fmt.Errorf("response body: %s", strings.TrimSpace(string(body))),
 		)
@@ -117,7 +117,7 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 
 	var token TokenData
 	if err := json.Unmarshal(body, &token); err != nil {
-		return nil, schwabErrors.NewAuthCallbackError("failed to parse token exchange response", err)
+		return nil, apperr.NewAuthCallbackError("failed to parse token exchange response", err)
 	}
 
 	nowUnix := now.Unix()
@@ -161,7 +161,7 @@ func RunLogin(cfg *Config, tokenPath, tokenEndpoint string, openBrowser bool, w 
 	if openBrowser {
 		logger.Info("Opening browser for Schwab login")
 		if err := browser.OpenURL(authURL); err != nil {
-			return schwabErrors.NewAuthCallbackError("failed to open browser", err)
+			return apperr.NewAuthCallbackError("failed to open browser", err)
 		}
 	} else {
 		logger.Info("Open this URL to authenticate", "url", authURL)
@@ -212,12 +212,12 @@ func randomOAuthState() (string, error) {
 func callbackAddress(cfg *Config) (string, error) {
 	parsedURL, err := url.Parse(cfg.CallbackURL)
 	if err != nil {
-		return "", schwabErrors.NewAuthCallbackError("invalid callback URL", err)
+		return "", apperr.NewAuthCallbackError("invalid callback URL", err)
 	}
 
 	host := parsedURL.Host
 	if host == "" {
-		return "", schwabErrors.NewAuthCallbackError("callback URL must include a host and port", nil)
+		return "", apperr.NewAuthCallbackError("callback URL must include a host and port", nil)
 	}
 
 	validatedAddr, err := validateCallbackAddr(host)
@@ -243,7 +243,7 @@ func startCallbackServer(addr, expectedState string, readyCh chan<- struct{}) (s
 		if readyCh != nil {
 			close(readyCh)
 		}
-		return "", schwabErrors.NewAuthCallbackError("failed to generate callback TLS certificate", err)
+		return "", apperr.NewAuthCallbackError("failed to generate callback TLS certificate", err)
 	}
 
 	listener, err := net.Listen("tcp", validatedAddr)
@@ -251,7 +251,7 @@ func startCallbackServer(addr, expectedState string, readyCh chan<- struct{}) (s
 		if readyCh != nil {
 			close(readyCh)
 		}
-		return "", schwabErrors.NewAuthCallbackError("failed to listen for OAuth callback", err)
+		return "", apperr.NewAuthCallbackError("failed to listen for OAuth callback", err)
 	}
 
 	tlsListener := tls.NewListener(listener, &tls.Config{Certificates: []tls.Certificate{certificate}})
@@ -267,7 +267,7 @@ func startCallbackServer(addr, expectedState string, readyCh chan<- struct{}) (s
 		if serveErr != nil && serveErr != http.ErrServerClosed {
 			once.Do(func() {
 				resultCh <- callbackResult{
-					err: schwabErrors.NewAuthCallbackError("OAuth callback server failed", serveErr),
+					err: apperr.NewAuthCallbackError("OAuth callback server failed", serveErr),
 				}
 			})
 		}
@@ -290,7 +290,7 @@ func startCallbackServer(addr, expectedState string, readyCh chan<- struct{}) (s
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
-		return "", schwabErrors.NewAuthCallbackError("timed out waiting for OAuth callback after 300 seconds", nil)
+		return "", apperr.NewAuthCallbackError("timed out waiting for OAuth callback after 300 seconds", nil)
 	}
 }
 
@@ -304,7 +304,7 @@ func callbackHandler(expectedState string, resultCh chan<- callbackResult, once 
 			http.Error(w, "state mismatch", http.StatusBadRequest)
 			once.Do(func() {
 				resultCh <- callbackResult{
-					err: schwabErrors.NewAuthCallbackError(
+					err: apperr.NewAuthCallbackError(
 						"OAuth callback state mismatch",
 						fmt.Errorf("expected state %q, got %q", expectedState, state),
 					),
@@ -317,7 +317,7 @@ func callbackHandler(expectedState string, resultCh chan<- callbackResult, once 
 			http.Error(w, "missing code", http.StatusBadRequest)
 			once.Do(func() {
 				resultCh <- callbackResult{
-					err: schwabErrors.NewAuthCallbackError("OAuth callback missing code", nil),
+					err: apperr.NewAuthCallbackError("OAuth callback missing code", nil),
 				}
 			})
 			return
@@ -340,11 +340,11 @@ func validateCallbackAddr(addr string) (string, error) {
 
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return "", schwabErrors.NewAuthCallbackError("callback address must include host and port", err)
+		return "", apperr.NewAuthCallbackError("callback address must include host and port", err)
 	}
 
 	if host != "127.0.0.1" {
-		return "", schwabErrors.NewAuthCallbackError("callback server must bind to 127.0.0.1 only", nil)
+		return "", apperr.NewAuthCallbackError("callback server must bind to 127.0.0.1 only", nil)
 	}
 
 	return addr, nil

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // synchronizedBuffer is a concurrency-safe writer for login flow tests.
@@ -151,7 +151,7 @@ func TestExchangeCode_Failure_ReturnsAuthCallbackError(t *testing.T) {
 	// Assert
 	assert.Nil(t, tokenFile)
 	require.Error(t, err)
-	var callbackErr *schwabErrors.AuthCallbackError
+	var callbackErr *apperr.AuthCallbackError
 	assert.ErrorAs(t, err, &callbackErr)
 	assert.Contains(t, err.Error(), "token exchange failed")
 }
@@ -194,7 +194,7 @@ func TestStartCallbackServer_StateMismatch_ReturnsAuthCallbackError(t *testing.T
 	// Assert
 	assert.Empty(t, result.code)
 	require.Error(t, result.err)
-	var callbackErr *schwabErrors.AuthCallbackError
+	var callbackErr *apperr.AuthCallbackError
 	assert.ErrorAs(t, result.err, &callbackErr)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Contains(t, responseBody, "state mismatch")

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 const (
@@ -47,7 +47,7 @@ func LoadToken(tokenPath string) (*TokenFile, error) {
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, schwabErrors.NewAuthRequiredError(
+			return nil, apperr.NewAuthRequiredError(
 				"token file not found: run `schwab-agent auth login` to authenticate",
 				err,
 			)
@@ -138,7 +138,7 @@ func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile
 	if resp.StatusCode != http.StatusOK {
 		var errResp tokenErrorResponse
 		if json.Unmarshal(body, &errResp) == nil && errResp.Error == "invalid_grant" {
-			return nil, schwabErrors.NewAuthExpiredError(
+			return nil, apperr.NewAuthExpiredError(
 				"refresh token expired: run `schwab-agent auth login` to re-authenticate",
 				nil,
 			)

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// tokenEndpoint is the Schwab OAuth token endpoint.
-	tokenEndpoint = "https://api.schwabapi.com/v1/oauth/token"
+	tokenEndpoint = "https://api.schwabapi.com/v1/oauth/token" //nolint:gosec // G101: API endpoint URL, not a credential
 
 	// refreshTokenMaxAge is 6.5 days in seconds, matching schwab-py's default.
 	refreshTokenMaxAge = 561600

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // makeTokenFile creates a TokenFile with sensible defaults for testing.
@@ -48,7 +48,7 @@ func TestLoadToken_MissingFile_ReturnsAuthRequiredError(t *testing.T) {
 	assert.Nil(t, tf)
 	require.Error(t, err)
 
-	var authReqErr *schwabErrors.AuthRequiredError
+	var authReqErr *apperr.AuthRequiredError
 	assert.ErrorAs(t, err, &authReqErr)
 	assert.Contains(t, err.Error(), "token file not found")
 }
@@ -110,7 +110,7 @@ func TestLoadToken_PermissionDenied_ReturnsError(t *testing.T) {
 	assert.Nil(t, tf)
 	require.Error(t, err)
 	// Should NOT be AuthRequiredError (file exists but can't be read)
-	var authReqErr *schwabErrors.AuthRequiredError
+	var authReqErr *apperr.AuthRequiredError
 	assert.False(t, errors.As(err, &authReqErr))
 }
 
@@ -410,7 +410,7 @@ func TestRefreshAccessToken_InvalidGrant_ReturnsAuthExpiredError(t *testing.T) {
 	assert.Nil(t, newTF)
 	require.Error(t, err)
 
-	var authExpErr *schwabErrors.AuthExpiredError
+	var authExpErr *apperr.AuthExpiredError
 	assert.ErrorAs(t, err, &authExpErr)
 	assert.Contains(t, err.Error(), "refresh token expired")
 }
@@ -490,7 +490,7 @@ func TestRefreshAccessToken_OtherHTTPError_ReturnsGenericError(t *testing.T) {
 	require.Error(t, err)
 
 	// Should NOT be AuthExpiredError for non-invalid_grant errors
-	var authExpErr *schwabErrors.AuthExpiredError
+	var authExpErr *apperr.AuthExpiredError
 	assert.False(t, errors.As(err, &authExpErr))
 }
 

--- a/internal/client/AGENTS.md
+++ b/internal/client/AGENTS.md
@@ -78,9 +78,9 @@ Some methods convert generic errors to domain-specific ones:
 
 ```go
 // quotes.go: 404 HTTPError -> SymbolNotFoundError
-var httpErr *schwabErrors.HTTPError
+var httpErr *apperr.HTTPError
 if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-    return nil, schwabErrors.NewSymbolNotFoundError(...)
+    return nil, apperr.NewSymbolNotFoundError(...)
 }
 ```
 

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -17,9 +17,9 @@ func (c *Client) AccountNumbers(ctx context.Context) ([]models.AccountNumber, er
 	err := c.doGet(ctx, "/trader/v1/accounts/accountNumbers", nil, &result)
 	if err != nil {
 		// Convert 404 HTTPError to AccountNotFoundError
-		var httpErr *schwabErrors.HTTPError
+		var httpErr *apperr.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return nil, schwabErrors.NewAccountNotFoundError("account numbers not found", err)
+			return nil, apperr.NewAccountNotFoundError("account numbers not found", err)
 		}
 		return nil, err
 	}
@@ -33,9 +33,9 @@ func (c *Client) Accounts(ctx context.Context) ([]models.Account, error) {
 	err := c.doGet(ctx, "/trader/v1/accounts", nil, &result)
 	if err != nil {
 		// Convert 404 HTTPError to AccountNotFoundError
-		var httpErr *schwabErrors.HTTPError
+		var httpErr *apperr.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return nil, schwabErrors.NewAccountNotFoundError("accounts not found", err)
+			return nil, apperr.NewAccountNotFoundError("accounts not found", err)
 		}
 		return nil, err
 	}
@@ -50,9 +50,9 @@ func (c *Client) Account(ctx context.Context, hashValue string) (*models.Account
 	err := c.doGet(ctx, path, nil, &result)
 	if err != nil {
 		// Convert 404 HTTPError to AccountNotFoundError
-		var httpErr *schwabErrors.HTTPError
+		var httpErr *apperr.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return nil, schwabErrors.NewAccountNotFoundError(fmt.Sprintf("account %s not found", hashValue), err)
+			return nil, apperr.NewAccountNotFoundError(fmt.Sprintf("account %s not found", hashValue), err)
 		}
 		return nil, err
 	}

--- a/internal/client/accounts_test.go
+++ b/internal/client/accounts_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -53,7 +53,7 @@ func TestAccountNumbers_404_ReturnsAccountNotFoundError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var accountErr *schwabErrors.AccountNotFoundError
+	var accountErr *apperr.AccountNotFoundError
 	require.ErrorAs(t, err, &accountErr)
 	assert.Contains(t, accountErr.Error(), "account numbers not found")
 }
@@ -121,7 +121,7 @@ func TestAccounts_404_ReturnsAccountNotFoundError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var accountErr *schwabErrors.AccountNotFoundError
+	var accountErr *apperr.AccountNotFoundError
 	require.ErrorAs(t, err, &accountErr)
 	assert.Contains(t, accountErr.Error(), "accounts not found")
 }
@@ -179,7 +179,7 @@ func TestAccount_404_ReturnsAccountNotFoundError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var accountErr *schwabErrors.AccountNotFoundError
+	var accountErr *apperr.AccountNotFoundError
 	require.ErrorAs(t, err, &accountErr)
 	assert.Contains(t, accountErr.Error(), "account invalid-hash not found")
 }
@@ -242,7 +242,7 @@ func TestAccount_401_ReturnsAuthExpiredError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var authErr *schwabErrors.AuthExpiredError
+	var authErr *apperr.AuthExpiredError
 	require.ErrorAs(t, err, &authErr)
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -16,7 +16,7 @@ import (
 	"net/url"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 const (
@@ -154,10 +154,10 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body, resul
 
 	// Map non-2xx status codes to typed errors.
 	if resp.StatusCode == http.StatusUnauthorized {
-		return schwabErrors.NewAuthExpiredError("authentication expired", nil)
+		return apperr.NewAuthExpiredError("authentication expired", nil)
 	}
 	if resp.StatusCode >= 400 {
-		return schwabErrors.NewHTTPError(
+		return apperr.NewHTTPError(
 			fmt.Sprintf("HTTP %d", resp.StatusCode),
 			resp.StatusCode,
 			string(respBody),

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // testResponse is a simple struct used for JSON round-trip tests.
@@ -248,7 +248,7 @@ func TestDoRequest_401_ReturnsAuthExpiredError(t *testing.T) {
 
 	require.Error(t, err)
 
-	var authErr *schwabErrors.AuthExpiredError
+	var authErr *apperr.AuthExpiredError
 	require.ErrorAs(t, err, &authErr)
 	assert.Contains(t, authErr.Error(), "authentication expired")
 }
@@ -266,7 +266,7 @@ func TestDoRequest_404_ReturnsHTTPError(t *testing.T) {
 
 	require.Error(t, err)
 
-	var httpErr *schwabErrors.HTTPError
+	var httpErr *apperr.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, 404, httpErr.StatusCode)
 	assert.Contains(t, httpErr.Body, "not found")
@@ -285,7 +285,7 @@ func TestDoRequest_500_ReturnsHTTPError(t *testing.T) {
 
 	require.Error(t, err)
 
-	var httpErr *schwabErrors.HTTPError
+	var httpErr *apperr.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, 500, httpErr.StatusCode)
 	assert.Contains(t, httpErr.Body, "internal server error")
@@ -304,7 +304,7 @@ func TestDoRequest_403_ReturnsHTTPError(t *testing.T) {
 
 	require.Error(t, err)
 
-	var httpErr *schwabErrors.HTTPError
+	var httpErr *apperr.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, 403, httpErr.StatusCode)
 }
@@ -322,7 +322,7 @@ func TestDoRequest_429_ReturnsHTTPError(t *testing.T) {
 
 	require.Error(t, err)
 
-	var httpErr *schwabErrors.HTTPError
+	var httpErr *apperr.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, 429, httpErr.StatusCode)
 	assert.Contains(t, httpErr.Body, "rate limited")

--- a/internal/client/instruments.go
+++ b/internal/client/instruments.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -33,7 +33,7 @@ func (c *Client) GetInstrument(ctx context.Context, cusip string) (*models.Instr
 		return nil, err
 	}
 	if len(result.Instruments) == 0 {
-		return nil, schwabErrors.NewSymbolNotFoundError(
+		return nil, apperr.NewSymbolNotFoundError(
 			fmt.Sprintf("instrument not found for CUSIP %s", cusip), nil,
 		)
 	}

--- a/internal/client/orders.go
+++ b/internal/client/orders.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -125,16 +125,16 @@ func (c *Client) PlaceOrder(ctx context.Context, hashValue string, order *models
 	// Map status codes to typed errors, checking order-rejection codes before
 	// the generic 4xx fallback so callers get OrderRejectedError specifically.
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, schwabErrors.NewAuthExpiredError("authentication expired", nil)
+		return nil, apperr.NewAuthExpiredError("authentication expired", nil)
 	}
 	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity {
-		return nil, schwabErrors.NewOrderRejectedError(
+		return nil, apperr.NewOrderRejectedError(
 			fmt.Sprintf("order rejected: %s", string(respBody)),
 			nil,
 		)
 	}
 	if resp.StatusCode >= 400 {
-		return nil, schwabErrors.NewHTTPError(
+		return nil, apperr.NewHTTPError(
 			fmt.Sprintf("HTTP %d", resp.StatusCode),
 			resp.StatusCode,
 			string(respBody),

--- a/internal/client/orders_test.go
+++ b/internal/client/orders_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -199,7 +199,7 @@ func TestPlaceOrder_400_ReturnsOrderRejectedError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var orderErr *schwabErrors.OrderRejectedError
+	var orderErr *apperr.OrderRejectedError
 	require.ErrorAs(t, err, &orderErr)
 	assert.Contains(t, orderErr.Error(), "order rejected")
 }
@@ -217,7 +217,7 @@ func TestPlaceOrder_422_ReturnsOrderRejectedError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var orderErr *schwabErrors.OrderRejectedError
+	var orderErr *apperr.OrderRejectedError
 	require.ErrorAs(t, err, &orderErr)
 	assert.Contains(t, orderErr.Error(), "order rejected")
 }

--- a/internal/client/quotes.go
+++ b/internal/client/quotes.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -36,15 +36,15 @@ func (c *Client) Quote(ctx context.Context, symbol string) (*models.QuoteEquity,
 	err := c.doGet(ctx, path, nil, &result)
 	if err != nil {
 		// Convert 404 HTTPError to SymbolNotFoundError
-		var httpErr *schwabErrors.HTTPError
+		var httpErr *apperr.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return nil, schwabErrors.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), err)
+			return nil, apperr.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), err)
 		}
 		return nil, err
 	}
 	q, ok := result[symbol]
 	if !ok {
-		return nil, schwabErrors.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), nil)
+		return nil, apperr.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), nil)
 	}
 	return q, nil
 }

--- a/internal/client/quotes_test.go
+++ b/internal/client/quotes_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -138,7 +138,7 @@ func TestQuote_404_ReturnsSymbolNotFoundError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var symbolErr *schwabErrors.SymbolNotFoundError
+	var symbolErr *apperr.SymbolNotFoundError
 	require.ErrorAs(t, err, &symbolErr)
 	assert.Contains(t, symbolErr.Error(), "symbol INVALID not found")
 }
@@ -157,7 +157,7 @@ func TestQuote_MissingSymbolInResponse(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var symbolErr *schwabErrors.SymbolNotFoundError
+	var symbolErr *apperr.SymbolNotFoundError
 	require.ErrorAs(t, err, &symbolErr)
 	assert.Contains(t, symbolErr.Error(), "symbol MISSING not found")
 }
@@ -175,7 +175,7 @@ func TestQuote_401_ReturnsAuthExpiredError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 
-	var authErr *schwabErrors.AuthExpiredError
+	var authErr *apperr.AuthExpiredError
 	require.ErrorAs(t, err, &authErr)
 }
 

--- a/internal/commands/AGENTS.md
+++ b/internal/commands/AGENTS.md
@@ -37,7 +37,7 @@ func QuoteCommand(c *client.Ref, w io.Writer) *cli.Command {
 All command output goes through `internal/output` envelopes:
 
 - `output.WriteSuccess(w, data, output.TimestampMeta())` for success
-- Return typed errors from `internal/errors` for failures (the Before hook handles formatting)
+- Return typed errors from `internal/apperr` for failures (the Before hook handles formatting)
 - `output.WritePartial(w, data, missing, meta)` when some results succeed and some fail (e.g., multi-symbol quote)
 
 Exception: `schema` and `order build` commands write raw JSON (not envelope-wrapped).

--- a/internal/commands/account.go
+++ b/internal/commands/account.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/auth"
 	"github.com/major/schwab-agent/internal/client"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/output"
 )
@@ -147,7 +147,7 @@ func resolveAccount(accountFlag, configPath string, positionalArgs []string) (st
 		}
 	}
 
-	return "", schwabErrors.NewAccountNotFoundError(
+	return "", apperr.NewAccountNotFoundError(
 		"no account specified: use --account flag or set default_account in config",
 		nil,
 	)
@@ -245,7 +245,7 @@ func accountTransactionCommand(c *client.Ref, configPath string, w io.Writer) *c
 
 					txnID, err := strconv.ParseInt(txnIDStr, 10, 64)
 					if err != nil {
-						return schwabErrors.NewValidationError("transaction ID must be a number", nil)
+						return apperr.NewValidationError("transaction ID must be a number", nil)
 					}
 
 					account, err := resolveAccount(cmd.String("account"), configPath, nil)

--- a/internal/commands/account_test.go
+++ b/internal/commands/account_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/auth"
 	"github.com/major/schwab-agent/internal/client"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/output"
 )
@@ -168,7 +168,7 @@ func TestAccountList_APIError(t *testing.T) {
 	err := cmd.Run(context.Background(), []string{"account", "list"})
 	require.Error(t, err)
 
-	var httpErr *schwabErrors.HTTPError
+	var httpErr *apperr.HTTPError
 	assert.True(t, errors.As(err, &httpErr))
 }
 
@@ -291,7 +291,7 @@ func TestAccountGet_NoAccount_Error(t *testing.T) {
 	err := cmd.Run(context.Background(), []string{"account", "get"})
 	require.Error(t, err)
 
-	var notFoundErr *schwabErrors.AccountNotFoundError
+	var notFoundErr *apperr.AccountNotFoundError
 	require.True(t, errors.As(err, &notFoundErr))
 	assert.Contains(t, notFoundErr.Message, "no account specified")
 	assert.Contains(t, notFoundErr.Details, "schwab-agent account numbers")
@@ -338,7 +338,7 @@ func TestAccountGet_APIError(t *testing.T) {
 	err := cmd.Run(context.Background(), []string{"account", "get", "BAD_HASH"})
 	require.Error(t, err)
 
-	var notFoundErr *schwabErrors.AccountNotFoundError
+	var notFoundErr *apperr.AccountNotFoundError
 	assert.True(t, errors.As(err, &notFoundErr))
 }
 
@@ -503,7 +503,7 @@ func TestAccountTransaction_List_NoAccount(t *testing.T) {
 	err := runTestCommand(t, cmd, "account", "transaction", "list")
 	require.Error(t, err)
 
-	var accountErr *schwabErrors.AccountNotFoundError
+	var accountErr *apperr.AccountNotFoundError
 	assert.ErrorAs(t, err, &accountErr)
 }
 
@@ -538,7 +538,7 @@ func TestAccountTransaction_Get_MissingTxnID(t *testing.T) {
 	err := runTestCommand(t, cmd, "account", "transaction", "get", "--account", "abc123")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -551,7 +551,7 @@ func TestAccountTransaction_Get_InvalidTxnID(t *testing.T) {
 	err := runTestCommand(t, cmd, "account", "transaction", "get", "--account", "abc123", "not-a-number")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -564,7 +564,7 @@ func TestAccountTransaction_Get_NoAccount(t *testing.T) {
 	err := runTestCommand(t, cmd, "account", "transaction", "get", "1001")
 	require.Error(t, err)
 
-	var accountErr *schwabErrors.AccountNotFoundError
+	var accountErr *apperr.AccountNotFoundError
 	assert.ErrorAs(t, err, &accountErr)
 }
 
@@ -602,7 +602,7 @@ func TestResolveAccount_NoAccountError(t *testing.T) {
 	require.Error(t, err)
 	assert.Empty(t, account)
 
-	var accountErr *schwabErrors.AccountNotFoundError
+	var accountErr *apperr.AccountNotFoundError
 	assert.ErrorAs(t, err, &accountErr)
 }
 

--- a/internal/commands/chain_test.go
+++ b/internal/commands/chain_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -149,7 +149,7 @@ func TestChainGetNoArgs(t *testing.T) {
 	err := runTestCommand(t, cmd, "chain", "get")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Empty(t, buf.String())
 }
@@ -163,7 +163,7 @@ func TestChainExpirationNoArgs(t *testing.T) {
 	err := runTestCommand(t, cmd, "chain", "expiration")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Empty(t, buf.String())
 }

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -1,14 +1,14 @@
 package commands
 
 import (
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // requireArg returns a ValidationError if value is empty.
 // Use this for required positional arguments and flag values.
 func requireArg(value, name string) error {
 	if value == "" {
-		return schwabErrors.NewValidationError(name+" is required", nil)
+		return apperr.NewValidationError(name+" is required", nil)
 	}
 
 	return nil

--- a/internal/commands/history_test.go
+++ b/internal/commands/history_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -95,7 +95,7 @@ func TestHistoryCommand_Get_MissingSymbol(t *testing.T) {
 	err := runTestCommand(t, cmd, "history", "get")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/commands/instrument_test.go
+++ b/internal/commands/instrument_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -67,7 +67,7 @@ func TestInstrumentCommand_Search_MissingQuery(t *testing.T) {
 	err := runTestCommand(t, cmd, "instrument", "search")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -101,7 +101,7 @@ func TestInstrumentCommand_Get_MissingCUSIP(t *testing.T) {
 	err := runTestCommand(t, cmd, "instrument", "get")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -140,7 +140,7 @@ func TestMarketCommand_Movers_MissingIndex(t *testing.T) {
 	err := runTestCommand(t, cmd, "market", "movers")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/auth"
 	"github.com/major/schwab-agent/internal/client"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/orderbuilder"
 	"github.com/major/schwab-agent/internal/output"
@@ -706,11 +706,11 @@ func readSpecSource(cmd *cli.Command, spec string) ([]byte, error) {
 func requireMutableEnabled(configPath string) error {
 	cfg, err := auth.LoadConfig(configPath)
 	if err != nil {
-		return schwabErrors.NewValidationError(mutableDisabledMessage, nil)
+		return apperr.NewValidationError(mutableDisabledMessage, nil)
 	}
 
 	if !cfg.IAlsoLikeToLiveDangerously {
-		return schwabErrors.NewValidationError(mutableDisabledMessage, nil)
+		return apperr.NewValidationError(mutableDisabledMessage, nil)
 	}
 
 	return nil
@@ -722,7 +722,7 @@ func requireConfirm(confirmed bool) error {
 		return nil
 	}
 
-	return schwabErrors.NewValidationError(confirmOrderMessage, nil)
+	return apperr.NewValidationError(confirmOrderMessage, nil)
 }
 
 // parseRequiredOrderID parses the first positional argument as an order ID.
@@ -1058,5 +1058,5 @@ func parsePutCall(call, put bool) (models.PutCall, error) {
 
 // newValidationError creates a consistent validation error for command parsing.
 func newValidationError(message string) error {
-	return schwabErrors.NewValidationError(message, nil)
+	return apperr.NewValidationError(message, nil)
 }

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/schwab-agent/internal/client"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/orderbuilder"
 	"github.com/major/schwab-agent/internal/output"
@@ -140,7 +140,7 @@ func TestOrderConfirmGate(t *testing.T) {
 			require.Error(t, err)
 			assert.Empty(t, stdout)
 
-			var validationErr *schwabErrors.ValidationError
+			var validationErr *apperr.ValidationError
 			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, "Add --confirm to execute this order", validationErr.Error())
 		})
@@ -381,7 +381,7 @@ func TestOrderMutableGuard(t *testing.T) {
 			require.Error(t, err)
 			assert.Empty(t, stdout)
 
-			var validationErr *schwabErrors.ValidationError
+			var validationErr *apperr.ValidationError
 			require.ErrorAs(t, err, &validationErr)
 			assert.Contains(t, validationErr.Error(), "i-also-like-to-live-dangerously")
 		})
@@ -402,7 +402,7 @@ func TestOrderMutableGuardTakesPriorityOverConfirm(t *testing.T) {
 	require.Error(t, err)
 	assert.Empty(t, stdout)
 
-	var validationErr *schwabErrors.ValidationError
+	var validationErr *apperr.ValidationError
 	require.ErrorAs(t, err, &validationErr)
 	assert.Contains(t, validationErr.Error(), "i-also-like-to-live-dangerously")
 }
@@ -1078,7 +1078,7 @@ func TestOrderBuildSpreadParseErrors(t *testing.T) {
 			require.Error(t, err)
 			assert.Empty(t, stdout)
 
-			var validationErr *schwabErrors.ValidationError
+			var validationErr *apperr.ValidationError
 			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, tc.wantMsg, validationErr.Error())
 		})

--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/major/schwab-agent/internal/client"
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -33,7 +33,7 @@ func quoteGetCommand(c *client.Ref, w io.Writer) *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			args := cmd.Args().Slice()
 			if len(args) == 0 {
-				return schwabErrors.NewValidationError("at least one symbol is required", nil)
+				return apperr.NewValidationError("at least one symbol is required", nil)
 			}
 
 			if len(args) == 1 {

--- a/internal/commands/quote_test.go
+++ b/internal/commands/quote_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +106,7 @@ func TestQuoteGetSingleNotFound(t *testing.T) {
 	err := runTestCommand(t, cmd, "quote", "get", "INVALID")
 	require.Error(t, err)
 
-	var symErr *schwabErrors.SymbolNotFoundError
+	var symErr *apperr.SymbolNotFoundError
 	assert.ErrorAs(t, err, &symErr)
 	assert.Empty(t, buf.String())
 }
@@ -120,7 +120,7 @@ func TestQuoteGetNoArgs(t *testing.T) {
 	err := runTestCommand(t, cmd, "quote", "get")
 	require.Error(t, err)
 
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Empty(t, buf.String())
 }

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -253,7 +253,7 @@ func TestTASMA_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -331,7 +331,7 @@ func TestTARSI_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -404,7 +404,7 @@ func TestTAMACD_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -452,7 +452,7 @@ func TestTAATR_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -506,7 +506,7 @@ func TestTABBands_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -578,7 +578,7 @@ func TestTAStochastic_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -631,7 +631,7 @@ func TestTAADX_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -689,7 +689,7 @@ func TestTAVWAP_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.ErrorAs(t, err, &valErr)
 	assert.Contains(t, valErr.Error(), "symbol")
 }
@@ -777,7 +777,7 @@ func TestTAHV_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.ErrorAs(t, err, &valErr)
 	assert.Contains(t, valErr.Error(), "symbol")
 }
@@ -794,7 +794,7 @@ func TestTAHV_InvalidPeriod(t *testing.T) {
 
 	// Assert - period=0 should produce a ValidationError from ta.HistoricalVolatility
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.ErrorAs(t, err, &valErr)
 }
 
@@ -855,7 +855,7 @@ func TestTAExpectedMove_MissingSymbol(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.ErrorAs(t, err, &valErr)
 	assert.Contains(t, valErr.Error(), "symbol")
 }

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -11,6 +11,8 @@ import (
 
 // TestQuoteEquityJSONRoundTrip verifies that QuoteEquity can be marshaled and unmarshaled correctly.
 func TestQuoteEquityJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	symbol := "AAPL"
 	bidPrice := 150.25
 	askPrice := 150.35
@@ -43,64 +45,39 @@ func TestQuoteEquityJSONRoundTrip(t *testing.T) {
 		},
 	}
 
-	// Marshal to JSON
+	// Marshal to JSON.
 	jsonData, err := json.Marshal(original)
-	if err != nil {
-		t.Fatalf("failed to marshal QuoteEquity: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Unmarshal back to struct
+	// Unmarshal back to struct.
 	unmarshaled := &QuoteEquity{}
 	err = json.Unmarshal(jsonData, unmarshaled)
-	if err != nil {
-		t.Fatalf("failed to unmarshal QuoteEquity: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Verify top-level fields
-	if unmarshaled.Symbol == nil || *unmarshaled.Symbol != symbol {
-		t.Errorf("symbol mismatch: expected %s, got %v", symbol, unmarshaled.Symbol)
-	}
+	// Verify top-level fields.
+	require.NotNil(t, unmarshaled.Symbol)
+	assert.Equal(t, symbol, *unmarshaled.Symbol)
 
-	// Verify nested quote fields
-	if unmarshaled.Quote == nil {
-		t.Fatal("quote sub-object is nil after unmarshal")
-	}
-	if unmarshaled.Quote.BidPrice == nil || *unmarshaled.Quote.BidPrice != bidPrice {
-		t.Errorf("bidPrice mismatch: expected %f, got %v", bidPrice, unmarshaled.Quote.BidPrice)
-	}
-	if unmarshaled.Quote.AskPrice == nil || *unmarshaled.Quote.AskPrice != askPrice {
-		t.Errorf("askPrice mismatch: expected %f, got %v", askPrice, unmarshaled.Quote.AskPrice)
-	}
-	if unmarshaled.Quote.LastPrice == nil || *unmarshaled.Quote.LastPrice != lastPrice {
-		t.Errorf("lastPrice mismatch: expected %f, got %v", lastPrice, unmarshaled.Quote.LastPrice)
-	}
-	if unmarshaled.Quote.NetChange == nil || *unmarshaled.Quote.NetChange != netChange {
-		t.Errorf("netChange mismatch: expected %f, got %v", netChange, unmarshaled.Quote.NetChange)
-	}
-	if unmarshaled.Quote.NetPercentChange == nil || *unmarshaled.Quote.NetPercentChange != netPercentChange {
-		t.Errorf("netPercentChange mismatch: expected %f, got %v", netPercentChange, unmarshaled.Quote.NetPercentChange)
-	}
-	if unmarshaled.Quote.TotalVolume == nil || *unmarshaled.Quote.TotalVolume != totalVolume {
-		t.Errorf("totalVolume mismatch: expected %d, got %v", totalVolume, unmarshaled.Quote.TotalVolume)
-	}
-	if unmarshaled.Quote.BidSize == nil || *unmarshaled.Quote.BidSize != bidSize {
-		t.Errorf("bidSize mismatch: expected %d, got %v", bidSize, unmarshaled.Quote.BidSize)
-	}
-	if unmarshaled.Quote.AskSize == nil || *unmarshaled.Quote.AskSize != askSize {
-		t.Errorf("askSize mismatch: expected %d, got %v", askSize, unmarshaled.Quote.AskSize)
-	}
+	// Verify nested quote fields.
+	require.NotNil(t, unmarshaled.Quote)
+	assert.Equal(t, bidPrice, *unmarshaled.Quote.BidPrice)
+	assert.Equal(t, askPrice, *unmarshaled.Quote.AskPrice)
+	assert.Equal(t, lastPrice, *unmarshaled.Quote.LastPrice)
+	assert.Equal(t, netChange, *unmarshaled.Quote.NetChange)
+	assert.Equal(t, netPercentChange, *unmarshaled.Quote.NetPercentChange)
+	assert.Equal(t, totalVolume, *unmarshaled.Quote.TotalVolume)
+	assert.Equal(t, bidSize, *unmarshaled.Quote.BidSize)
+	assert.Equal(t, askSize, *unmarshaled.Quote.AskSize)
 
-	// Verify nested reference fields
-	if unmarshaled.Reference == nil {
-		t.Fatal("reference sub-object is nil after unmarshal")
-	}
-	if unmarshaled.Reference.Description == nil || *unmarshaled.Reference.Description != description {
-		t.Errorf("description mismatch: expected %s, got %v", description, unmarshaled.Reference.Description)
-	}
+	// Verify nested reference fields.
+	require.NotNil(t, unmarshaled.Reference)
+	assert.Equal(t, description, *unmarshaled.Reference.Description)
 }
 
 // TestCandleJSONRoundTrip verifies that Candle can be marshaled and unmarshaled correctly.
 func TestCandleJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	open := 150.00
 	high := 151.50
 	low := 149.75
@@ -117,75 +94,51 @@ func TestCandleJSONRoundTrip(t *testing.T) {
 		Datetime: &datetime,
 	}
 
-	// Marshal to JSON
+	// Marshal to JSON.
 	jsonData, err := json.Marshal(original)
-	if err != nil {
-		t.Fatalf("failed to marshal Candle: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Unmarshal back to struct
+	// Unmarshal back to struct.
 	unmarshaled := &Candle{}
 	err = json.Unmarshal(jsonData, unmarshaled)
-	if err != nil {
-		t.Fatalf("failed to unmarshal Candle: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Verify fields match
-	if unmarshaled.Open == nil || *unmarshaled.Open != open {
-		t.Errorf("open mismatch: expected %f, got %v", open, unmarshaled.Open)
-	}
-	if unmarshaled.High == nil || *unmarshaled.High != high {
-		t.Errorf("high mismatch: expected %f, got %v", high, unmarshaled.High)
-	}
-	if unmarshaled.Low == nil || *unmarshaled.Low != low {
-		t.Errorf("low mismatch: expected %f, got %v", low, unmarshaled.Low)
-	}
-	if unmarshaled.Close == nil || *unmarshaled.Close != closePrice {
-		t.Errorf("close mismatch: expected %f, got %v", closePrice, unmarshaled.Close)
-	}
-	if unmarshaled.Volume == nil || *unmarshaled.Volume != volume {
-		t.Errorf("volume mismatch: expected %d, got %v", volume, unmarshaled.Volume)
-	}
-	if unmarshaled.Datetime == nil || *unmarshaled.Datetime != datetime {
-		t.Errorf("datetime mismatch: expected %d, got %v", datetime, unmarshaled.Datetime)
-	}
+	// Verify fields match.
+	assert.Equal(t, open, *unmarshaled.Open)
+	assert.Equal(t, high, *unmarshaled.High)
+	assert.Equal(t, low, *unmarshaled.Low)
+	assert.Equal(t, closePrice, *unmarshaled.Close)
+	assert.Equal(t, volume, *unmarshaled.Volume)
+	assert.Equal(t, datetime, *unmarshaled.Datetime)
 }
 
 // TestPositionJSONRoundTrip verifies that Position can be marshaled and unmarshaled correctly.
 func TestPositionJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
 	longQuantity := 100.0
 	marketValue := 15000.0
 	averagePrice := 150.0
 
 	original := &Position{
-		LongQuantity:  &longQuantity,
-		MarketValue:   &marketValue,
-		AveragePrice:  &averagePrice,
+		LongQuantity: &longQuantity,
+		MarketValue:  &marketValue,
+		AveragePrice: &averagePrice,
 	}
 
-	// Marshal to JSON
+	// Marshal to JSON.
 	jsonData, err := json.Marshal(original)
-	if err != nil {
-		t.Fatalf("failed to marshal Position: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Unmarshal back to struct
+	// Unmarshal back to struct.
 	unmarshaled := &Position{}
 	err = json.Unmarshal(jsonData, unmarshaled)
-	if err != nil {
-		t.Fatalf("failed to unmarshal Position: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Verify fields match
-	if unmarshaled.LongQuantity == nil || *unmarshaled.LongQuantity != longQuantity {
-		t.Errorf("longQuantity mismatch: expected %f, got %v", longQuantity, unmarshaled.LongQuantity)
-	}
-	if unmarshaled.MarketValue == nil || *unmarshaled.MarketValue != marketValue {
-		t.Errorf("marketValue mismatch: expected %f, got %v", marketValue, unmarshaled.MarketValue)
-	}
-	if unmarshaled.AveragePrice == nil || *unmarshaled.AveragePrice != averagePrice {
-		t.Errorf("averagePrice mismatch: expected %f, got %v", averagePrice, unmarshaled.AveragePrice)
-	}
+	// Verify fields match.
+	assert.Equal(t, longQuantity, *unmarshaled.LongQuantity)
+	assert.Equal(t, marketValue, *unmarshaled.MarketValue)
+	assert.Equal(t, averagePrice, *unmarshaled.AveragePrice)
 }
 
 // --- SchwabTime tests ---

--- a/internal/orderbuilder/validate.go
+++ b/internal/orderbuilder/validate.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -355,7 +355,7 @@ func validateSpreadPrice(price float64, strategy string) error {
 
 // validationError creates a ValidationError with a fix-suggesting details message.
 func validationError(message, details string) error {
-	err := schwabErrors.NewValidationError(message, nil)
+	err := apperr.NewValidationError(message, nil)
 	err.Details = details
 	return err
 }

--- a/internal/orderbuilder/validate_test.go
+++ b/internal/orderbuilder/validate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -570,7 +570,7 @@ func assertValidationError(t *testing.T, err error, expectedMessage, expectedDet
 
 	require.Error(t, err)
 
-	var validationErr *schwabErrors.ValidationError
+	var validationErr *apperr.ValidationError
 	require.True(t, errors.As(err, &validationErr))
 	assert.Equal(t, expectedMessage, validationErr.Message)
 	assert.Equal(t, expectedDetails, validationErr.Details)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // Metadata holds the standard metadata fields for response envelopes.
@@ -58,22 +58,22 @@ func WriteSuccess(w io.Writer, data any, metadata Metadata) error {
 }
 
 // WriteError writes an error response to the writer.
-// It maps the error type to an appropriate error code string using schwabErrors.ErrorCode().
+// It maps the error type to an appropriate error code string using apperr.ErrorCode().
 // The response is formatted as a JSON envelope with error details.
 func WriteError(w io.Writer, err error) error {
-	code := schwabErrors.ErrorCode(err)
+	code := apperr.ErrorCode(err)
 	message := err.Error()
 
 	// Extract details from specific error types
 	var details string
-	var schwabErr *schwabErrors.SchwabError
+	var schwabErr *apperr.SchwabError
 	if errors.As(err, &schwabErr) {
 		details = schwabErr.Details
 	}
 
 	// Include the upstream response body when available so API errors from
 	// Schwab are visible in the CLI output instead of just "status: NNN".
-	var httpErr *schwabErrors.HTTPError
+	var httpErr *apperr.HTTPError
 	if errors.As(err, &httpErr) {
 		if httpErr.Body != "" {
 			details = fmt.Sprintf("status: %d, body: %s", httpErr.StatusCode, httpErr.Body)

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,7 +72,7 @@ func TestWriteSuccessWithComplexData(t *testing.T) {
 
 func TestWriteErrorAuthRequired(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewAuthRequiredError("authentication required", errors.New("no token"))
+	err := apperr.NewAuthRequiredError("authentication required", errors.New("no token"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -87,7 +87,7 @@ func TestWriteErrorAuthRequired(t *testing.T) {
 
 func TestWriteErrorAuthExpired(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewAuthExpiredError("auth expired", errors.New("401 response"))
+	err := apperr.NewAuthExpiredError("auth expired", errors.New("401 response"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -102,7 +102,7 @@ func TestWriteErrorAuthExpired(t *testing.T) {
 
 func TestWriteErrorAuthCallback(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewAuthCallbackError("callback failed", errors.New("invalid state"))
+	err := apperr.NewAuthCallbackError("callback failed", errors.New("invalid state"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -117,7 +117,7 @@ func TestWriteErrorAuthCallback(t *testing.T) {
 
 func TestWriteErrorOrderRejected(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewOrderRejectedError("order rejected", errors.New("insufficient funds"))
+	err := apperr.NewOrderRejectedError("order rejected", errors.New("insufficient funds"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -132,7 +132,7 @@ func TestWriteErrorOrderRejected(t *testing.T) {
 
 func TestWriteErrorSymbolNotFound(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewSymbolNotFoundError("symbol not found", errors.New("api returned empty"))
+	err := apperr.NewSymbolNotFoundError("symbol not found", errors.New("api returned empty"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -147,7 +147,7 @@ func TestWriteErrorSymbolNotFound(t *testing.T) {
 
 func TestWriteErrorAccountNotFound(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewAccountNotFoundError("account not found", errors.New("invalid account id"))
+	err := apperr.NewAccountNotFoundError("account not found", errors.New("invalid account id"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -162,7 +162,7 @@ func TestWriteErrorAccountNotFound(t *testing.T) {
 
 func TestWriteErrorHTTPError(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewHTTPError("http error", 500, "Internal Server Error", errors.New("server error"))
+	err := apperr.NewHTTPError("http error", 500, "Internal Server Error", errors.New("server error"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -178,7 +178,7 @@ func TestWriteErrorHTTPError(t *testing.T) {
 
 func TestWriteErrorValidationError(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewValidationError("validation failed", errors.New("invalid input"))
+	err := apperr.NewValidationError("validation failed", errors.New("invalid input"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -193,7 +193,7 @@ func TestWriteErrorValidationError(t *testing.T) {
 
 func TestWriteErrorOrderBuildError(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewOrderBuildError("order build failed", errors.New("invalid order params"))
+	err := apperr.NewOrderBuildError("order build failed", errors.New("invalid order params"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)
@@ -223,7 +223,7 @@ func TestWriteErrorGenericError(t *testing.T) {
 
 func TestWriteErrorWithDetails(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewSchwabError("custom error", errors.New("cause"))
+	err := apperr.NewSchwabError("custom error", errors.New("cause"))
 	err.Details = "additional context"
 
 	writeErr := WriteError(buf, err)
@@ -336,7 +336,7 @@ func TestEnvelopeJSONStructure(t *testing.T) {
 
 func TestErrorEnvelopeJSONStructure(t *testing.T) {
 	buf := &bytes.Buffer{}
-	err := schwabErrors.NewAuthRequiredError("auth required", errors.New("no token"))
+	err := apperr.NewAuthRequiredError("auth required", errors.New("no token"))
 
 	writeErr := WriteError(buf, err)
 	require.NoError(t, writeErr)

--- a/internal/ta/atr_bbands.go
+++ b/internal/ta/atr_bbands.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/markcheno/go-talib"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // ATR computes Average True Range from OHLC data.
@@ -13,19 +13,19 @@ import (
 // Returns ValidationError if period <= 0, slices have mismatched lengths, or insufficient data.
 func ATR(highs, lows, closes []float64, period int) ([]float64, error) {
 	if period <= 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("atr period must be > 0, got %d", period),
 			nil,
 		)
 	}
 	if len(highs) != len(lows) || len(highs) != len(closes) {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("atr: mismatched slice lengths: highs=%d, lows=%d, closes=%d", len(highs), len(lows), len(closes)),
 			nil,
 		)
 	}
 	if len(closes) < period+1 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("atr requires at least %d values, got %d", period+1, len(closes)),
 			nil,
 		)
@@ -39,19 +39,19 @@ func ATR(highs, lows, closes []float64, period int) ([]float64, error) {
 // Returns (upper, middle, lower []float64, err error) with leading zeros stripped and lengths aligned.
 func BBands(closes []float64, period int, stdDev float64) (upper, middle, lower []float64, err error) {
 	if period <= 0 {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("bbands period must be > 0, got %d", period),
 			nil,
 		)
 	}
 	if stdDev <= 0 {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("bbands stdDev must be > 0, got %g", stdDev),
 			nil,
 		)
 	}
 	if len(closes) < period {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("bbands requires at least %d values, got %d", period, len(closes)),
 			nil,
 		)

--- a/internal/ta/atr_bbands_test.go
+++ b/internal/ta/atr_bbands_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestATR_ValidValues(t *testing.T) {
@@ -38,7 +38,7 @@ func TestATR_MismatchedLengths(t *testing.T) {
 	closes := make([]float64, 10)
 	_, err := ATR(highs, lows, closes, 14)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Contains(t, err.Error(), "length")
 }
@@ -49,7 +49,7 @@ func TestATR_InvalidPeriod(t *testing.T) {
 	closes := make([]float64, 20)
 	_, err := ATR(highs, lows, closes, 0)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -103,7 +103,7 @@ func TestBBands_InvalidStdDev(t *testing.T) {
 	}
 	_, _, _, err := BBands(closes, 20, 0.0)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -111,6 +111,6 @@ func TestBBands_InvalidPeriod(t *testing.T) {
 	closes := make([]float64, 30)
 	_, _, _, err := BBands(closes, 0, 2.0)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }

--- a/internal/ta/expected_move.go
+++ b/internal/ta/expected_move.go
@@ -3,7 +3,7 @@ package ta
 import (
 	"fmt"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // DefaultMultiplier is the straddle price adjustment factor used by schwab-mcp.
@@ -25,7 +25,7 @@ type ExpectedMoveResult struct {
 func ExpectedMove(underlyingPrice, callPrice, putPrice, multiplier float64) (*ExpectedMoveResult, error) {
 	// Validate underlyingPrice
 	if underlyingPrice <= 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("underlyingPrice must be > 0, got %.4f", underlyingPrice),
 			nil,
 		)
@@ -33,7 +33,7 @@ func ExpectedMove(underlyingPrice, callPrice, putPrice, multiplier float64) (*Ex
 
 	// Validate callPrice
 	if callPrice < 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("callPrice must be >= 0, got %.4f", callPrice),
 			nil,
 		)
@@ -41,7 +41,7 @@ func ExpectedMove(underlyingPrice, callPrice, putPrice, multiplier float64) (*Ex
 
 	// Validate putPrice
 	if putPrice < 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("putPrice must be >= 0, got %.4f", putPrice),
 			nil,
 		)
@@ -49,14 +49,14 @@ func ExpectedMove(underlyingPrice, callPrice, putPrice, multiplier float64) (*Ex
 
 	// Validate multiplier
 	if multiplier <= 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("multiplier must be > 0, got %.4f", multiplier),
 			nil,
 		)
 	}
 
 	if multiplier > 1.0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("multiplier must be <= 1.0, got %.4f", multiplier),
 			nil,
 		)

--- a/internal/ta/expected_move_test.go
+++ b/internal/ta/expected_move_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestExpectedMove_Correct(t *testing.T) {
@@ -54,7 +54,7 @@ func TestExpectedMove_InvalidUnderlying(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -64,7 +64,7 @@ func TestExpectedMove_NegativeUnderlying(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -74,7 +74,7 @@ func TestExpectedMove_InvalidMultiplier(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -84,7 +84,7 @@ func TestExpectedMove_MultiplierAboveOne(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/ta/helpers.go
+++ b/internal/ta/helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -13,7 +13,7 @@ func ExtractClose(candles []models.Candle) ([]float64, error) {
 	result := make([]float64, len(candles))
 	for i, c := range candles {
 		if c.Close == nil {
-			return nil, schwabErrors.NewValidationError(
+			return nil, apperr.NewValidationError(
 				fmt.Sprintf("nil close at index %d", i),
 				nil,
 			)
@@ -28,7 +28,7 @@ func ExtractHigh(candles []models.Candle) ([]float64, error) {
 	result := make([]float64, len(candles))
 	for i, c := range candles {
 		if c.High == nil {
-			return nil, schwabErrors.NewValidationError(
+			return nil, apperr.NewValidationError(
 				fmt.Sprintf("nil high at index %d", i),
 				nil,
 			)
@@ -43,7 +43,7 @@ func ExtractLow(candles []models.Candle) ([]float64, error) {
 	result := make([]float64, len(candles))
 	for i, c := range candles {
 		if c.Low == nil {
-			return nil, schwabErrors.NewValidationError(
+			return nil, apperr.NewValidationError(
 				fmt.Sprintf("nil low at index %d", i),
 				nil,
 			)
@@ -58,7 +58,7 @@ func ExtractOpen(candles []models.Candle) ([]float64, error) {
 	result := make([]float64, len(candles))
 	for i, c := range candles {
 		if c.Open == nil {
-			return nil, schwabErrors.NewValidationError(
+			return nil, apperr.NewValidationError(
 				fmt.Sprintf("nil open at index %d", i),
 				nil,
 			)
@@ -73,7 +73,7 @@ func ExtractVolume(candles []models.Candle) ([]float64, error) {
 	result := make([]float64, len(candles))
 	for i, c := range candles {
 		if c.Volume == nil {
-			return nil, schwabErrors.NewValidationError(
+			return nil, apperr.NewValidationError(
 				fmt.Sprintf("nil volume at index %d", i),
 				nil,
 			)
@@ -103,7 +103,7 @@ func ExtractTimestamps(candles []models.Candle) []string {
 // Error message format: "sma requires at least 20 candles, got 5"
 func ValidateMinCandles(candles []models.Candle, required int, indicator string) error {
 	if len(candles) < required {
-		return schwabErrors.NewValidationError(
+		return apperr.NewValidationError(
 			fmt.Sprintf("%s requires at least %d candles, got %d", indicator, required, len(candles)),
 			nil,
 		)

--- a/internal/ta/helpers_test.go
+++ b/internal/ta/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
 )
 
@@ -33,7 +33,7 @@ func TestExtractClose_NilField(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "nil close")
@@ -63,7 +63,7 @@ func TestExtractHigh_NilField(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "nil high")
@@ -92,7 +92,7 @@ func TestExtractLow_NilField(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "nil low")
@@ -121,7 +121,7 @@ func TestExtractOpen_NilField(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "nil open")
@@ -150,7 +150,7 @@ func TestExtractVolume_NilField(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "nil volume")
@@ -211,7 +211,7 @@ func TestValidateMinCandles_Insufficient(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 	assert.Equal(t, "sma requires at least 20 candles, got 5", err.Error())
 }

--- a/internal/ta/indicators.go
+++ b/internal/ta/indicators.go
@@ -6,20 +6,20 @@ import (
 
 	"github.com/markcheno/go-talib"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // SMA computes Simple Moving Average. Strips leading zeros from output.
 // Returns ValidationError if period <= 0 or len(closes) < period.
 func SMA(closes []float64, period int) ([]float64, error) {
 	if period <= 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("sma period must be > 0, got %d", period),
 			nil,
 		)
 	}
 	if len(closes) < period {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("sma requires at least %d values, got %d", period, len(closes)),
 			nil,
 		)
@@ -32,13 +32,13 @@ func SMA(closes []float64, period int) ([]float64, error) {
 // Returns ValidationError if period <= 0 or len(closes) < period.
 func EMA(closes []float64, period int) ([]float64, error) {
 	if period <= 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("ema period must be > 0, got %d", period),
 			nil,
 		)
 	}
 	if len(closes) < period {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("ema requires at least %d values, got %d", period, len(closes)),
 			nil,
 		)
@@ -51,13 +51,13 @@ func EMA(closes []float64, period int) ([]float64, error) {
 // Returns ValidationError if period <= 1 or len(closes) < period+1.
 func RSI(closes []float64, period int) ([]float64, error) {
 	if period <= 1 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("rsi period must be > 1, got %d", period),
 			nil,
 		)
 	}
 	if len(closes) < period+1 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("rsi requires at least %d values, got %d", period+1, len(closes)),
 			nil,
 		)

--- a/internal/ta/indicators_test.go
+++ b/internal/ta/indicators_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestSMA_Correct(t *testing.T) {
@@ -26,7 +26,7 @@ func TestSMA_InvalidPeriod(t *testing.T) {
 	_, err := SMA([]float64{1, 2, 3}, 0)
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -35,7 +35,7 @@ func TestSMA_InsufficientData(t *testing.T) {
 	_, err := SMA([]float64{1, 2, 3}, 5)
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -61,7 +61,7 @@ func TestEMA_InvalidPeriod(t *testing.T) {
 	_, err := EMA([]float64{1, 2, 3}, 0)
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -70,7 +70,7 @@ func TestEMA_InsufficientData(t *testing.T) {
 	_, err := EMA([]float64{1, 2, 3}, 5)
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -102,7 +102,7 @@ func TestRSI_InvalidPeriod(t *testing.T) {
 	_, err := RSI(closes, 1)
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -111,7 +111,7 @@ func TestRSI_InsufficientData(t *testing.T) {
 	_, err := RSI([]float64{1, 2, 3}, 5)
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/ta/interval.go
+++ b/internal/ta/interval.go
@@ -1,7 +1,7 @@
 package ta
 
 import (
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // IntervalToHistoryParams maps a human interval string to PriceHistory query params.
@@ -30,7 +30,7 @@ func IntervalToHistoryParams(interval string) (periodType, period, freqType, fre
 	case "30min":
 		return "day", "10", "minute", "30", nil
 	default:
-		return "", "", "", "", schwabErrors.NewValidationError(
+		return "", "", "", "", apperr.NewValidationError(
 			"unsupported interval: "+interval,
 			nil,
 		)

--- a/internal/ta/interval_test.go
+++ b/internal/ta/interval_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestIntervalToHistoryParams(t *testing.T) {
@@ -96,7 +96,7 @@ func TestIntervalToHistoryParams(t *testing.T) {
 			// Assert
 			if tt.wantErr {
 				require.Error(t, err)
-				var valErr *schwabErrors.ValidationError
+				var valErr *apperr.ValidationError
 				require.True(t, assert.ErrorAs(t, err, &valErr), "error should be ValidationError")
 				assert.Contains(t, err.Error(), tt.errMsg)
 			} else {

--- a/internal/ta/macd.go
+++ b/internal/ta/macd.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/markcheno/go-talib"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // MACD computes Moving Average Convergence/Divergence.
@@ -15,20 +15,20 @@ import (
 // len(closes) must be >= slowPeriod + signalPeriod.
 func MACD(closes []float64, fastPeriod, slowPeriod, signalPeriod int) (macdLine, signalLine, histogram []float64, err error) {
 	if fastPeriod <= 0 || slowPeriod <= 0 || signalPeriod <= 0 {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			"macd: all periods must be > 0",
 			nil,
 		)
 	}
 	if fastPeriod >= slowPeriod {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("macd: fast period (%d) must be less than slow period (%d)", fastPeriod, slowPeriod),
 			nil,
 		)
 	}
 	required := slowPeriod + signalPeriod
 	if len(closes) < required {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("macd requires at least %d values, got %d", required, len(closes)),
 			nil,
 		)

--- a/internal/ta/macd_test.go
+++ b/internal/ta/macd_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestMACD_ThreeAlignedSlices(t *testing.T) {
@@ -60,7 +60,7 @@ func TestMACD_RejectsFastGeSlow(t *testing.T) {
 	// fast >= slow should fail
 	_, _, _, err := MACD(closes, 26, 12, 9)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Contains(t, err.Error(), "fast period")
 }
@@ -69,7 +69,7 @@ func TestMACD_RejectsZeroPeriod(t *testing.T) {
 	closes := make([]float64, 50)
 	_, _, _, err := MACD(closes, 0, 26, 9)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -78,6 +78,6 @@ func TestMACD_InsufficientData(t *testing.T) {
 	closes := make([]float64, 10)
 	_, _, _, err := MACD(closes, 12, 26, 9)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }

--- a/internal/ta/stoch_adx.go
+++ b/internal/ta/stoch_adx.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/markcheno/go-talib"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // Stochastic computes the Stochastic Oscillator (%K and %D lines).
@@ -19,13 +19,13 @@ import (
 // Returns (slowK, slowD []float64, err error). Both slices are zero-stripped and aligned.
 func Stochastic(highs, lows, closes []float64, kPeriod, smoothK, dPeriod int) (slowK, slowD []float64, err error) {
 	if kPeriod <= 0 || smoothK <= 0 || dPeriod <= 0 {
-		return nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, apperr.NewValidationError(
 			"stochastic: all periods must be > 0",
 			nil,
 		)
 	}
 	if len(highs) != len(lows) || len(highs) != len(closes) {
-		return nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("stochastic: mismatched slice lengths: highs=%d, lows=%d, closes=%d", len(highs), len(lows), len(closes)),
 			nil,
 		)
@@ -59,13 +59,13 @@ func Stochastic(highs, lows, closes []float64, kPeriod, smoothK, dPeriod int) (s
 // Returns (adx, plusDI, minusDI []float64, err error). All slices stripped and aligned.
 func ADX(highs, lows, closes []float64, period int) (adx, plusDI, minusDI []float64, err error) {
 	if period <= 0 {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("adx period must be > 0, got %d", period),
 			nil,
 		)
 	}
 	if len(highs) != len(lows) || len(highs) != len(closes) {
-		return nil, nil, nil, schwabErrors.NewValidationError(
+		return nil, nil, nil, apperr.NewValidationError(
 			fmt.Sprintf("adx: mismatched slice lengths: highs=%d, lows=%d, closes=%d", len(highs), len(lows), len(closes)),
 			nil,
 		)

--- a/internal/ta/stoch_adx_test.go
+++ b/internal/ta/stoch_adx_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestStochastic_ValidRange(t *testing.T) {
@@ -44,7 +44,7 @@ func TestStochastic_MismatchedLengths(t *testing.T) {
 	closes := make([]float64, 10)
 	_, _, err := Stochastic(highs, lows, closes, 14, 3, 3)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -54,7 +54,7 @@ func TestStochastic_InvalidPeriod(t *testing.T) {
 	closes := make([]float64, 50)
 	_, _, err := Stochastic(highs, lows, closes, 0, 3, 3)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -108,7 +108,7 @@ func TestADX_InvalidPeriod(t *testing.T) {
 	closes := make([]float64, 50)
 	_, _, _, err := ADX(highs, lows, closes, 0)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -118,6 +118,6 @@ func TestADX_MismatchedLengths(t *testing.T) {
 	closes := make([]float64, 10)
 	_, _, _, err := ADX(highs, lows, closes, 14)
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }

--- a/internal/ta/volatility.go
+++ b/internal/ta/volatility.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"math"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 const (
@@ -34,14 +34,14 @@ type HistoricalVolatilityResult struct {
 // It uses simple returns, sample standard deviation, and reports volatility in percentage terms.
 func HistoricalVolatility(closes []float64, period int) (*HistoricalVolatilityResult, error) {
 	if period <= 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("historical volatility period must be > 0, got %d", period),
 			nil,
 		)
 	}
 
 	if len(closes) < period+1 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf(
 				"historical volatility requires at least %d closing prices, got %d",
 				period+1,

--- a/internal/ta/volatility_test.go
+++ b/internal/ta/volatility_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestHistoricalVolatility_Correct(t *testing.T) {
@@ -58,7 +58,7 @@ func TestHistoricalVolatility_InvalidPeriod(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -68,7 +68,7 @@ func TestHistoricalVolatility_InsufficientData(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 

--- a/internal/ta/vwap.go
+++ b/internal/ta/vwap.go
@@ -4,7 +4,7 @@ package ta
 import (
 	"fmt"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 // VWAP computes Volume Weighted Average Price.
@@ -13,14 +13,14 @@ import (
 func VWAP(highs, lows, closes, volumes []float64) ([]float64, error) {
 	// Validate input lengths
 	if len(highs) == 0 || len(lows) == 0 || len(closes) == 0 || len(volumes) == 0 {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			"VWAP requires non-empty slices",
 			nil,
 		)
 	}
 
 	if len(highs) != len(lows) || len(highs) != len(closes) || len(highs) != len(volumes) {
-		return nil, schwabErrors.NewValidationError(
+		return nil, apperr.NewValidationError(
 			fmt.Sprintf("VWAP requires equal-length slices: got highs=%d, lows=%d, closes=%d, volumes=%d",
 				len(highs), len(lows), len(closes), len(volumes)),
 			nil,
@@ -41,7 +41,7 @@ func VWAP(highs, lows, closes, volumes []float64) ([]float64, error) {
 
 		// Check if cumulative volume is zero (all volumes so far are zero)
 		if cumulativeVol == 0 {
-			return nil, schwabErrors.NewValidationError(
+			return nil, apperr.NewValidationError(
 				"VWAP requires non-zero volume data",
 				nil,
 			)

--- a/internal/ta/vwap_test.go
+++ b/internal/ta/vwap_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	schwabErrors "github.com/major/schwab-agent/internal/errors"
+	"github.com/major/schwab-agent/internal/apperr"
 )
 
 func TestVWAP_Correct(t *testing.T) {
@@ -70,7 +70,7 @@ func TestVWAP_AllZeroVolume(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -116,7 +116,7 @@ func TestVWAP_MismatchedLengths(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }
 
@@ -132,6 +132,6 @@ func TestVWAP_EmptySlices(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
-	var valErr *schwabErrors.ValidationError
+	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 }


### PR DESCRIPTION
## Summary

- **Codecov**: upload `coverage.out` to Codecov after test runs (uses `CODECOV_TOKEN` secret)
- **govulncheck**: new CI job scanning dependencies for known Go vulnerabilities
- **gosec**: added to golangci-lint config with nolint directives for false positives (G101 endpoint URLs, G117 config marshal) and a real fix for G112 (added `ReadHeaderTimeout` to OAuth callback server)
- **OpenSSF Scorecard**: weekly workflow publishing SARIF results to GitHub Security tab
- README badges added for Codecov and OpenSSF Scorecard

All actions pinned by SHA. Lint clean, tests pass.