### PR TITLE
fix: scale TA history lookback based on indicator period

### DIFF
--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -207,7 +207,8 @@ func taEMACommand(c *client.Ref, w io.Writer) *cli.Command {
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
-			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period, "ema")
+			// EMA uses exponential smoothing; 3x period provides convergence stability.
+			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period*3, "ema")
 			if err != nil {
 				return err
 			}
@@ -242,7 +243,8 @@ func taRSICommand(c *client.Ref, w io.Writer) *cli.Command {
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
-			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period, "rsi")
+			// RSI uses Wilder smoothing; 3x period provides convergence stability.
+			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period*3, "rsi")
 			if err != nil {
 				return err
 			}
@@ -285,8 +287,8 @@ func taMACDCommand(c *client.Ref, w io.Writer) *cli.Command {
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
-			// Use slow period for data window calculation since it's the largest lookback
-			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, slow, "macd")
+			// MACD layers slow EMA + signal EMA; 2x the combined period provides convergence.
+			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, (slow+signal)*2, "macd")
 			if err != nil {
 				return err
 			}
@@ -347,7 +349,8 @@ func taATRCommand(c *client.Ref, w io.Writer) *cli.Command {
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
-			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period, "atr")
+			// ATR uses Wilder smoothing; 3x period provides convergence stability.
+			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period*3, "atr")
 			if err != nil {
 				return err
 			}
@@ -464,7 +467,9 @@ func taStochCommand(c *client.Ref, w io.Writer) *cli.Command {
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
-			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, kPeriod, "stoch")
+			// Stochastic chains three windowed ops (raw %K, smoothed %K, %D);
+			// total depth is the sum of all window sizes.
+			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, kPeriod+smoothK+dPeriod, "stoch")
 			if err != nil {
 				return err
 			}
@@ -532,7 +537,8 @@ func taADXCommand(c *client.Ref, w io.Writer) *cli.Command {
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
-			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period, "adx")
+			// ADX double-smooths (DI pass + ADX pass); 4x period ensures both converge.
+			candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, period*4, "adx")
 			if err != nil {
 				return err
 			}
@@ -854,15 +860,18 @@ func mustParseFloat(s string) float64 {
 }
 
 // fetchAndValidateCandles fetches price history and validates minimum candle count.
-// Returns the candle slice and pre-extracted timestamps for alignment.
+// requiredCandles is indicator-specific: each caller computes its own minimum based
+// on warmup needs (e.g. SMA needs exactly period, EMA needs 3x for convergence,
+// ADX needs 4x for double smoothing). The history lookback window is scaled to
+// match. See https://github.com/major/schwab-agent/issues/12.
 func fetchAndValidateCandles(
 	ctx context.Context,
 	c *client.Ref,
 	symbol, interval string,
-	period int,
+	requiredCandles int,
 	indicator string,
 ) ([]models.Candle, []string, error) {
-	periodType, periodVal, freqType, freq, err := ta.IntervalToHistoryParams(interval)
+	periodType, periodVal, freqType, freq, err := ta.IntervalToHistoryParams(interval, requiredCandles)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -878,8 +887,7 @@ func fetchAndValidateCandles(
 		return nil, nil, err
 	}
 
-	required := max(period*3, period+20)
-	if err := ta.ValidateMinCandles(result.Candles, required, indicator); err != nil {
+	if err := ta.ValidateMinCandles(result.Candles, requiredCandles, indicator); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -257,6 +257,43 @@ func TestTASMA_MissingSymbol(t *testing.T) {
 	assert.ErrorAs(t, err, &valErr)
 }
 
+// TestTASMA_LargePeriodScalesHistory verifies that SMA with a large period (e.g. 200)
+// works without requesting excessive history. SMA only needs exactly period candles,
+// so SMA 200 fits in a 1-year window (252 trading days). Before the fix for #12, the
+// generic formula over-requested 600 candles and then failed validation.
+func TestTASMA_LargePeriodScalesHistory(t *testing.T) {
+	// Arrange: handler that verifies SMA 200 only requests 1 year of data
+	// (SMA needs exactly period candles, and 252 > 200).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
+
+		// SMA 200 needs exactly 200 candles. 1 year of daily data provides 252,
+		// which is sufficient. No need to request multiple years.
+		period := r.URL.Query().Get("period")
+		assert.Equal(t, "1", period,
+			"SMA 200 needs 200 candles; 1 year (252 trading days) is sufficient")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockCandleListJSON("IBM", 252)))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	require.NoError(t, runTestCommand(t, cmd, "ta", "sma", "--period", "200", "--points", "1", "IBM"))
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	assert.Equal(t, "sma", data["indicator"])
+	assert.Equal(t, "IBM", data["symbol"])
+	assert.InDelta(t, 200, data["period"], 0.1)
+
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	assert.Len(t, values, 1, "--points 1 should limit output to 1 entry")
+}
+
 func TestTAEMA_ValidEnvelope(t *testing.T) {
 	// Arrange
 	srv := httptest.NewServer(priceHistoryHandler(t, "MSFT", 80))
@@ -336,7 +373,7 @@ func TestTARSI_MissingSymbol(t *testing.T) {
 }
 
 func TestTAMACD_ValidEnvelope(t *testing.T) {
-	// Arrange - 80 candles needed for MACD (slow=26, data window = max(78, 46) = 78)
+	// Arrange - MACD needs (slow+signal)*2 = (26+9)*2 = 70 candles; 80 provides headroom
 	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 80))
 	defer srv.Close()
 
@@ -370,7 +407,7 @@ func TestTAMACD_ValidEnvelope(t *testing.T) {
 }
 
 func TestTAMACD_CustomFlags(t *testing.T) {
-	// Arrange - fast=8, slow=21, signal=5; data window = max(63, 41) = 63
+	// Arrange - fast=8, slow=21, signal=5; required = (21+5)*2 = 52 candles
 	srv := httptest.NewServer(priceHistoryHandler(t, "MSFT", 80))
 	defer srv.Close()
 
@@ -409,7 +446,7 @@ func TestTAMACD_MissingSymbol(t *testing.T) {
 }
 
 func TestTAATR_ValidEnvelope(t *testing.T) {
-	// Arrange - 60 candles for ATR (period=14, data window = max(42, 34) = 42)
+	// Arrange - ATR needs period*3 = 14*3 = 42 candles; 60 provides headroom
 	srv := httptest.NewServer(priceHistoryHandler(t, "GOOG", 60))
 	defer srv.Close()
 
@@ -457,7 +494,7 @@ func TestTAATR_MissingSymbol(t *testing.T) {
 }
 
 func TestTABBands_ValidEnvelope(t *testing.T) {
-	// Arrange - 80 candles for BBands (period=20, data window = max(60, 40) = 60)
+	// Arrange - BBands needs exactly period = 20 candles; 80 provides headroom
 	srv := httptest.NewServer(priceHistoryHandler(t, "AMZN", 80))
 	defer srv.Close()
 
@@ -511,7 +548,7 @@ func TestTABBands_MissingSymbol(t *testing.T) {
 }
 
 func TestTAStochastic_ValidEnvelope(t *testing.T) {
-	// Arrange - k-period=14 default, data window = max(42, 34) = 42, use 60 candles for headroom
+	// Arrange - Stochastic needs k+smoothK+d = 14+3+3 = 20 candles; 60 provides headroom
 	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 60))
 	defer srv.Close()
 
@@ -712,8 +749,7 @@ func TestTAVWAP_NoPointsFlag(t *testing.T) {
 }
 
 func TestTAHV_ValidEnvelope(t *testing.T) {
-	// Arrange - period+21 passed to fetchAndValidateCandles, which applies max(p*3, p+20).
-	// For default period=20: 41*3=123 candles required. Use 200 for headroom.
+	// Arrange - HV passes period+21 = 41 directly as requiredCandles. Use 200 for headroom.
 	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 200))
 	defer srv.Close()
 
@@ -751,7 +787,7 @@ func TestTAHV_ValidEnvelope(t *testing.T) {
 }
 
 func TestTAHV_WithPeriod(t *testing.T) {
-	// Arrange - period=30, so 51 passed to fetchAndValidateCandles -> max(153, 71)=153 required.
+	// Arrange - period=30, so period+21 = 51 passed directly as requiredCandles.
 	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 200))
 	defer srv.Close()
 

--- a/internal/ta/interval.go
+++ b/internal/ta/interval.go
@@ -1,34 +1,120 @@
 package ta
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/major/schwab-agent/internal/apperr"
 )
 
-// IntervalToHistoryParams maps a human interval string to PriceHistory query params.
-// Returns (periodType, period, freqType, freq string, err error)
-// Supported: daily, weekly, 1min, 5min, 15min, 30min
-// Mapping:
-//   daily  -> year, 1, daily, 1
-//   weekly -> year, 1, weekly, 1
-//   1min   -> day, 10, minute, 1
-//   5min   -> day, 10, minute, 5
-//   15min  -> day, 10, minute, 15
-//   30min  -> day, 10, minute, 30
-// Returns ValidationError for unsupported intervals.
-func IntervalToHistoryParams(interval string) (periodType, period, freqType, freq string, err error) {
+const (
+	weeksPerYear = 52
+
+	// regularSessionMinutesPerDay is the number of 1-minute candles in a regular
+	// US market session (9:30-16:00 = 6.5 hours). Extended hours are excluded;
+	// revisit if the API is configured to return extended-hours candles.
+	regularSessionMinutesPerDay = 390
+
+	// maxYearPeriod is the largest "year" period the Schwab API accepts.
+	maxYearPeriod = 20
+	// maxDayPeriod is the largest "day" period the Schwab API accepts.
+	maxDayPeriod = 10
+)
+
+// validYearPeriods lists the period values the Schwab API documents for periodType "year".
+// Sending values not in this list may be silently rejected or misinterpreted.
+var validYearPeriods = []int{1, 2, 3, 5, 10, 15, 20}
+
+// validDayPeriods lists the period values the Schwab API documents for periodType "day".
+var validDayPeriods = []int{1, 2, 3, 4, 5, 10}
+
+// ceilDiv returns the ceiling of a/b for positive integers.
+func ceilDiv(a, b int) int {
+	return (a + b - 1) / b
+}
+
+// nextValidPeriod returns the smallest documented API period value >= n.
+// If n exceeds all valid periods, returns the largest valid period.
+func nextValidPeriod(n int, valid []int) int {
+	for _, v := range valid {
+		if v >= n {
+			return v
+		}
+	}
+	return valid[len(valid)-1]
+}
+
+// maxCandlesForInterval returns the theoretical maximum number of candles
+// the Schwab API can return for a given interval at the longest documented period.
+// Returns 0 for unknown intervals.
+func maxCandlesForInterval(interval string) int {
 	switch interval {
 	case "daily":
-		return "year", "1", "daily", "1", nil
+		return maxYearPeriod * tradingDaysPerYear
 	case "weekly":
-		return "year", "1", "weekly", "1", nil
+		return maxYearPeriod * weeksPerYear
 	case "1min":
-		return "day", "10", "minute", "1", nil
+		return maxDayPeriod * regularSessionMinutesPerDay
 	case "5min":
-		return "day", "10", "minute", "5", nil
+		return maxDayPeriod * (regularSessionMinutesPerDay / 5)
 	case "15min":
-		return "day", "10", "minute", "15", nil
+		return maxDayPeriod * (regularSessionMinutesPerDay / 15)
 	case "30min":
-		return "day", "10", "minute", "30", nil
+		return maxDayPeriod * (regularSessionMinutesPerDay / 30)
+	default:
+		return 0
+	}
+}
+
+// IntervalToHistoryParams maps a human interval string to PriceHistory query params.
+// requiredCandles controls how much history to fetch: the period is scaled up so the
+// API returns at least that many candles. Pass 0 to use the default (minimum) lookback.
+//
+// Period values are rounded up to the next value in the Schwab API's documented set
+// (years: 1,2,3,5,10,15,20; days: 1,2,3,4,5,10) to avoid sending unsupported values.
+//
+// Returns a ValidationError if requiredCandles exceeds the API's maximum capacity for
+// the given interval, or if the interval is not recognized.
+func IntervalToHistoryParams(interval string, requiredCandles int) (periodType, period, freqType, freq string, err error) {
+	// Fail early when the request exceeds the API's maximum history depth.
+	// Without this check, the period gets silently capped and the post-fetch
+	// validation produces a confusing "got N candles" error that blames the
+	// symbol's history rather than the API limit.
+	if mc := maxCandlesForInterval(interval); mc > 0 && requiredCandles > mc {
+		return "", "", "", "", apperr.NewValidationError(
+			fmt.Sprintf(
+				"indicator requires %d candles but %s interval supports at most %d (Schwab API limit)",
+				requiredCandles, interval, mc,
+			),
+			nil,
+		)
+	}
+
+	switch interval {
+	case "daily":
+		years := max(1, ceilDiv(requiredCandles, tradingDaysPerYear))
+		years = nextValidPeriod(years, validYearPeriods)
+		return "year", strconv.Itoa(years), "daily", "1", nil
+	case "weekly":
+		years := max(1, ceilDiv(requiredCandles, weeksPerYear))
+		years = nextValidPeriod(years, validYearPeriods)
+		return "year", strconv.Itoa(years), "weekly", "1", nil
+	case "1min":
+		days := max(1, ceilDiv(requiredCandles, regularSessionMinutesPerDay))
+		days = nextValidPeriod(days, validDayPeriods)
+		return "day", strconv.Itoa(days), "minute", "1", nil
+	case "5min":
+		days := max(1, ceilDiv(requiredCandles, regularSessionMinutesPerDay/5))
+		days = nextValidPeriod(days, validDayPeriods)
+		return "day", strconv.Itoa(days), "minute", "5", nil
+	case "15min":
+		days := max(1, ceilDiv(requiredCandles, regularSessionMinutesPerDay/15))
+		days = nextValidPeriod(days, validDayPeriods)
+		return "day", strconv.Itoa(days), "minute", "15", nil
+	case "30min":
+		days := max(1, ceilDiv(requiredCandles, regularSessionMinutesPerDay/30))
+		days = nextValidPeriod(days, validDayPeriods)
+		return "day", strconv.Itoa(days), "minute", "30", nil
 	default:
 		return "", "", "", "", apperr.NewValidationError(
 			"unsupported interval: "+interval,

--- a/internal/ta/interval_test.go
+++ b/internal/ta/interval_test.go
@@ -11,77 +11,200 @@ import (
 
 func TestIntervalToHistoryParams(t *testing.T) {
 	tests := []struct {
-		name      string
-		interval  string
-		wantPT    string
-		wantP     string
-		wantFT    string
-		wantF     string
-		wantErr   bool
-		errMsg    string
+		name            string
+		interval        string
+		requiredCandles int
+		wantPT          string
+		wantP           string
+		wantFT          string
+		wantF           string
+		wantErr         bool
+		errMsg          string
 	}{
+		// Default lookback (requiredCandles=0 or small enough for minimum period)
 		{
-			name:     "daily",
-			interval: "daily",
-			wantPT:   "year",
-			wantP:    "1",
-			wantFT:   "daily",
-			wantF:    "1",
-			wantErr:  false,
+			name:            "daily default",
+			interval:        "daily",
+			requiredCandles: 0,
+			wantPT:          "year",
+			wantP:           "1",
+			wantFT:          "daily",
+			wantF:           "1",
 		},
 		{
-			name:     "weekly",
-			interval: "weekly",
-			wantPT:   "year",
-			wantP:    "1",
-			wantFT:   "weekly",
-			wantF:    "1",
-			wantErr:  false,
+			name:            "weekly default",
+			interval:        "weekly",
+			requiredCandles: 0,
+			wantPT:          "year",
+			wantP:           "1",
+			wantFT:          "weekly",
+			wantF:           "1",
 		},
 		{
-			name:     "1min",
-			interval: "1min",
-			wantPT:   "day",
-			wantP:    "10",
-			wantFT:   "minute",
-			wantF:    "1",
-			wantErr:  false,
+			name:            "1min default",
+			interval:        "1min",
+			requiredCandles: 0,
+			wantPT:          "day",
+			wantP:           "1",
+			wantFT:          "minute",
+			wantF:           "1",
 		},
 		{
-			name:     "5min",
-			interval: "5min",
-			wantPT:   "day",
-			wantP:    "10",
-			wantFT:   "minute",
-			wantF:    "5",
-			wantErr:  false,
+			name:            "5min default",
+			interval:        "5min",
+			requiredCandles: 0,
+			wantPT:          "day",
+			wantP:           "1",
+			wantFT:          "minute",
+			wantF:           "5",
 		},
 		{
-			name:     "15min",
-			interval: "15min",
-			wantPT:   "day",
-			wantP:    "10",
-			wantFT:   "minute",
-			wantF:    "15",
-			wantErr:  false,
+			name:            "15min default",
+			interval:        "15min",
+			requiredCandles: 0,
+			wantPT:          "day",
+			wantP:           "1",
+			wantFT:          "minute",
+			wantF:           "15",
 		},
 		{
-			name:     "30min",
-			interval: "30min",
-			wantPT:   "day",
-			wantP:    "10",
-			wantFT:   "minute",
-			wantF:    "30",
-			wantErr:  false,
+			name:            "30min default",
+			interval:        "30min",
+			requiredCandles: 0,
+			wantPT:          "day",
+			wantP:           "1",
+			wantFT:          "minute",
+			wantF:           "30",
+		},
+
+		// Period scaling for daily: 600 candles / 252 days per year = 3 years
+		{
+			name:            "daily scaled for SMA 200",
+			interval:        "daily",
+			requiredCandles: 600,
+			wantPT:          "year",
+			wantP:           "3",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+		// 252 candles fits in 1 year
+		{
+			name:            "daily stays 1 year when sufficient",
+			interval:        "daily",
+			requiredCandles: 252,
+			wantPT:          "year",
+			wantP:           "1",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+		// 253 candles spills into year 2
+		{
+			name:            "daily scales to 2 years at boundary",
+			interval:        "daily",
+			requiredCandles: 253,
+			wantPT:          "year",
+			wantP:           "2",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+		// 4 years is not a documented API value; rounds up to 5
+		{
+			name:            "daily rounds 4 years up to 5",
+			interval:        "daily",
+			requiredCandles: 800,
+			wantPT:          "year",
+			wantP:           "5",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+		// Exactly at the API maximum (20 years * 252 = 5040)
+		{
+			name:            "daily at max valid period",
+			interval:        "daily",
+			requiredCandles: 5040,
+			wantPT:          "year",
+			wantP:           "20",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+
+		// Period scaling for weekly: 600 candles / 52 weeks = 12, rounds to 15
+		{
+			name:            "weekly rounds 12 years up to 15",
+			interval:        "weekly",
+			requiredCandles: 600,
+			wantPT:          "year",
+			wantP:           "15",
+			wantFT:          "weekly",
+			wantF:           "1",
+		},
+		// 52 candles fits in 1 year
+		{
+			name:            "weekly stays 1 year when sufficient",
+			interval:        "weekly",
+			requiredCandles: 52,
+			wantPT:          "year",
+			wantP:           "1",
+			wantFT:          "weekly",
+			wantF:           "1",
+		},
+
+		// Period scaling for intraday: 390 1-min candles per day
+		{
+			name:            "1min scales to 2 days",
+			interval:        "1min",
+			requiredCandles: 500,
+			wantPT:          "day",
+			wantP:           "2",
+			wantFT:          "minute",
+			wantF:           "1",
+		},
+		// 5min: 78 candles per day, 200 candles needs 3 days
+		{
+			name:            "5min scales to 3 days",
+			interval:        "5min",
+			requiredCandles: 200,
+			wantPT:          "day",
+			wantP:           "3",
+			wantFT:          "minute",
+			wantF:           "5",
+		},
+		// 5min: 6 days is not valid, rounds to 10
+		{
+			name:            "5min rounds 6 days up to 10",
+			interval:        "5min",
+			requiredCandles: 450,
+			wantPT:          "day",
+			wantP:           "10",
+			wantFT:          "minute",
+			wantF:           "5",
+		},
+
+		// Infeasible requests (exceed API maximum capacity)
+		{
+			name:            "daily exceeds max capacity",
+			interval:        "daily",
+			requiredCandles: 999999,
+			wantErr:         true,
+			errMsg:          "indicator requires 999999 candles but daily interval supports at most 5040",
 		},
 		{
-			name:     "invalid",
+			name:            "15min exceeds max capacity",
+			interval:        "15min",
+			requiredCandles: 999999,
+			wantErr:         true,
+			errMsg:          "indicator requires 999999 candles but 15min interval supports at most 260",
+		},
+
+		// Error cases
+		{
+			name:     "invalid interval",
 			interval: "invalid",
 			wantErr:  true,
 			errMsg:   "unsupported interval",
 		},
 		{
-			name:     "empty",
+			name:     "empty interval",
 			interval: "",
 			wantErr:  true,
 			errMsg:   "unsupported interval",
@@ -91,7 +214,7 @@ func TestIntervalToHistoryParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Act
-			pt, p, ft, f, err := IntervalToHistoryParams(tt.interval)
+			pt, p, ft, f, err := IntervalToHistoryParams(tt.interval, tt.requiredCandles)
 
 			// Assert
 			if tt.wantErr {
@@ -107,5 +230,70 @@ func TestIntervalToHistoryParams(t *testing.T) {
 				assert.Equal(t, tt.wantF, f)
 			}
 		})
+	}
+}
+
+func TestCeilDiv(t *testing.T) {
+	tests := []struct {
+		a, b, want int
+	}{
+		{1, 1, 1},
+		{5, 2, 3},
+		{6, 3, 2},
+		{7, 3, 3},
+		{252, 252, 1},
+		{253, 252, 2},
+		{600, 252, 3},
+		{0, 252, 0},
+	}
+
+	for _, tt := range tests {
+		got := ceilDiv(tt.a, tt.b)
+		assert.Equal(t, tt.want, got, "ceilDiv(%d, %d)", tt.a, tt.b)
+	}
+}
+
+func TestNextValidPeriod(t *testing.T) {
+	tests := []struct {
+		n    int
+		valid []int
+		want int
+	}{
+		{1, validYearPeriods, 1},
+		{3, validYearPeriods, 3},
+		{4, validYearPeriods, 5},   // 4 is not valid, rounds to 5
+		{6, validYearPeriods, 10},  // 6 is not valid, rounds to 10
+		{11, validYearPeriods, 15}, // 11 is not valid, rounds to 15
+		{16, validYearPeriods, 20}, // 16 is not valid, rounds to 20
+		{21, validYearPeriods, 20}, // exceeds max, capped at 20
+		{1, validDayPeriods, 1},
+		{6, validDayPeriods, 10},  // 6 is not valid, rounds to 10
+		{11, validDayPeriods, 10}, // exceeds max, capped at 10
+	}
+
+	for _, tt := range tests {
+		got := nextValidPeriod(tt.n, tt.valid)
+		assert.Equal(t, tt.want, got, "nextValidPeriod(%d, %v)", tt.n, tt.valid)
+	}
+}
+
+func TestMaxCandlesForInterval(t *testing.T) {
+	tests := []struct {
+		interval string
+		want     int
+	}{
+		{"daily", 5040},  // 20 years * 252 trading days
+		{"weekly", 1040}, // 20 years * 52 weeks
+		{"1min", 3900},   // 10 days * 390 minutes
+		{"5min", 780},    // 10 days * 78 bars
+		{"15min", 260},   // 10 days * 26 bars
+		{"30min", 130},   // 10 days * 13 bars
+		{"invalid", 0},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		got := maxCandlesForInterval(tt.interval)
+		assert.Equal(t, tt.want, got, "maxCandlesForInterval(%q)", tt.interval)
 	}
 }


### PR DESCRIPTION
## Summary

- `IntervalToHistoryParams` now accepts a `requiredCandles` parameter and scales the API period dynamically instead of hardcoding 1 year (daily/weekly) or 10 days (intraday)
- `fetchAndValidateCandles` calculates the candle requirement (`max(period*3, period+20)`) *before* the API call so the lookback window covers what the indicator needs
- Adds regression test verifying `ta sma --period 200` requests at least 3 years of daily history

## Problem

`ta sma IBM --period 200 --points 1` returned:

```json
{"error":{"code":"VALIDATION_ERROR","message":"sma requires at least 600 candles, got 252"}}
```

The default 1-year daily lookback returns ~252 candles, but SMA 200 needs 600 (3x period for warmup).

## Fix

Move the required-candle calculation before the history fetch and pass it into `IntervalToHistoryParams`, which now picks the right period:

| Interval | Rate | Example: 600 candles needed | Period |
|---|---|---|---|
| daily | 252/year | ceil(600/252) = 3 | `year/3` |
| weekly | 52/year | ceil(600/52) = 12 | `year/12` |
| 1min | 390/day | ceil(600/390) = 2 | `day/2` |
| 5min | 78/day | ceil(600/78) = 8 | `day/8` |

Periods are capped at API maximums (20 years, 10 days).

Fixes #12