### PR TITLE
test: add error path coverage for orders, auth, and TA commands

### DIFF
--- a/internal/client/orders_test.go
+++ b/internal/client/orders_test.go
@@ -305,3 +305,154 @@ func TestCancelOrder_Success(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestPlaceOrder_401_ReturnsAuthExpiredError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.PlaceOrder(context.Background(), "abc123", testOrderRequest())
+
+	require.Error(t, err)
+
+	var authErr *apperr.AuthExpiredError
+	require.ErrorAs(t, err, &authErr)
+}
+
+func TestPlaceOrder_500_ReturnsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.PlaceOrder(context.Background(), "abc123", testOrderRequest())
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+}
+
+func TestPlaceOrder_NoLocationHeader(t *testing.T) {
+	// 201 Created with no Location header should return empty PlaceOrderResponse.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	resp, err := c.PlaceOrder(context.Background(), "abc123", testOrderRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.OrderID)
+}
+
+func TestPlaceOrder_MalformedLocationHeader(t *testing.T) {
+	// Location header with non-integer trailing segment should return a parse error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/trader/v1/accounts/abc123/orders/not-a-number")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.PlaceOrder(context.Background(), "abc123", testOrderRequest())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse order ID from Location header")
+}
+
+func TestListOrders_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.ListOrders(context.Background(), "abc123", OrderListParams{})
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestAllOrders_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.AllOrders(context.Background(), OrderListParams{})
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestGetOrder_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.GetOrder(context.Background(), "abc123", 12345)
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestPreviewOrder_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.PreviewOrder(context.Background(), "abc123", testOrderRequest())
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestReplaceOrder_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	err := c.ReplaceOrder(context.Background(), "abc123", 12345, testOrderRequest())
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestCancelOrder_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	err := c.CancelOrder(context.Background(), "abc123", 12345)
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}

--- a/internal/commands/auth_test.go
+++ b/internal/commands/auth_test.go
@@ -415,4 +415,87 @@ func TestDefaultAuthConfigPath_ReturnsConfigPath(t *testing.T) {
 	assert.Equal(t, filepath.Join(tmpDir, "schwab-agent", "config.json"), path)
 }
 
+func TestDefaultAuthConfigPath_FallsBackToHomeDir(t *testing.T) {
+	// When XDG_CONFIG_HOME is unset, defaultAuthConfigPath falls back to
+	// os.UserHomeDir() + .config/schwab-agent/config.json.
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	path := defaultAuthConfigPath()
+	// The path should end with .config/schwab-agent/config.json regardless
+	// of the home directory prefix.
+	assert.Contains(t, path, filepath.Join(".config", "schwab-agent", "config.json"))
+}
+
+func TestAuthRefreshCommand_MissingConfig(t *testing.T) {
+	// When no config is provided and the config file doesn't exist, refresh should fail.
+	// Clear env vars so LoadConfig can't succeed from environment alone.
+	t.Setenv("SCHWAB_CLIENT_ID", "")
+	t.Setenv("SCHWAB_CLIENT_SECRET", "")
+	t.Setenv("SCHWAB_CALLBACK_URL", "")
+
+	var stdout bytes.Buffer
+	deps := defaultAuthDeps()
+	deps.configPath = func() string { return "/nonexistent/config.json" }
+
+	cmd := newAuthCommand(nil, "/nonexistent/token.json", &stdout, deps)
+	err := runTestCommand(t, cmd, "auth", "refresh")
+
+	require.Error(t, err)
+}
+
+func TestAuthRefreshCommand_MissingToken(t *testing.T) {
+	var stdout bytes.Buffer
+	deps := defaultAuthDeps()
+
+	cmd := newAuthCommand(
+		&auth.Config{ClientID: "id", ClientSecret: "secret"},
+		"/nonexistent/token.json",
+		&stdout,
+		deps,
+	)
+	err := runTestCommand(t, cmd, "auth", "refresh")
+
+	require.Error(t, err)
+}
+
+func TestAuthRefreshCommand_RefreshFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token.json")
+	require.NoError(t, auth.SaveToken(tokenPath, &auth.TokenFile{
+		CreationTimestamp: time.Now().Unix(),
+		Token: auth.TokenData{
+			AccessToken:  "old-token",
+			RefreshToken: "refresh-token",
+			ExpiresAt:    float64(time.Now().Unix() - 100),
+		},
+	}))
+
+	deps := defaultAuthDeps()
+	deps.refreshAccessToken = func(_ *auth.Config, _ *auth.TokenFile, _ string) (*auth.TokenFile, error) {
+		return nil, fmt.Errorf("refresh failed: server error")
+	}
+
+	var stdout bytes.Buffer
+	cmd := newAuthCommand(
+		&auth.Config{ClientID: "id", ClientSecret: "secret"},
+		tokenPath,
+		&stdout,
+		deps,
+	)
+	err := runTestCommand(t, cmd, "auth", "refresh")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refresh failed")
+}
+
+func TestAccountSetDefaultCommand_MissingHash(t *testing.T) {
+	var stdout bytes.Buffer
+	cmd := AccountSetDefaultCommand("/whatever/config.json", &stdout)
+
+	err := runTestCommand(t, cmd, "set-default")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account hash is required")
+}
+
 

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -1756,3 +1756,126 @@ func TestOrderBuildBracketOutputsRequestJSON(t *testing.T) {
 	require.NotNil(t, stopLoss.StopPrice)
 	assert.Equal(t, 175.0, *stopLoss.StopPrice)
 }
+
+func TestParseInstruction_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{"empty string", "", "action is required"},
+		{"whitespace only", "   ", "action is required"},
+		{"invalid action", "INVALID", "action is invalid"},
+		{"partial match", "BU", "action is invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseInstruction(tt.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+
+			var validationErr *apperr.ValidationError
+			require.ErrorAs(t, err, &validationErr)
+		})
+	}
+}
+
+func TestOrderPreview_EmptySpec(t *testing.T) {
+	// Arrange / Act
+	stdout, err := runOrderCommand(t, nil, writeTestConfig(t, "hash123"), "",
+		"order", "preview")
+
+	// Assert
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "spec is required")
+}
+
+func TestOrderPreview_APIError(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server error"}`))
+	}))
+	defer srv.Close()
+
+	spec := `{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderLegCollection":[{"instruction":"BUY","quantity":1,"instrument":{"assetType":"EQUITY","symbol":"AAPL"}}]}`
+	cliClient := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, writeTestConfig(t, "hash123"), "",
+		"order", "preview", "--spec", spec)
+
+	// Assert
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestOrderPlace_MissingSpec(t *testing.T) {
+	// order place (no subcommand) requires --spec
+	stdout, err := runOrderCommand(t, nil, writeTestConfigMutable(t, "hash123"), "",
+		"order", "place")
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "spec is required")
+}
+
+func TestOrderPlace_InvalidSpec_NonJSONPrefix(t *testing.T) {
+	// Spec that doesn't start with { or [ should return the "inline JSON" error.
+	stdout, err := runOrderCommand(t, nil, writeTestConfigMutable(t, "hash123"), "",
+		"order", "place", "--spec", "hello world", "--confirm")
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "spec must be inline JSON, @file, or -")
+}
+
+func TestOrderPlace_InvalidSpec_BadJSON(t *testing.T) {
+	// Spec starts with { but isn't valid JSON.
+	stdout, err := runOrderCommand(t, nil, writeTestConfigMutable(t, "hash123"), "",
+		"order", "place", "--spec", "{not valid json}", "--confirm")
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "spec must contain valid JSON")
+}
+
+func TestOrderPreview_SpecFileNotFound(t *testing.T) {
+	stdout, err := runOrderCommand(t, nil, writeTestConfig(t, "hash123"), "",
+		"order", "preview", "--spec", "@/nonexistent/file.json")
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "read spec file")
+}
+
+func TestOrderReplace_MissingOrderID(t *testing.T) {
+	// Replace requires a positional order-id argument.
+	stdout, err := runOrderCommand(t, nil, writeTestConfigMutable(t, "hash123"), "",
+		"order", "replace", "--confirm",
+		"--symbol", "AAPL", "--action", "BUY", "--quantity", "10")
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "order-id is required")
+}
+
+func TestOrderReplace_InvalidAction(t *testing.T) {
+	// Replace parses equity params; invalid --action triggers parseInstruction error.
+	stdout, err := runOrderCommand(t, nil, writeTestConfigMutable(t, "hash123"), "",
+		"order", "replace", "12345", "--confirm",
+		"--symbol", "AAPL", "--action", "INVALID", "--quantity", "10")
+
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "action is invalid")
+}

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -926,6 +926,54 @@ func TestTAExpectedMove_EmptyChain(t *testing.T) {
 	assert.Contains(t, err.Error(), "no options available")
 }
 
+func TestTASMA_APIError(t *testing.T) {
+	// Arrange: server returns 500 for price history request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	err := runTestCommand(t, cmd, "ta", "sma", "IBM", "--period", "20")
+
+	// Assert
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
+func TestTASMA_InsufficientCandles(t *testing.T) {
+	// SMA 20 requires 20 candles; returning only 10 should fail validation.
+	srv := httptest.NewServer(priceHistoryHandler(t, "IBM", 10))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	err := runTestCommand(t, cmd, "ta", "sma", "IBM", "--period", "20")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 20 candles")
+}
+
+func TestTAEMA_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	err := runTestCommand(t, cmd, "ta", "ema", "IBM", "--period", "20")
+
+	require.Error(t, err)
+
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+}
+
 func TestMustParseFloat(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

- Add 30 new tests covering untested error branches across `client/orders`, `commands/order`, `commands/auth`, and `commands/ta`
- Overall coverage: 88.9% -> 90.3%, with client package at 92.7% (+2.6%) and commands at 88.8% (+2.4%)

### Tests added

**client/orders.go** (10 tests): PlaceOrder 401 auth expired, 500 HTTP error, missing Location header, malformed Location header; API error paths for ListOrders, AllOrders, GetOrder, PreviewOrder, ReplaceOrder, CancelOrder

**commands/order.go** (8 tests): parseInstruction empty/invalid action, preview empty spec, preview API error, place missing spec, place invalid spec (non-JSON prefix + bad JSON), spec file not found, replace missing order-id, replace invalid action

**commands/auth.go** (5 tests): defaultAuthConfigPath home dir fallback, refresh with missing config, refresh with missing token, refresh failure propagation, set-default missing hash argument

**commands/ta.go** (3 tests): SMA API error (500), SMA insufficient candles, EMA API error