### PR TITLE
fix: use correct Schwab API index symbols for movers command

### DIFF
--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -55,10 +55,12 @@ func MarketCommand(c *client.Ref, w io.Writer) *cli.Command {
 			},
 			{
 				Name:  "movers",
-				Usage: "Get top movers for an index (e.g. $SPX.X, $DJI, $COMPX)",
+				// Valid index symbols from the Schwab API (not thinkorswim-style).
+			// The API returns a 400 with the full list if you pass an invalid one.
+			Usage: "Get top movers for an index ($SPX, $DJI, $COMPX, NYSE, NASDAQ, OTCBB, INDEX_ALL, EQUITY_ALL, OPTION_ALL, OPTION_PUT, OPTION_CALL)",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "sort", Usage: "Sort order (VOLUME, TRADES, PERCENT_CHANGE_UP, PERCENT_CHANGE_DOWN)"},
-					&cli.StringFlag{Name: "frequency", Usage: "Frequency (0, 1, 5, 10, 30, 60)"},
+					&cli.StringFlag{Name: "frequency", Usage: "Minimum percent change magnitude (0, 1, 5, 10, 30, 60)"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					index := cmd.Args().First()

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -98,7 +98,7 @@ func TestMarketCommand_Movers_Success(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := MarketCommand(testClient(t, srv), &buf)
-	require.NoError(t, runTestCommand(t, cmd, "market", "movers", "$SPX.X"))
+	require.NoError(t, runTestCommand(t, cmd, "market", "movers", "$SPX"))
 
 	var envelope output.Envelope
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
@@ -153,6 +153,6 @@ func TestMarketCommand_Movers_APIError(t *testing.T) {
 
 	var buf bytes.Buffer
 	cmd := MarketCommand(testClient(t, srv), &buf)
-	err := runTestCommand(t, cmd, "market", "movers", "$SPX.X")
+	err := runTestCommand(t, cmd, "market", "movers", "$SPX")
 	require.Error(t, err)
 }

--- a/skills/schwab-read.md
+++ b/skills/schwab-read.md
@@ -161,8 +161,9 @@ Available markets: equity, option, bond, future, forex
 ### Movers
 
 ```bash
-schwab-agent market movers $SPX.X
-schwab-agent market movers $DJI --sort PERCENT_CHANGE_UP
+schwab-agent market movers '$SPX'
+schwab-agent market movers '$DJI' --sort PERCENT_CHANGE_UP
+schwab-agent market movers EQUITY_ALL --sort VOLUME
 ```
 
 Flags: `--sort` (VOLUME/TRADES/PERCENT_CHANGE_UP/PERCENT_CHANGE_DOWN), `--frequency` (0/1/5/10/30/60)


### PR DESCRIPTION
## Summary

- Replace thinkorswim-style `$SPX.X` with the correct Schwab API symbol `$SPX` in usage text, tests, and skill file
- List all 11 valid index symbols in the usage text (`$SPX`, `$DJI`, `$COMPX`, `NYSE`, `NASDAQ`, `OTCBB`, `INDEX_ALL`, `EQUITY_ALL`, `OPTION_ALL`, `OPTION_PUT`, `OPTION_CALL`)
- Clarify `--frequency` flag description (minimum percent change magnitude, not a time interval)

Fixes #5