### PR TITLE
test: cover low-hanging coverage gaps across apperr, auth, commands

### DIFF
--- a/internal/apperr/errors_test.go
+++ b/internal/apperr/errors_test.go
@@ -343,3 +343,33 @@ func TestWrappedOrderBuildError(t *testing.T) {
 		t.Errorf("ExitCodeFor(wrapped OrderBuildError) = %d, want 1", code)
 	}
 }
+
+// TestWithDetails_AllConstructors verifies the WithDetails option sets the
+// details field on every error constructor. The existing TestDetailsFieldPreservation
+// covers AuthRequiredError; this table-driven test covers the remaining types.
+func TestWithDetails_AllConstructors(t *testing.T) {
+	const hint = "check your settings"
+
+	tests := []struct {
+		name    string
+		details string
+	}{
+		{"AuthExpired", NewAuthExpiredError("expired", nil, WithDetails(hint)).Details()},
+		{"AuthCallback", NewAuthCallbackError("callback", nil, WithDetails(hint)).Details()},
+		{"OrderRejected", NewOrderRejectedError("rejected", nil, WithDetails(hint)).Details()},
+		{"SymbolNotFound", NewSymbolNotFoundError("not found", nil, WithDetails(hint)).Details()},
+		{"AccountNotFound", NewAccountNotFoundError("not found", nil, WithDetails(hint)).Details()},
+		{"HTTPError", NewHTTPError("http", 500, "body", nil, WithDetails(hint)).Details()},
+		{"Validation", NewValidationError("invalid", nil, WithDetails(hint)).Details()},
+		{"OrderBuild", NewOrderBuildError("build", nil, WithDetails(hint)).Details()},
+		{"SchwabError", NewSchwabError("generic", nil, WithDetails(hint)).Details()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.details != hint {
+				t.Errorf("Details() = %q, want %q", tt.details, hint)
+			}
+		})
+	}
+}

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -503,6 +503,36 @@ func TestLoadConfig_IAlsoLikeToLiveDangerously_LoadsFalse(t *testing.T) {
 	assert.False(t, cfg.IAlsoLikeToLiveDangerously)
 }
 
+func TestSaveConfig_MkdirAllFailure(t *testing.T) {
+	// Arrange: use a path under /dev/null which is not a directory,
+	// so MkdirAll will fail trying to create the parent.
+	badPath := "/dev/null/impossible/config.json"
+	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
+
+	// Act
+	err := SaveConfig(badPath, cfg)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create config directory")
+}
+
+func TestSaveConfig_WriteFileFailure(t *testing.T) {
+	// Arrange: create a read-only directory so WriteFile fails.
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.MkdirAll(readOnlyDir, 0o500))
+	configPath := filepath.Join(readOnlyDir, "config.json")
+	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
+
+	// Act
+	err := SaveConfig(configPath, cfg)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write config file")
+}
+
 func TestSaveConfig_PreservesIAlsoLikeToLiveDangerously(t *testing.T) {
 	// Arrange
 	tmpDir := t.TempDir()

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -258,6 +258,36 @@ func TestRunLogin_PrintsURLAndSavesToken(t *testing.T) {
 	assert.InDelta(t, float64(tokenFile.CreationTimestamp+900), tokenFile.Token.ExpiresAt, 1)
 }
 
+func TestValidateCallbackAddr_EdgeCases(t *testing.T) {
+	t.Run("empty addr returns default", func(t *testing.T) {
+		addr, err := validateCallbackAddr("")
+		require.NoError(t, err)
+		assert.Equal(t, defaultCallbackAddr, addr)
+	})
+
+	t.Run("missing port returns error", func(t *testing.T) {
+		_, err := validateCallbackAddr("127.0.0.1")
+		require.Error(t, err)
+		var callbackErr *apperr.AuthCallbackError
+		assert.ErrorAs(t, err, &callbackErr)
+		assert.Contains(t, err.Error(), "host and port")
+	})
+
+	t.Run("non-loopback host returns error", func(t *testing.T) {
+		_, err := validateCallbackAddr("192.168.1.1:8182")
+		require.Error(t, err)
+		var callbackErr *apperr.AuthCallbackError
+		assert.ErrorAs(t, err, &callbackErr)
+		assert.Contains(t, err.Error(), "127.0.0.1")
+	})
+
+	t.Run("valid loopback addr passes through", func(t *testing.T) {
+		addr, err := validateCallbackAddr("127.0.0.1:9999")
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1:9999", addr)
+	})
+}
+
 // freeLoopbackAddress reserves and returns an available loopback port for tests.
 func freeLoopbackAddress(t *testing.T) string {
 	t.Helper()

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -205,6 +205,35 @@ func TestSaveToken_OverwritesExistingFile(t *testing.T) {
 	assert.Equal(t, "updated-access-token", loaded.Token.AccessToken)
 }
 
+func TestSaveToken_MkdirAllFailure(t *testing.T) {
+	// Arrange: use a path under /dev/null which cannot be a directory parent.
+	badPath := "/dev/null/impossible/token.json"
+	tf := makeTokenFile(1713700000, 1713701800.0)
+
+	// Act
+	err := SaveToken(badPath, tf)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create token directory")
+}
+
+func TestSaveToken_WriteFileFailure(t *testing.T) {
+	// Arrange: create a read-only directory so WriteFile fails.
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	require.NoError(t, os.MkdirAll(readOnlyDir, 0o500))
+	tokenPath := filepath.Join(readOnlyDir, "token.json")
+	tf := makeTokenFile(1713700000, 1713701800.0)
+
+	// Act
+	err := SaveToken(tokenPath, tf)
+
+	// Assert
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write token file")
+}
+
 // --- IsAccessTokenExpired tests ---
 
 func TestIsAccessTokenExpired_FutureExpiry_ReturnsFalse(t *testing.T) {

--- a/internal/commands/schema_test.go
+++ b/internal/commands/schema_test.go
@@ -255,6 +255,17 @@ func TestSchemaCommand_NestedCommandPath(t *testing.T) {
 	assert.True(t, equityCmd.Flags["--symbol"].Required)
 }
 
+func TestClassifyFlag_UnknownType_FallsBackToString(t *testing.T) {
+	// The default branch handles any flag type not explicitly matched
+	// (String, Int, Float64, Bool). UintFlag triggers this path.
+	t.Run("with name", func(t *testing.T) {
+		f := &cli.UintFlag{Name: "retries", Usage: "retry count"}
+		name, schema := classifyFlag(f)
+		assert.Equal(t, "retries", name)
+		assert.Equal(t, "string", schema.Type, "unknown flag types fall back to string")
+	})
+}
+
 func TestSchemaCommand_RawJSONOutput(t *testing.T) {
 	// Verify schema outputs raw JSON, not wrapped in the standard envelope.
 	app := testApp()

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -889,3 +889,23 @@ func TestTAExpectedMove_EmptyChain(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no options available")
 }
+
+func TestMustParseFloat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want float64
+	}{
+		{"valid integer", "100", 100.0},
+		{"valid decimal", "3.14", 3.14},
+		{"empty string", "", 0},
+		{"invalid string", "notanumber", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mustParseFloat(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `WithDetails` option tests for all 9 remaining error constructors in `apperr` (was 75%, only `AuthRequiredError` had coverage)
- Test `classifyFlag` default branch in `schema.go` via `UintFlag` (was 55.6%)
- Cover all `validateCallbackAddr` edge cases: empty addr, missing port, non-loopback host (was 62.5%)
- Test `mustParseFloat` helper in `ta.go` (was 0%)
- Test `SaveConfig`/`SaveToken` error paths for `MkdirAll` and `WriteFile` failures (was 66.7%)

All tests pass with race detector. Zero lint issues.