### PR TITLE
fix: use string comparison instead of len() for empty check

### DIFF
--- a/internal/orderbuilder/fuzz_test.go
+++ b/internal/orderbuilder/fuzz_test.go
@@ -70,7 +70,7 @@ func FuzzBuildParseOCCRoundTrip(f *testing.F) {
 		// Filter out inputs that can't produce valid OCC symbols.
 		// Real ticker symbols are ASCII uppercase letters only.
 		trimmed := strings.TrimSpace(underlying)
-		if len(trimmed) == 0 || len(trimmed) > 6 {
+		if trimmed == "" || len(trimmed) > 6 {
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Fix gocritic `emptyStringTest` lint error in fuzz_test.go: replace `len(trimmed) == 0` with `trimmed == ""`