### PR TITLE
feat: add --positions flag to account list and get commands

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -1,0 +1,215 @@
+# Feature Parity: schwab-agent vs schwab-py
+
+Gap analysis of what schwab-py supports that schwab-agent does not. Streaming/websocket features excluded (not relevant for LLM consumers).
+
+Features are rated for LLM trading usefulness (how valuable is this for an AI agent making trading decisions?) and implementation difficulty.
+
+> schwab-agent has features schwab-py does NOT: technical analysis indicators, schema introspection, and OCC symbol build/parse. Those are not listed here since they're already advantages.
+
+## Usefulness Rating Scale
+
+| Rating | Meaning |
+|--------|---------|
+| 5 | Essential for competent LLM trading |
+| 4 | Very useful, covers common trading scenarios |
+| 3 | Moderately useful, specific but real use cases |
+| 2 | Niche, rarely needed for typical LLM workflows |
+| 1 | Specialized, almost never relevant |
+
+## Difficulty Rating Scale
+
+| Rating | Meaning |
+|--------|---------|
+| Easy | Models/enums already exist, just wire up CLI flags or query params |
+| Medium | Some builder logic needed, moderate testing |
+| Hard | Significant new builder logic, validation, multi-leg coordination |
+
+---
+
+## Critical Gaps
+
+### Account Positions (`?fields=positions`)
+
+**Usefulness: 5** | **Difficulty: Easy**
+
+The model layer is fully ready: `SecuritiesAccount` has `Positions []Position` with all fields (quantities, P&L, market value, instrument details). However, the client methods pass `nil` query params, so the Schwab API never includes position data in the response. The `Positions` slice always deserializes as empty.
+
+schwab-py: `get_account(account_hash, fields=Client.Account.Fields.POSITIONS)`
+schwab-agent: model exists, just needs `?fields=positions` query param passed to the API
+
+Fix is minimal: add a `--positions` flag (or always include it) and pass `map[string]string{"fields": "positions"}` to `doGet`. No new model code needed.
+
+This is probably the single highest-impact gap. An LLM cannot make informed trading decisions without knowing what it already owns.
+
+### Trailing Stop Orders
+
+**Usefulness: 5** | **Difficulty: Medium**
+
+`parseOrderType()` doesn't accept TRAILING_STOP or TRAILING_STOP_LIMIT. The models already have fields for `stopPriceLinkBasis`, `stopPriceLinkType`, `stopPriceOffset`, and `stopType`, but the order builder doesn't expose them.
+
+Trailing stops are fundamental risk management. An LLM managing a portfolio should be able to set a trailing stop at X% or $Y below market price and let it ride.
+
+Implementation requires:
+- Add TRAILING_STOP, TRAILING_STOP_LIMIT to `parseOrderType()`
+- Add CLI flags: `--stop-offset`, `--stop-link-basis`, `--stop-link-type`, `--stop-type`
+- Wire flags into order builder
+- Activation price flag for conditional trailing stops
+
+### Special Instructions (ALL_OR_NONE, DO_NOT_REDUCE)
+
+**Usefulness: 4** | **Difficulty: Easy**
+
+No `--special-instruction` flag on order commands. The model field exists (`SpecialInstruction`) but isn't populated.
+
+ALL_OR_NONE prevents partial fills, which matters when an LLM is sizing positions for specific portfolio allocations. DO_NOT_REDUCE prevents share count adjustment on dividends/splits.
+
+---
+
+## High-Value Gaps
+
+### Quote Field Filtering
+
+**Usefulness: 4** | **Difficulty: Easy**
+
+Quote endpoints don't pass `fields` (QUOTE, FUNDAMENTAL, EXTENDED, REFERENCE, REGULAR) or `indicative` params. LLMs get the default field set with no way to request fundamental data (P/E, dividend yield, etc.) alongside price data.
+
+An LLM doing any kind of valuation-aware trading needs FUNDAMENTAL fields. Currently requires a separate instrument lookup.
+
+### Stop Type (STANDARD, BID, ASK, LAST, MARK)
+
+**Usefulness: 4** | **Difficulty: Easy**
+
+No `--stop-type` flag. Defaults to whatever Schwab picks. For options and volatile stocks, an LLM should specify whether the stop triggers on BID, ASK, LAST, or MARK price. MARK is particularly important for options since it reflects fair value.
+
+### Market on Close / Limit on Close
+
+**Usefulness: 3** | **Difficulty: Easy**
+
+MARKET_ON_CLOSE and LIMIT_ON_CLOSE not in `parseOrderType()`. Useful for end-of-day rebalancing strategies. An LLM running a daily rebalance model would use these to execute at the closing auction price.
+
+### First-Triggers-Second Utility
+
+**Usefulness: 3** | **Difficulty: Medium**
+
+schwab-agent has bracket orders and OCO, but no general-purpose trigger mechanism. schwab-py's `first_triggers_second()` lets you chain any two orders: "buy this stock, then immediately place a covered call." An LLM could compose multi-step strategies without manual sequencing.
+
+Currently the bracket builder hardcodes the trigger pattern. A general trigger utility would enable more creative order flows.
+
+### Order Repeat/Reconstruction
+
+**Usefulness: 3** | **Difficulty: Medium**
+
+schwab-py's `construct_repeat_order()` takes a historical order and rebuilds it for resubmission (stripping filled quantities, resetting status, etc.). An LLM that identifies a previously successful trade pattern could repeat it without manually reconstructing every field.
+
+The Python-specific `code_for_builder()` doesn't translate, but the repeat concept does.
+
+---
+
+## Medium-Value Gaps
+
+### Destination Routing
+
+**Usefulness: 2** | **Difficulty: Easy**
+
+No `--destination` flag for exchange routing (INET, ECN_ARCA, CBOE, AMEX, etc.). The model field exists. Relevant for LLMs that care about execution quality or need to route to specific exchanges for liquidity reasons. Most LLM trading probably doesn't need this.
+
+### Price Link Basis/Type
+
+**Usefulness: 2** | **Difficulty: Easy**
+
+`priceLinkBasis` (MANUAL, BASE, TRIGGER, LAST, BID, ASK, etc.) and `priceLinkType` (VALUE, PERCENT, TICK) fields exist in models but aren't exposed. These control how limit prices adjust relative to a reference price. Advanced feature, but useful for LLMs implementing dynamic pricing strategies.
+
+### Calendar Spreads
+
+**Usefulness: 2** | **Difficulty: Medium**
+
+Not in the order builder. A calendar spread sells a near-term option and buys a longer-term option at the same strike. Useful for income strategies and volatility plays, but an LLM could construct this manually with two separate legs using the existing option builder.
+
+### Diagonal Spreads
+
+**Usefulness: 2** | **Difficulty: Medium**
+
+Not in the order builder. Like a calendar but with different strikes. Same manual workaround as calendar spreads - two legs at different strikes and expirations.
+
+### Collar / Collar with Stock
+
+**Usefulness: 2** | **Difficulty: Medium**
+
+Protective collar (long stock + long put + short call). Not in builder. Useful for portfolio protection, but an LLM could construct the legs individually. A dedicated builder would reduce errors and make intent clearer.
+
+---
+
+## Low-Value Gaps
+
+### Butterfly Spreads
+
+**Usefulness: 1** | **Difficulty: Hard**
+
+Three-leg or four-leg strategy. Rarely used by automated systems. An LLM would need significant options expertise to deploy these profitably. Manual leg construction is viable.
+
+### Back Ratio Spreads
+
+**Usefulness: 1** | **Difficulty: Hard**
+
+Unequal number of long and short options. Very specialized volatility play. Not something most LLM trading agents would attempt.
+
+### Double Diagonal
+
+**Usefulness: 1** | **Difficulty: Hard**
+
+Four-leg strategy combining two diagonals. Extremely specialized. Manual construction viable for the rare case an LLM would use this.
+
+### Unbalanced Strategies
+
+**Usefulness: 1** | **Difficulty: Hard**
+
+Unbalanced butterfly, condor, vertical roll variants. Highly specialized, almost never relevant for automated trading.
+
+### Exercise Orders
+
+**Usefulness: 1** | **Difficulty: Easy**
+
+Early exercise of options. LLMs should almost never do this (selling the option captures remaining time value). Only relevant for deep ITM options near expiration with dividend capture.
+
+### Cabinet Orders
+
+**Usefulness: 1** | **Difficulty: Easy**
+
+Closing worthless options for a nominal price ($0.01). Very niche, end-of-cycle cleanup.
+
+### NON_MARKETABLE Order Type
+
+**Usefulness: 1** | **Difficulty: Easy**
+
+Limit orders priced away from the market. Schwab usually infers this from the limit price. Explicitly setting it adds little value.
+
+---
+
+## Summary by Priority
+
+If implementing in order of LLM trading value per effort:
+
+| Priority | Feature | Usefulness | Difficulty |
+|----------|---------|------------|------------|
+| 1 | Account positions field | 5 | Easy |
+| 2 | Trailing stop orders | 5 | Medium |
+| 3 | Special instructions | 4 | Easy |
+| 4 | Quote field filtering | 4 | Easy |
+| 5 | Stop type flag | 4 | Easy |
+| 6 | Market/Limit on Close | 3 | Easy |
+| 7 | First-triggers-second | 3 | Medium |
+| 8 | Order repeat | 3 | Medium |
+| 9 | Destination routing | 2 | Easy |
+| 10 | Price link basis/type | 2 | Easy |
+| 11 | Calendar spreads | 2 | Medium |
+| 12 | Diagonal spreads | 2 | Medium |
+| 13 | Collar builder | 2 | Medium |
+| 14 | Butterfly builder | 1 | Hard |
+| 15 | Back ratio builder | 1 | Hard |
+| 16 | Double diagonal builder | 1 | Hard |
+| 17 | Unbalanced strategies | 1 | Hard |
+| 18 | Exercise orders | 1 | Easy |
+| 19 | Cabinet orders | 1 | Easy |
+| 20 | NON_MARKETABLE type | 1 | Easy |
+
+The first 5 items would cover the most impactful gaps with reasonable effort. Items 1, 3, 4, and 5 are particularly low-hanging fruit since the model fields already exist.

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
@@ -27,10 +28,16 @@ func (c *Client) AccountNumbers(ctx context.Context) ([]models.AccountNumber, er
 }
 
 // Accounts retrieves all accounts.
+// Pass field names (e.g. "positions") to include additional data in the response.
+// The Schwab API only returns position data when explicitly requested via ?fields=positions.
 // Returns AccountNotFoundError on 404.
-func (c *Client) Accounts(ctx context.Context) ([]models.Account, error) {
+func (c *Client) Accounts(ctx context.Context, fields ...string) ([]models.Account, error) {
+	var params map[string]string
+	if len(fields) > 0 {
+		params = map[string]string{"fields": strings.Join(fields, ",")}
+	}
 	var result []models.Account
-	err := c.doGet(ctx, "/trader/v1/accounts", nil, &result)
+	err := c.doGet(ctx, "/trader/v1/accounts", params, &result)
 	if err != nil {
 		// Convert 404 HTTPError to AccountNotFoundError
 		var httpErr *apperr.HTTPError
@@ -43,11 +50,17 @@ func (c *Client) Accounts(ctx context.Context) ([]models.Account, error) {
 }
 
 // Account retrieves a specific account by hash value.
+// Pass field names (e.g. "positions") to include additional data in the response.
+// The Schwab API only returns position data when explicitly requested via ?fields=positions.
 // Returns AccountNotFoundError on 404.
-func (c *Client) Account(ctx context.Context, hashValue string) (*models.Account, error) {
+func (c *Client) Account(ctx context.Context, hashValue string, fields ...string) (*models.Account, error) {
 	path := fmt.Sprintf("/trader/v1/accounts/%s", hashValue)
+	var params map[string]string
+	if len(fields) > 0 {
+		params = map[string]string{"fields": strings.Join(fields, ",")}
+	}
 	var result models.Account
-	err := c.doGet(ctx, path, nil, &result)
+	err := c.doGet(ctx, path, params, &result)
 	if err != nil {
 		// Convert 404 HTTPError to AccountNotFoundError
 		var httpErr *apperr.HTTPError

--- a/internal/client/accounts_test.go
+++ b/internal/client/accounts_test.go
@@ -184,6 +184,97 @@ func TestAccount_404_ReturnsAccountNotFoundError(t *testing.T) {
 	assert.Contains(t, accountErr.Error(), "account invalid-hash not found")
 }
 
+func TestAccounts_WithPositionsField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the fields query parameter is sent to the API.
+		assert.Equal(t, "positions", r.URL.Query().Get("fields"))
+
+		w.Header().Set("Content-Type", "application/json")
+		response := []models.Account{
+			{
+				SecuritiesAccount: &models.SecuritiesAccount{
+					Type:          ptr("MARGIN"),
+					AccountNumber: ptr("123456789"),
+					Positions: []models.Position{
+						{
+							LongQuantity: ptr(float64(100)),
+							MarketValue:  ptr(15000.00),
+							Instrument: &models.AccountsInstrument{
+								Symbol:    ptr("AAPL"),
+								AssetType: ptr("EQUITY"),
+							},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	result, err := c.Accounts(context.Background(), "positions")
+
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Len(t, result[0].SecuritiesAccount.Positions, 1)
+	assert.Equal(t, "AAPL", *result[0].SecuritiesAccount.Positions[0].Instrument.Symbol)
+	assert.Equal(t, 100.0, *result[0].SecuritiesAccount.Positions[0].LongQuantity)
+}
+
+func TestAccounts_WithoutFields_NoQueryParam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No fields param should be sent when none are requested.
+		assert.Empty(t, r.URL.Query().Get("fields"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode([]models.Account{}))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	_, err := c.Accounts(context.Background())
+
+	require.NoError(t, err)
+}
+
+func TestAccount_WithPositionsField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "positions", r.URL.Query().Get("fields"))
+		assert.Equal(t, "/trader/v1/accounts/hash123", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		response := models.Account{
+			SecuritiesAccount: &models.SecuritiesAccount{
+				Type:          ptr("MARGIN"),
+				AccountNumber: ptr("123456789"),
+				Positions: []models.Position{
+					{
+						LongQuantity:  ptr(float64(50)),
+						ShortQuantity: ptr(float64(0)),
+						MarketValue:   ptr(8500.00),
+						Instrument: &models.AccountsInstrument{
+							Symbol:    ptr("MSFT"),
+							AssetType: ptr("EQUITY"),
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	result, err := c.Account(context.Background(), "hash123", "positions")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.SecuritiesAccount.Positions, 1)
+	assert.Equal(t, "MSFT", *result.SecuritiesAccount.Positions[0].Instrument.Symbol)
+	assert.Equal(t, 50.0, *result.SecuritiesAccount.Positions[0].LongQuantity)
+}
+
 func TestAccount_WithComplexData(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/commands/account.go
+++ b/internal/commands/account.go
@@ -64,8 +64,19 @@ func accountListCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
 		Name:  "list",
 		Usage: "List all accounts with nicknames and settings",
-		Action: func(ctx context.Context, _ *cli.Command) error {
-			accounts, err := c.Accounts(ctx)
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "positions",
+				Usage: "Include current positions for each account",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			var fields []string
+			if cmd.Bool("positions") {
+				fields = append(fields, "positions")
+			}
+
+			accounts, err := c.Accounts(ctx, fields...)
 			if err != nil {
 				return err
 			}
@@ -87,13 +98,24 @@ func accountGetCommand(c *client.Ref, configPath string, w io.Writer) *cli.Comma
 	return &cli.Command{
 		Name:  "get",
 		Usage: "Get account details by hash value",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "positions",
+				Usage: "Include current positions in the account response",
+			},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			hash, err := resolveAccount(cmd.String("account"), configPath, cmd.Args().Slice())
 			if err != nil {
 				return err
 			}
 
-			account, err := c.Account(ctx, hash)
+			var fields []string
+			if cmd.Bool("positions") {
+				fields = append(fields, "positions")
+			}
+
+			account, err := c.Account(ctx, hash, fields...)
 			if err != nil {
 				return err
 			}

--- a/internal/commands/account_test.go
+++ b/internal/commands/account_test.go
@@ -115,6 +115,76 @@ func TestAccountList_Success(t *testing.T) {
 	assert.Equal(t, false, second["primaryAccount"])
 }
 
+func TestAccountList_WithPositionsFlag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/trader/v1/accounts" {
+			// Verify the positions field is requested.
+			assert.Equal(t, "positions", r.URL.Query().Get("fields"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{
+				"securitiesAccount": {
+					"type": "MARGIN",
+					"accountNumber": "12345",
+					"positions": [{
+						"longQuantity": 100,
+						"marketValue": 15000.00,
+						"instrument": {"symbol": "AAPL", "assetType": "EQUITY"}
+					}]
+				}
+			}]`))
+
+			return
+		}
+		// Preferences endpoint
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accounts": []}`))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd := AccountCommand(testClient(t, srv), "", &buf)
+	require.NoError(t, runTestCommand(t, cmd, "account", "list", "--positions"))
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+
+	accountList, ok := dataMap["accounts"].([]any)
+	require.True(t, ok)
+	require.Len(t, accountList, 1)
+
+	// Verify positions came through in the response
+	acct, ok := accountList[0].(map[string]any)
+	require.True(t, ok)
+	sa, ok := acct["securitiesAccount"].(map[string]any)
+	require.True(t, ok)
+	positions, ok := sa["positions"].([]any)
+	require.True(t, ok)
+	assert.Len(t, positions, 1)
+}
+
+func TestAccountList_WithoutPositionsFlag_NoFieldsParam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/trader/v1/accounts" {
+			// No fields param when --positions is not passed.
+			assert.Empty(t, r.URL.Query().Get("fields"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"securitiesAccount": {"type": "MARGIN", "accountNumber": "12345"}}]`))
+
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accounts": []}`))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd := AccountCommand(testClient(t, srv), "", &buf)
+	require.NoError(t, runTestCommand(t, cmd, "account", "list"))
+}
+
 func TestAccountList_PreferencesFailure_StillReturnsAccounts(t *testing.T) {
 	// Preferences endpoint returns 500, but account list should still succeed
 	// without nicknames.
@@ -198,6 +268,47 @@ func TestAccountNumbers_Success(t *testing.T) {
 	accountList, ok := dataMap["accounts"].([]any)
 	require.True(t, ok)
 	assert.Len(t, accountList, 2)
+}
+
+func TestAccountGet_WithPositionsFlag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/trader/v1/accounts/MY_HASH" {
+			assert.Equal(t, "positions", r.URL.Query().Get("fields"))
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"securitiesAccount": {
+					"type": "MARGIN",
+					"accountNumber": "12345",
+					"positions": [{
+						"longQuantity": 200,
+						"marketValue": 30000.00,
+						"instrument": {"symbol": "MSFT", "assetType": "EQUITY"}
+					}]
+				}
+			}`))
+
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accounts": []}`))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd := AccountCommand(testClient(t, srv), "", &buf)
+	require.NoError(t, runTestCommand(t, cmd, "account", "get", "--positions", "MY_HASH"))
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, "MY_HASH", env.Metadata.Account)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+	sa, ok := dataMap["securitiesAccount"].(map[string]any)
+	require.True(t, ok)
+	positions, ok := sa["positions"].([]any)
+	require.True(t, ok)
+	assert.Len(t, positions, 1)
 }
 
 func TestAccountGet_FlagOverridesAll(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `--positions` flag to `account list` and `account get` commands
- When set, passes `?fields=positions` query param to Schwab API so position data is included in the response
- Models already supported position deserialization; only the query param plumbing was missing
- Also includes a feature parity analysis doc (`FEATURE_PARITY.md`) comparing schwab-agent with schwab-py

## Details

The Schwab API only returns position data when `fields=positions` is explicitly requested. Without this flag, positions are always empty even though the `Position` model is fully defined. The client methods use variadic `fields ...string` for backward compatibility (no args = no change in behavior).

## Testing

- Client tests verify `?fields=positions` query param is sent when requested and omitted when not
- Command tests verify the flag wires through to the client layer correctly
- All existing tests pass (backward compatible change)