### PR TITLE
feat(auth): support proxy base URL routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,23 @@ Create `~/.config/schwab-agent/config.json`:
 {
   "client_id": "your-client-id",
   "client_secret": "your-client-secret",
+  "base_url": "https://api.schwabapi.com",
+  "base_url_insecure": false,
   "callback_url": "https://127.0.0.1:8182"
 }
 ```
+
+`base_url` is the single outbound endpoint root for REST API calls and Schwab OAuth authorize/token requests. Leave it at the default for direct Schwab access, or point it at a Schwab-compatible proxy.
+
+If your proxy terminates TLS with a local self-signed certificate, set `base_url_insecure` to `true` so outbound REST and OAuth token/refresh requests skip certificate verification. This is intentionally opt-in for local development only.
 
 Or use environment variables (these take priority over the config file):
 
 ```bash
 export SCHWAB_CLIENT_ID=your-client-id
 export SCHWAB_CLIENT_SECRET=your-client-secret
+export SCHWAB_BASE_URL=https://api.schwabapi.com   # default
+export SCHWAB_BASE_URL_INSECURE=false              # default
 export SCHWAB_CALLBACK_URL=https://127.0.0.1:8182  # default
 ```
 

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -7,10 +7,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/urfave/cli/v3"
 
@@ -28,13 +31,13 @@ var version = "dev"
 // Tests override individual fields; production uses defaultAppDeps().
 type appDeps struct {
 	newClient            func(token string, opts ...client.Option) *client.Client
-	tokenRefreshEndpoint func() string
+	tokenRefreshEndpoint func(*auth.Config) string
 }
 
 func defaultAppDeps() appDeps {
 	return appDeps{
 		newClient:            client.NewClient,
-		tokenRefreshEndpoint: func() string { return "https://api.schwabapi.com/v1/oauth/token" },
+		tokenRefreshEndpoint: func(cfg *auth.Config) string { return cfg.OAuthTokenURL() },
 	}
 }
 
@@ -118,6 +121,11 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 
 			cfg, err := auth.LoadConfig(resolvedConfigPath)
 			if err != nil {
+				var validationErr *apperr.ValidationError
+				if errors.As(err, &validationErr) && !strings.Contains(validationErr.Message, "Missing required credentials") {
+					return ctx, err
+				}
+
 				return ctx, apperr.NewAuthRequiredError(
 					"Missing required credentials: set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add client_id and client_secret to the config file",
 					err,
@@ -143,7 +151,7 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 			}
 
 			if auth.IsAccessTokenExpired(token) {
-				refreshed, err := auth.RefreshAccessToken(cfg, token, deps.tokenRefreshEndpoint())
+				refreshed, err := auth.RefreshAccessToken(cfg, token, deps.tokenRefreshEndpoint(cfg))
 				if err != nil {
 					return ctx, err
 				}
@@ -153,9 +161,13 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 				token = refreshed
 			}
 
-			apiClient.Client = deps.newClient(token.Token.AccessToken,
-				client.WithUserAgent("schwab-agent/"+version),
-			)
+			clientOptions := []client.Option{
+				client.WithUserAgent("schwab-agent/" + version),
+				client.WithBaseURL(cfg.APIBaseURL()),
+				client.WithHTTPClient(cfg.HTTPClient(30 * time.Second)),
+			}
+
+			apiClient.Client = deps.newClient(token.Token.AccessToken, clientOptions...)
 			return ctx, nil
 		},
 		Commands: []*cli.Command{

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -20,6 +21,34 @@ import (
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/apperr"
 )
+
+func TestMain(m *testing.M) {
+	envVars := []string{
+		"SCHWAB_CLIENT_ID",
+		"SCHWAB_CLIENT_SECRET",
+		"SCHWAB_CALLBACK_URL",
+		"SCHWAB_BASE_URL",
+		"SCHWAB_BASE_URL_INSECURE",
+	}
+
+	original := make(map[string]string, len(envVars))
+	for _, key := range envVars {
+		original[key] = os.Getenv(key)
+		_ = os.Unsetenv(key)
+	}
+
+	exitCode := m.Run()
+
+	for _, key := range envVars {
+		if value, ok := original[key]; ok && value != "" {
+			_ = os.Setenv(key, value)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
+
+	os.Exit(exitCode)
+}
 
 // runApp builds and executes the root command without allowing urfave/cli to call os.Exit.
 func runApp(t *testing.T, args ...string) (string, error) {
@@ -136,6 +165,28 @@ func TestBeforeHook_ReturnsAuthRequiredErrorForMissingConfig(t *testing.T) {
 	assert.Equal(t, 3, apperr.ExitCodeFor(err))
 }
 
+func TestBeforeHook_ReturnsValidationErrorForInvalidBaseURLConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configPath := filepath.Join(tmpDir, "invalid-config.json")
+	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		CallbackURL:  "https://127.0.0.1:8182",
+		BaseURL:      "https://api.schwabapi.com",
+	}))
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"client_id":"test-client","client_secret":"test-secret","base_url":"://bad"}`), 0o600))
+
+	_, err := runApp(t, "schwab-agent", "--config", configPath, "account")
+	require.Error(t, err)
+
+	var validationErr *apperr.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Contains(t, err.Error(), "invalid base_url")
+	assert.Equal(t, 1, apperr.ExitCodeFor(err))
+}
+
 func TestBeforeHook_ReturnsAuthExpiredErrorForStaleRefreshToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
@@ -160,6 +211,33 @@ func TestBeforeHook_ReturnsAuthExpiredErrorForStaleRefreshToken(t *testing.T) {
 	require.ErrorAs(t, err, &authErr)
 	assert.Equal(t, "Run `schwab-agent auth login` to re-authenticate", authErr.Details())
 	assert.Equal(t, 3, apperr.ExitCodeFor(err))
+}
+
+func TestAuthStatus_UsesRuntimeConfigAndTokenFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	defaultConfigPath := filepath.Join(tmpDir, "schwab-agent", "config.json")
+	defaultTokenPath := filepath.Join(tmpDir, "schwab-agent", "token.json")
+	runtimeConfigPath := filepath.Join(tmpDir, "runtime-config.json")
+	runtimeTokenPath := filepath.Join(tmpDir, "runtime-token.json")
+
+	writeTestConfig(t, defaultConfigPath)
+	writeTestToken(t, defaultTokenPath, freshToken())
+	require.NoError(t, auth.SaveConfig(runtimeConfigPath, &auth.Config{
+		ClientID:     "runtime-client-id",
+		ClientSecret: "runtime-secret",
+	}))
+	writeTestToken(t, runtimeTokenPath, freshToken())
+
+	stdout, err := runApp(t,
+		"schwab-agent",
+		"--config", runtimeConfigPath,
+		"--token", runtimeTokenPath,
+		"auth", "status",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, `"client_id":"runt..."`)
 }
 
 func TestBeforeHook_RefreshesExpiredToken(t *testing.T) {
@@ -198,12 +276,71 @@ func TestBeforeHook_RefreshesExpiredToken(t *testing.T) {
 	defer server.Close()
 
 	deps := defaultAppDeps()
-	deps.tokenRefreshEndpoint = func() string { return server.URL + "/oauth/token" }
+	deps.tokenRefreshEndpoint = func(_ *auth.Config) string { return server.URL + "/oauth/token" }
 	deps.newClient = func(token string, _ ...client.Option) *client.Client {
 		return client.NewClient(token, client.WithBaseURL(server.URL))
 	}
 
 	_, err := runAppWithDeps(t, deps, "schwab-agent", "--config", configPath, "--token", tokenPath, "account", "numbers")
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), refreshCalls.Load())
+
+	refreshed, loadErr := auth.LoadToken(tokenPath)
+	require.NoError(t, loadErr)
+	assert.Equal(t, "fresh-access-token", refreshed.Token.AccessToken)
+	assert.True(t, refreshed.Token.ExpiresAt > float64(time.Now().Unix()))
+}
+
+func TestBeforeHook_UsesConfiguredProxyForRefreshAndAPIRequests(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configPath := filepath.Join(tmpDir, "schwab-agent", "config.json")
+	tokenPath := filepath.Join(tmpDir, "schwab-agent", "token.json")
+	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
+		ClientID:        "test-client",
+		ClientSecret:    "test-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURL:         "https://placeholder.invalid",
+		BaseURLInsecure: true,
+	}))
+	writeTestToken(t, tokenPath, &auth.TokenFile{
+		CreationTimestamp: time.Now().Add(-time.Hour).Unix(),
+		Token: auth.TokenData{
+			AccessToken:  "expired-access-token",
+			RefreshToken: "refresh-token",
+			ExpiresIn:    1800,
+			ExpiresAt:    float64(time.Now().Add(-time.Hour).Unix()),
+		},
+	})
+
+	var refreshCalls atomic.Int32
+	proxy := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/proxy/v1/oauth/token":
+			refreshCalls.Add(1)
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "Basic dGVzdC1jbGllbnQ6dGVzdC1zZWNyZXQ=", r.Header.Get("Authorization"))
+			_, _ = w.Write([]byte(`{"access_token":"fresh-access-token","token_type":"Bearer","expires_in":1800,"refresh_token":"refresh-token","scope":"api"}`))
+		case "/proxy/trader/v1/accounts/accountNumbers":
+			assert.Equal(t, "Bearer fresh-access-token", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"accountNumber":"123456789","hashValue":"hash-123"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer proxy.Close()
+
+	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
+		ClientID:        "test-client",
+		ClientSecret:    "test-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURL:         proxy.URL + "/proxy/",
+		BaseURLInsecure: true,
+	}))
+
+	_, err := runAppWithDeps(t, defaultAppDeps(), "schwab-agent", "--config", configPath, "--token", tokenPath, "account", "numbers")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), refreshCalls.Load())
 

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -2,22 +2,133 @@
 package auth
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
 
+const (
+	defaultBaseURL = "https://api.schwabapi.com"
+)
+
 // Config holds Schwab API credentials and settings.
 type Config struct {
-	ClientID                  string `json:"client_id"`
-	ClientSecret              string `json:"client_secret"`
-	CallbackURL               string `json:"callback_url"`
-	DefaultAccount            string `json:"default_account"`
+	ClientID                   string `json:"client_id"`
+	ClientSecret               string `json:"client_secret"`
+	BaseURL                    string `json:"base_url"`
+	BaseURLInsecure            bool   `json:"base_url_insecure"`
+	CallbackURL                string `json:"callback_url"`
+	DefaultAccount             string `json:"default_account"`
 	IAlsoLikeToLiveDangerously bool   `json:"i-also-like-to-live-dangerously"`
+}
+
+// APIBaseURL returns the normalized REST/OAuth base URL, defaulting to Schwab's
+// production host when the config leaves base_url empty.
+func (cfg *Config) APIBaseURL() string {
+	if cfg == nil {
+		return defaultBaseURL
+	}
+
+	normalizedBaseURL, err := normalizeBaseURL(cfg.BaseURL)
+	if err != nil {
+		trimmedBaseURL := strings.TrimSpace(cfg.BaseURL)
+		if trimmedBaseURL != "" {
+			return trimmedBaseURL
+		}
+
+		return defaultBaseURL
+	}
+
+	return normalizedBaseURL
+}
+
+// OAuthAuthorizeURL derives the authorize endpoint from base_url so a
+// Schwab-compatible proxy can front both REST and OAuth traffic consistently.
+func (cfg *Config) OAuthAuthorizeURL() string {
+	return cfg.resolveAPIPath("/v1/oauth/authorize")
+}
+
+// OAuthTokenURL derives the token/refresh endpoint from base_url. We keep this
+// separate from callback_url because the callback is still the local loopback
+// listener, while authorize/token traffic may be routed through a proxy.
+func (cfg *Config) OAuthTokenURL() string {
+	return cfg.resolveAPIPath("/v1/oauth/token")
+}
+
+// HTTPClient returns an outbound HTTP client for REST or OAuth requests.
+// When base_url_insecure is true we skip certificate verification so local
+// self-signed proxy setups can terminate TLS without requiring a custom trust
+// store on every developer machine.
+func (cfg *Config) HTTPClient(timeout time.Duration) *http.Client {
+	insecure := cfg != nil && cfg.BaseURLInsecure
+	client := &http.Client{Timeout: timeout}
+
+	if !insecure {
+		return client
+	}
+
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return client
+	}
+
+	clonedTransport := transport.Clone()
+	clonedTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // base_url_insecure is an explicit opt-in for local self-signed proxies
+	client.Transport = clonedTransport
+
+	return client
+}
+
+// resolveAPIPath joins an API path onto the normalized base URL while
+// preserving any proxy path prefix present in base_url.
+func (cfg *Config) resolveAPIPath(endpointPath string) string {
+	baseURL, err := url.Parse(cfg.APIBaseURL())
+	if err != nil {
+		return cfg.APIBaseURL()
+	}
+
+	baseURL.Path = path.Join(strings.TrimRight(baseURL.Path, "/"), endpointPath)
+	baseURL.RawPath = ""
+	baseURL.RawQuery = ""
+	baseURL.Fragment = ""
+
+	return baseURL.String()
+}
+
+// normalizeBaseURL trims whitespace, enforces an absolute URL, and removes a
+// trailing slash so downstream code can safely append REST/OAuth paths.
+func normalizeBaseURL(rawBaseURL string) (string, error) {
+	rawBaseURL = strings.TrimSpace(rawBaseURL)
+	if rawBaseURL == "" {
+		rawBaseURL = defaultBaseURL
+	}
+
+	parsedURL, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse base_url: %w", err)
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", fmt.Errorf("base_url must include scheme and host")
+	}
+
+	parsedURL.Path = strings.TrimRight(parsedURL.Path, "/")
+	parsedURL.RawPath = ""
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
+
+	return parsedURL.String(), nil
 }
 
 // LoadConfig reads config from file and applies env var overrides.
@@ -55,10 +166,32 @@ func LoadConfig(configPath string) (*Config, error) {
 		cfg.CallbackURL = callbackURL
 	}
 
+	if baseURL := os.Getenv("SCHWAB_BASE_URL"); baseURL != "" {
+		cfg.BaseURL = baseURL
+	}
+
+	if rawBaseURLInsecure, ok := os.LookupEnv("SCHWAB_BASE_URL_INSECURE"); ok {
+		baseURLInsecure, err := strconv.ParseBool(strings.TrimSpace(rawBaseURLInsecure))
+		if err != nil {
+			return nil, apperr.NewValidationError(
+				"Invalid SCHWAB_BASE_URL_INSECURE: expected true or false",
+				err,
+			)
+		}
+
+		cfg.BaseURLInsecure = baseURLInsecure
+	}
+
 	// Set default callback URL if still empty
 	if cfg.CallbackURL == "" {
 		cfg.CallbackURL = "https://127.0.0.1:8182"
 	}
+
+	normalizedBaseURL, err := normalizeBaseURL(cfg.BaseURL)
+	if err != nil {
+		return nil, apperr.NewValidationError("invalid base_url", err)
+	}
+	cfg.BaseURL = normalizedBaseURL
 
 	// Validate required fields
 	if cfg.ClientID == "" || cfg.ClientSecret == "" {

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -1,15 +1,46 @@
 package auth
 
 import (
+	"crypto/tls"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/major/schwab-agent/internal/apperr"
 )
+
+func TestMain(m *testing.M) {
+	envVars := []string{
+		"SCHWAB_CLIENT_ID",
+		"SCHWAB_CLIENT_SECRET",
+		"SCHWAB_CALLBACK_URL",
+		"SCHWAB_BASE_URL",
+		"SCHWAB_BASE_URL_INSECURE",
+	}
+
+	original := make(map[string]string, len(envVars))
+	for _, key := range envVars {
+		original[key] = os.Getenv(key)
+		_ = os.Unsetenv(key)
+	}
+
+	exitCode := m.Run()
+
+	for _, key := range envVars {
+		if value, ok := original[key]; ok && value != "" {
+			_ = os.Setenv(key, value)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
+
+	os.Exit(exitCode)
+}
 
 func TestLoadConfig_MissingFile_ReturnsValidationError(t *testing.T) {
 	// Arrange
@@ -151,6 +182,103 @@ func TestLoadConfig_DefaultCallbackURL(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, "https://127.0.0.1:8182", cfg.CallbackURL)
+	assert.Equal(t, defaultBaseURL, cfg.BaseURL)
+}
+
+func TestLoadConfig_EnvVarOverridesBaseURLAndInsecure(t *testing.T) {
+	// Arrange
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	configData := Config{
+		ClientID:        "test-id",
+		ClientSecret:    "test-secret",
+		BaseURL:         "https://file.example.com/ignored",
+		BaseURLInsecure: false,
+	}
+
+	data, err := json.Marshal(configData)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, data, 0o600))
+
+	t.Setenv("SCHWAB_BASE_URL", "  https://env.example.com/proxy/  ")
+	t.Setenv("SCHWAB_BASE_URL_INSECURE", "true")
+
+	// Act
+	cfg, err := LoadConfig(configPath)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, "https://env.example.com/proxy", cfg.BaseURL)
+	assert.True(t, cfg.BaseURLInsecure)
+}
+
+func TestLoadConfig_InvalidBaseURLInsecureEnv_ReturnsValidationError(t *testing.T) {
+	// Arrange
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"client_id":"id","client_secret":"secret"}`), 0o600))
+	t.Setenv("SCHWAB_BASE_URL_INSECURE", "definitely-not-bool")
+
+	// Act
+	cfg, err := LoadConfig(configPath)
+
+	// Assert
+	assert.Nil(t, cfg)
+	require.Error(t, err)
+
+	var valErr *apperr.ValidationError
+	assert.ErrorAs(t, err, &valErr)
+	assert.Contains(t, err.Error(), "SCHWAB_BASE_URL_INSECURE")
+}
+
+func TestLoadConfig_InvalidBaseURL_ReturnsValidationError(t *testing.T) {
+	// Arrange
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"client_id":"id","client_secret":"secret","base_url":"://bad"}`), 0o600))
+
+	// Act
+	cfg, err := LoadConfig(configPath)
+
+	// Assert
+	assert.Nil(t, cfg)
+	require.Error(t, err)
+
+	var valErr *apperr.ValidationError
+	assert.ErrorAs(t, err, &valErr)
+	assert.Contains(t, err.Error(), "base_url")
+}
+
+func TestConfigOAuthHelpers_DeriveURLsFromBaseURL(t *testing.T) {
+	cfg := &Config{BaseURL: "https://proxy.example.com/root"}
+
+	assert.Equal(t, "https://proxy.example.com/root/v1/oauth/authorize", cfg.OAuthAuthorizeURL())
+	assert.Equal(t, "https://proxy.example.com/root/v1/oauth/token", cfg.OAuthTokenURL())
+}
+
+func TestConfigHTTPClient_BaseURLInsecureConfiguresTLS(t *testing.T) {
+	secureClient := (&Config{}).HTTPClient(5 * time.Second)
+	assert.Equal(t, 5*time.Second, secureClient.Timeout)
+	assert.Nil(t, secureClient.Transport)
+
+	insecureClient := (&Config{BaseURLInsecure: true}).HTTPClient(5 * time.Second)
+	require.NotNil(t, insecureClient.Transport)
+
+	transport, ok := insecureClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
+
+	// Sanity check that the helper does not mutate the global default transport.
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok)
+	if defaultTransport.TLSClientConfig != nil {
+		assert.False(t, defaultTransport.TLSClientConfig.InsecureSkipVerify)
+	}
+
+	// Touch the tls import so the intent of the transport assertion is explicit.
+	_ = tls.VersionTLS13
 }
 
 func TestLoadConfig_MissingClientID_ReturnsValidationError(t *testing.T) {

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -28,12 +28,6 @@ import (
 )
 
 const (
-	// authorizeEndpoint is Schwab's OAuth authorization endpoint.
-	authorizeEndpoint = "https://api.schwabapi.com/v1/oauth/authorize"
-
-	// oauthTokenEndpoint is Schwab's OAuth token endpoint.
-	oauthTokenEndpoint = "https://api.schwabapi.com/v1/oauth/token" //nolint:gosec // G101: API endpoint URL, not a credential
-
 	// defaultCallbackAddr limits the local callback server to loopback.
 	defaultCallbackAddr = "127.0.0.1:8182"
 
@@ -52,13 +46,6 @@ const (
 	callbackServerTimeout = 300 * time.Second
 )
 
-// oauthHTTPClient is the HTTP client for OAuth token exchange and refresh
-// requests. Has an explicit timeout to prevent hanging on network issues,
-// unlike http.DefaultClient which has no timeout.
-var oauthHTTPClient = &http.Client{
-	Timeout: oauthHTTPTimeout,
-}
-
 // AuthorizeURL builds the Schwab authorization URL and returns it with a random state value.
 func AuthorizeURL(cfg *Config) (authURL, state string, err error) {
 	state, err = randomOAuthState()
@@ -73,7 +60,7 @@ func AuthorizeURL(cfg *Config) (authURL, state string, err error) {
 	query.Set("scope", "api")
 	query.Set("state", state)
 
-	return authorizeEndpoint + "?" + query.Encode(), state, nil
+	return cfg.OAuthAuthorizeURL() + "?" + query.Encode(), state, nil
 }
 
 // ExchangeCode exchanges an OAuth authorization code for a token file.
@@ -81,7 +68,7 @@ func AuthorizeURL(cfg *Config) (authURL, state string, err error) {
 // making the function deterministic for tests.
 func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*TokenFile, error) {
 	if tokenEndpoint == "" {
-		tokenEndpoint = oauthTokenEndpoint
+		tokenEndpoint = cfg.OAuthTokenURL()
 	}
 
 	formData := url.Values{}
@@ -97,7 +84,7 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
 
-	resp, err := oauthHTTPClient.Do(req)
+	resp, err := cfg.HTTPClient(oauthHTTPTimeout).Do(req)
 	if err != nil {
 		return nil, apperr.NewAuthCallbackError("token exchange request failed", err)
 	}
@@ -390,5 +377,3 @@ func generateSelfSignedCertificate() (tls.Certificate, error) {
 
 	return certificate, nil
 }
-
-

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -46,9 +46,9 @@ func (b *synchronizedBuffer) String() string {
 }
 
 func TestOAuthHTTPClient_HasTimeout(t *testing.T) {
-	// The OAuth HTTP client must have an explicit timeout to prevent hanging
-	// on network issues. http.DefaultClient has Timeout=0 (no timeout).
-	assert.Equal(t, 30*time.Second, oauthHTTPClient.Timeout,
+	// The config-derived OAuth HTTP client must have an explicit timeout to
+	// prevent hanging on network issues. http.DefaultClient has Timeout=0.
+	assert.Equal(t, 30*time.Second, (&Config{}).HTTPClient(oauthHTTPTimeout).Timeout,
 		"OAuth HTTP client must have a timeout to prevent hanging requests")
 }
 
@@ -69,7 +69,7 @@ func TestAuthorizeURL_ReturnsExpectedParametersAndState(t *testing.T) {
 	parsedURL, err := url.Parse(authURL)
 	require.NoError(t, err)
 
-	assert.Equal(t, authorizeEndpoint, parsedURL.Scheme+"://"+parsedURL.Host+parsedURL.Path)
+	assert.Equal(t, cfg.OAuthAuthorizeURL(), parsedURL.Scheme+"://"+parsedURL.Host+parsedURL.Path)
 	assert.Equal(t, state, parsedURL.Query().Get("state"))
 	assert.Equal(t, "test-client", parsedURL.Query().Get("client_id"))
 	assert.Equal(t, "https://127.0.0.1:8182", parsedURL.Query().Get("redirect_uri"))
@@ -78,6 +78,22 @@ func TestAuthorizeURL_ReturnsExpectedParametersAndState(t *testing.T) {
 	assert.Len(t, state, 64)
 	_, err = hex.DecodeString(state)
 	require.NoError(t, err)
+}
+
+func TestAuthorizeURL_UsesDerivedBaseURL(t *testing.T) {
+	cfg := &Config{
+		ClientID:     "test-client",
+		ClientSecret: "unused",
+		CallbackURL:  "https://127.0.0.1:8182",
+		BaseURL:      "https://proxy.example.com/prefix",
+	}
+
+	authURL, _, err := AuthorizeURL(cfg)
+	require.NoError(t, err)
+
+	parsedURL, err := url.Parse(authURL)
+	require.NoError(t, err)
+	assert.Equal(t, "https://proxy.example.com/prefix/v1/oauth/authorize", parsedURL.Scheme+"://"+parsedURL.Host+parsedURL.Path)
 }
 
 func TestExchangeCode_Success_UsesBasicAuthAndReturnsTokenFile(t *testing.T) {
@@ -154,6 +170,40 @@ func TestExchangeCode_Failure_ReturnsAuthCallbackError(t *testing.T) {
 	var callbackErr *apperr.AuthCallbackError
 	assert.ErrorAs(t, err, &callbackErr)
 	assert.Contains(t, err.Error(), "token exchange failed")
+}
+
+func TestExchangeCode_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/proxy/v1/oauth/token", r.URL.Path)
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		assert.Equal(t, "derived-code", r.Form.Get("code"))
+		assert.Equal(t, "https://127.0.0.1:8182", r.Form.Get("redirect_uri"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "proxy-access-token",
+			"token_type":    "Bearer",
+			"expires_in":    1800,
+			"refresh_token": "proxy-refresh-token",
+			"scope":         "api",
+		}))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURL:         server.URL + "/proxy/",
+		BaseURLInsecure: true,
+	}
+
+	tokenFile, err := ExchangeCode(cfg, "derived-code", "", time.Unix(1_700_000_000, 0))
+	require.NoError(t, err)
+	require.NotNil(t, tokenFile)
+	assert.Equal(t, "proxy-access-token", tokenFile.Token.AccessToken)
+	assert.Equal(t, "proxy-refresh-token", tokenFile.Token.RefreshToken)
 }
 
 func TestStartCallbackServer_Success_ReturnsCode(t *testing.T) {
@@ -247,7 +297,7 @@ func TestRunLogin_PrintsURLAndSavesToken(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Contains(t, writer.String(), authorizeEndpoint)
+	assert.Contains(t, writer.String(), cfg.OAuthAuthorizeURL())
 
 	tokenFile, err := LoadToken(tokenPath)
 	require.NoError(t, err)

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -15,9 +15,6 @@ import (
 )
 
 const (
-	// tokenEndpoint is the Schwab OAuth token endpoint.
-	tokenEndpoint = "https://api.schwabapi.com/v1/oauth/token" //nolint:gosec // G101: API endpoint URL, not a credential
-
 	// refreshTokenMaxAge is 6.5 days in seconds, matching schwab-py's default.
 	refreshTokenMaxAge = 561600
 
@@ -106,7 +103,7 @@ type tokenErrorResponse struct {
 // The endpoint parameter allows overriding the token URL for testing.
 func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile, error) {
 	if endpoint == "" {
-		endpoint = tokenEndpoint
+		endpoint = cfg.OAuthTokenURL()
 	}
 
 	// Build form body
@@ -123,7 +120,7 @@ func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
 
-	resp, err := oauthHTTPClient.Do(req)
+	resp, err := cfg.HTTPClient(oauthHTTPTimeout).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token refresh request failed: %w", err)
 	}
@@ -161,5 +158,3 @@ func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile
 		Token:             newToken,
 	}, nil
 }
-
-

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -391,6 +391,40 @@ func TestRefreshAccessToken_Success_ReturnsNewTokenFile(t *testing.T) {
 	assert.InDelta(t, float64(time.Now().Unix()+1800), newTF.Token.ExpiresAt, 5.0)
 }
 
+func TestRefreshAccessToken_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/proxy/v1/oauth/token", r.URL.Path)
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		assert.Equal(t, "test-refresh-token", r.Form.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "derived-access-token",
+			"token_type":    "Bearer",
+			"expires_in":    1800,
+			"refresh_token": "derived-refresh-token",
+			"scope":         "api",
+		}))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		ClientID:        "test-client",
+		ClientSecret:    "test-secret",
+		BaseURL:         server.URL + "/proxy/",
+		BaseURLInsecure: true,
+	}
+
+	tf := makeTokenFile(time.Now().Add(-1*time.Hour).Unix(), float64(time.Now().Add(-5*time.Minute).Unix()))
+
+	newTF, err := RefreshAccessToken(cfg, tf, "")
+	require.NoError(t, err)
+	require.NotNil(t, newTF)
+	assert.Equal(t, "derived-access-token", newTF.Token.AccessToken)
+	assert.Equal(t, "derived-refresh-token", newTF.Token.RefreshToken)
+}
+
 func TestRefreshAccessToken_PreservesCreationTimestamp(t *testing.T) {
 	// Arrange
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -27,7 +27,7 @@ type authDeps struct {
 	oauthTokenEndpoint func() string
 	refreshAccessToken func(*auth.Config, *auth.TokenFile, string) (*auth.TokenFile, error)
 	runLogin           func(*auth.Config, string, string, bool, io.Writer) error
-	newAccountClient   func(string) accountNumbersClient
+	newAccountClient   func(string, *auth.Config) accountNumbersClient
 }
 
 // defaultAuthDeps returns the production dependency set.
@@ -37,8 +37,13 @@ func defaultAuthDeps() authDeps {
 		oauthTokenEndpoint: func() string { return "" },
 		refreshAccessToken: auth.RefreshAccessToken,
 		runLogin:           auth.RunLogin,
-		newAccountClient: func(token string) accountNumbersClient {
-			return client.NewClient(token)
+		newAccountClient: func(token string, cfg *auth.Config) accountNumbersClient {
+			clientOptions := []client.Option{
+				client.WithBaseURL(cfg.APIBaseURL()),
+				client.WithHTTPClient(cfg.HTTPClient(30 * time.Second)),
+			}
+
+			return client.NewClient(token, clientOptions...)
 		},
 	}
 }
@@ -131,32 +136,37 @@ func authLoginCommand(cfg *auth.Config, tokenPath string, w io.Writer, deps auth
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			loginConfig, err := requireAuthConfig(cfg, deps.configPath)
+			defaultConfigPath := deps.configPath()
+			resolvedConfigPath := resolveAuthConfigPath(cmd, defaultConfigPath)
+			resolvedTokenPath := resolveAuthTokenPath(cmd, tokenPath)
+			effectiveConfig := runtimeAuthConfig(cfg, resolvedConfigPath, defaultConfigPath)
+
+			loginConfig, err := requireAuthConfig(effectiveConfig, resolvedConfigPath)
 			if err != nil {
 				return err
 			}
 
 			var loginOutput strings.Builder
 			openBrowser := !cmd.Bool("no-browser")
-			if err := deps.runLogin(loginConfig, tokenPath, deps.oauthTokenEndpoint(), openBrowser, &loginOutput); err != nil {
+			if err := deps.runLogin(loginConfig, resolvedTokenPath, deps.oauthTokenEndpoint(), openBrowser, &loginOutput); err != nil {
 				return err
 			}
 
-			tokenFile, err := auth.LoadToken(tokenPath)
+			tokenFile, err := auth.LoadToken(resolvedTokenPath)
 			if err != nil {
 				return err
 			}
 
 			defaultAccount := configDefaultAccount(loginConfig)
 			autoSetDefault := false
-			accounts, err := deps.newAccountClient(tokenFile.Token.AccessToken).AccountNumbers(ctx)
+			accounts, err := deps.newAccountClient(tokenFile.Token.AccessToken, loginConfig).AccountNumbers(ctx)
 			if err != nil {
 				return err
 			}
 
 			if len(accounts) == 1 {
 				defaultAccount = accounts[0].HashValue
-				if err := auth.SetDefaultAccount(deps.configPath(), defaultAccount); err != nil {
+				if err := auth.SetDefaultAccount(resolvedConfigPath, defaultAccount); err != nil {
 					return err
 				}
 				autoSetDefault = true
@@ -181,13 +191,18 @@ func authStatusCommand(cfg *auth.Config, tokenPath string, w io.Writer, deps aut
 	return &cli.Command{
 		Name:  "status",
 		Usage: "Show token and config status",
-		Action: func(_ context.Context, _ *cli.Command) error {
-			tokenFile, err := auth.LoadToken(tokenPath)
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			defaultConfigPath := deps.configPath()
+			resolvedConfigPath := resolveAuthConfigPath(cmd, defaultConfigPath)
+			resolvedTokenPath := resolveAuthTokenPath(cmd, tokenPath)
+			effectiveConfig := runtimeAuthConfig(cfg, resolvedConfigPath, defaultConfigPath)
+
+			tokenFile, err := auth.LoadToken(resolvedTokenPath)
 			if err != nil {
 				return err
 			}
 
-			statusConfig := optionalAuthConfig(cfg, deps.configPath)
+			statusConfig := optionalAuthConfig(effectiveConfig, resolvedConfigPath)
 			data := authStatusData{
 				Valid:            !auth.IsAccessTokenExpired(tokenFile),
 				ExpiresAt:        unixSecondsToRFC3339(tokenFile.Token.ExpiresAt),
@@ -206,13 +221,18 @@ func authRefreshCommand(cfg *auth.Config, tokenPath string, w io.Writer, deps au
 	return &cli.Command{
 		Name:  "refresh",
 		Usage: "Refresh the current access token",
-		Action: func(_ context.Context, _ *cli.Command) error {
-			refreshConfig, err := requireAuthConfig(cfg, deps.configPath)
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			defaultConfigPath := deps.configPath()
+			resolvedConfigPath := resolveAuthConfigPath(cmd, defaultConfigPath)
+			resolvedTokenPath := resolveAuthTokenPath(cmd, tokenPath)
+			effectiveConfig := runtimeAuthConfig(cfg, resolvedConfigPath, defaultConfigPath)
+
+			refreshConfig, err := requireAuthConfig(effectiveConfig, resolvedConfigPath)
 			if err != nil {
 				return err
 			}
 
-			tokenFile, err := auth.LoadToken(tokenPath)
+			tokenFile, err := auth.LoadToken(resolvedTokenPath)
 			if err != nil {
 				return err
 			}
@@ -222,7 +242,7 @@ func authRefreshCommand(cfg *auth.Config, tokenPath string, w io.Writer, deps au
 				return err
 			}
 
-			if err := auth.SaveToken(tokenPath, refreshedToken); err != nil {
+			if err := auth.SaveToken(resolvedTokenPath, refreshedToken); err != nil {
 				return err
 			}
 
@@ -233,22 +253,53 @@ func authRefreshCommand(cfg *auth.Config, tokenPath string, w io.Writer, deps au
 	}
 }
 
+// resolveAuthConfigPath returns the runtime config path for auth subcommands.
+func resolveAuthConfigPath(cmd *cli.Command, fallback string) string {
+	if path := strings.TrimSpace(cmd.String("config")); path != "" {
+		return path
+	}
+
+	return fallback
+}
+
+// resolveAuthTokenPath returns the runtime token path for auth subcommands.
+func resolveAuthTokenPath(cmd *cli.Command, fallback string) string {
+	if path := strings.TrimSpace(cmd.String("token")); path != "" {
+		return path
+	}
+
+	return fallback
+}
+
+// runtimeAuthConfig returns the captured config only when the command is using
+// the same config path that buildApp() used to construct the command tree.
+// If the user supplies a different --config path at runtime, we must ignore the
+// captured config and reload from disk so auth subcommands see the same proxy
+// and credential settings as the rest of the CLI.
+func runtimeAuthConfig(cfg *auth.Config, resolvedConfigPath, defaultConfigPath string) *auth.Config {
+	if resolvedConfigPath != defaultConfigPath {
+		return nil
+	}
+
+	return cfg
+}
+
 // requireAuthConfig returns a valid auth config or loads it from disk.
-func requireAuthConfig(cfg *auth.Config, configPath func() string) (*auth.Config, error) {
+func requireAuthConfig(cfg *auth.Config, configPath string) (*auth.Config, error) {
 	if cfg != nil && cfg.ClientID != "" && cfg.ClientSecret != "" {
 		return cfg, nil
 	}
 
-	return auth.LoadConfig(configPath())
+	return auth.LoadConfig(configPath)
 }
 
 // optionalAuthConfig returns the provided config or best-effort loaded config.
-func optionalAuthConfig(cfg *auth.Config, configPath func() string) *auth.Config {
+func optionalAuthConfig(cfg *auth.Config, configPath string) *auth.Config {
 	if cfg != nil {
 		return cfg
 	}
 
-	loadedConfig, err := auth.LoadConfig(configPath())
+	loadedConfig, err := auth.LoadConfig(configPath)
 	if err != nil {
 		return &auth.Config{}
 	}

--- a/internal/commands/auth_test.go
+++ b/internal/commands/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +20,34 @@ import (
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/output"
 )
+
+func TestMain(m *testing.M) {
+	envVars := []string{
+		"SCHWAB_CLIENT_ID",
+		"SCHWAB_CLIENT_SECRET",
+		"SCHWAB_CALLBACK_URL",
+		"SCHWAB_BASE_URL",
+		"SCHWAB_BASE_URL_INSECURE",
+	}
+
+	original := make(map[string]string, len(envVars))
+	for _, key := range envVars {
+		original[key] = os.Getenv(key)
+		_ = os.Unsetenv(key)
+	}
+
+	exitCode := m.Run()
+
+	for _, key := range envVars {
+		if value, ok := original[key]; ok && value != "" {
+			_ = os.Setenv(key, value)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
+
+	os.Exit(exitCode)
+}
 
 // testEnvelope mirrors the standard JSON success envelope for assertions.
 type testEnvelope struct {
@@ -170,7 +199,7 @@ func TestAuthLoginCommand_AutoSetsDefaultAccount(t *testing.T) {
 	deps := defaultAuthDeps()
 	deps.configPath = func() string { return configPath }
 	deps.oauthTokenEndpoint = func() string { return server.URL + "/v1/oauth/token" }
-	deps.newAccountClient = func(token string) accountNumbersClient {
+	deps.newAccountClient = func(token string, _ *auth.Config) accountNumbersClient {
 		return client.NewClient(token, client.WithBaseURL(server.URL))
 	}
 	deps.runLogin = func(cfg *auth.Config, targetTokenPath string, tokenEndpoint string, openBrowser bool, w io.Writer) error {
@@ -216,6 +245,75 @@ func TestAuthLoginCommand_AutoSetsDefaultAccount(t *testing.T) {
 	assert.True(t, payload.Valid)
 	assert.Equal(t, "hash-abc", payload.DefaultAccount)
 	assert.Equal(t, "https://example.com/authorize", payload.AuthorizationURL)
+	assert.True(t, payload.AutoSetDefault)
+}
+
+func TestAuthLoginCommand_DefaultAccountLookupUsesConfiguredProxy(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+	tokenPath := filepath.Join(tmpDir, "token.json")
+
+	proxy := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/proxy/trader/v1/accounts/accountNumbers":
+			assert.Equal(t, "Bearer access-token", r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"accountNumber":"123456789","hashValue":"hash-proxy"}]`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer proxy.Close()
+
+	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURL:         proxy.URL + "/proxy/",
+		BaseURLInsecure: true,
+	}))
+
+	deps := defaultAuthDeps()
+	deps.configPath = func() string { return configPath }
+	deps.runLogin = func(_ *auth.Config, targetTokenPath string, _ string, openBrowser bool, w io.Writer) error {
+		assert.False(t, openBrowser)
+		_, err := fmt.Fprintln(w, "https://proxy.example.com/proxy/v1/oauth/authorize")
+		require.NoError(t, err)
+
+		return auth.SaveToken(targetTokenPath, &auth.TokenFile{
+			CreationTimestamp: time.Now().UTC().Add(-1 * time.Hour).Unix(),
+			Token: auth.TokenData{
+				AccessToken:  "access-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    1800,
+				RefreshToken: "refresh-token",
+				Scope:        "api",
+				ExpiresAt:    float64(time.Now().UTC().Add(30 * time.Minute).Unix()),
+			},
+		})
+	}
+
+	var stdout bytes.Buffer
+	cmd := newAuthCommand(&auth.Config{
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURL:         proxy.URL + "/proxy/",
+		BaseURLInsecure: true,
+	}, tokenPath, &stdout, deps)
+
+	err := cmd.Run(context.Background(), []string{"auth", "login", "--no-browser"})
+	require.NoError(t, err)
+
+	savedConfig, err := auth.LoadConfig(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "hash-proxy", savedConfig.DefaultAccount)
+
+	envelope := decodeAuthEnvelope(t, stdout.Bytes())
+	var payload testLoginPayload
+	require.NoError(t, json.Unmarshal(envelope.Data, &payload))
+	assert.Equal(t, "hash-proxy", payload.DefaultAccount)
+	assert.Equal(t, "https://proxy.example.com/proxy/v1/oauth/authorize", payload.AuthorizationURL)
 	assert.True(t, payload.AutoSetDefault)
 }
 
@@ -338,7 +436,7 @@ func TestConfigDefaultAccount(t *testing.T) {
 func TestRequireAuthConfig_UsesProvidedConfig(t *testing.T) {
 	// When config already has client credentials, it returns the same config.
 	cfg := &auth.Config{ClientID: "id", ClientSecret: "secret"}
-	got, err := requireAuthConfig(cfg, func() string { return "/nonexistent" })
+	got, err := requireAuthConfig(cfg, "/nonexistent")
 	require.NoError(t, err)
 	assert.Equal(t, cfg, got)
 }
@@ -357,7 +455,7 @@ func TestRequireAuthConfig_LoadsFromDisk(t *testing.T) {
 		ClientSecret: "disk-secret",
 	}))
 
-	got, err := requireAuthConfig(&auth.Config{}, func() string { return configPath })
+	got, err := requireAuthConfig(&auth.Config{}, configPath)
 	require.NoError(t, err)
 	assert.Equal(t, "disk-id", got.ClientID)
 }
@@ -368,13 +466,13 @@ func TestRequireAuthConfig_ErrorOnMissingFile(t *testing.T) {
 	t.Setenv("SCHWAB_CLIENT_SECRET", "")
 	t.Setenv("SCHWAB_CALLBACK_URL", "")
 
-	_, err := requireAuthConfig(&auth.Config{}, func() string { return "/nonexistent/config.json" })
+	_, err := requireAuthConfig(&auth.Config{}, "/nonexistent/config.json")
 	assert.Error(t, err)
 }
 
 func TestOptionalAuthConfig_UsesProvided(t *testing.T) {
 	cfg := &auth.Config{ClientID: "provided"}
-	got := optionalAuthConfig(cfg, func() string { return "/nonexistent" })
+	got := optionalAuthConfig(cfg, "/nonexistent")
 	assert.Equal(t, cfg, got)
 }
 
@@ -392,7 +490,7 @@ func TestOptionalAuthConfig_NilFallsBackToFile(t *testing.T) {
 		ClientSecret: "secret",
 	}))
 
-	got := optionalAuthConfig(nil, func() string { return configPath })
+	got := optionalAuthConfig(nil, configPath)
 	assert.Equal(t, "from-disk", got.ClientID)
 }
 
@@ -402,7 +500,7 @@ func TestOptionalAuthConfig_NilWithMissingFileReturnsEmpty(t *testing.T) {
 	t.Setenv("SCHWAB_CLIENT_SECRET", "")
 	t.Setenv("SCHWAB_CALLBACK_URL", "")
 
-	got := optionalAuthConfig(nil, func() string { return "/nonexistent/config.json" })
+	got := optionalAuthConfig(nil, "/nonexistent/config.json")
 	assert.NotNil(t, got)
 	assert.Empty(t, got.ClientID)
 }
@@ -497,5 +595,3 @@ func TestAccountSetDefaultCommand_MissingHash(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "account hash is required")
 }
-
-

--- a/skills/schwab-config-auth.md
+++ b/skills/schwab-config-auth.md
@@ -34,9 +34,13 @@ Config file location: `~/.config/schwab-agent/config.json`
 |-------|-------------|
 | `client_id` | Schwab app client ID |
 | `client_secret` | Schwab app client secret |
+| `base_url` | Outbound base URL for REST API calls and OAuth authorize/token requests (default: `https://api.schwabapi.com`) |
+| `base_url_insecure` | Set to `true` to skip TLS verification for outbound proxy calls that use a local self-signed certificate |
 | `callback_url` | OAuth2 callback URL (default: https://127.0.0.1:8182) |
 | `default_account` | Default account hash for commands that need an account |
 | `i-also-like-to-live-dangerously` | Set to true to enable mutable operations (order placement, cancel, replace) |
+
+`base_url` is the single source of truth for outbound Schwab traffic. `schwab-agent` derives the OAuth authorize URL (`<base_url>/v1/oauth/authorize`) and token/refresh URL (`<base_url>/v1/oauth/token`) from it, and also uses the same base URL for authenticated REST API requests.
 
 Default callback URL: `https://127.0.0.1:8182`
 
@@ -54,6 +58,8 @@ Environment variables take priority over config file values.
 |----------|-------------|
 | `SCHWAB_CLIENT_ID` | Override client ID from config file |
 | `SCHWAB_CLIENT_SECRET` | Override client secret from config file |
+| `SCHWAB_BASE_URL` | Override outbound REST/OAuth base URL |
+| `SCHWAB_BASE_URL_INSECURE` | Override insecure TLS mode for local self-signed proxies (`true`/`false`) |
 | `SCHWAB_CALLBACK_URL` | Override callback URL (default: https://127.0.0.1:8182) |
 
 ## Troubleshooting
@@ -63,4 +69,5 @@ Environment variables take priority over config file values.
 | "auth required" error | Run `schwab-agent auth login` to get new tokens |
 | "auth expired" error | Refresh token is stale (>6.5 days old), run `schwab-agent auth login` again |
 | "callback error" | Check callback URL matches Schwab app settings (default: https://127.0.0.1:8182) |
+| TLS/certificate error with a local proxy | Set `base_url` to the proxy URL and `base_url_insecure` / `SCHWAB_BASE_URL_INSECURE` to `true` if the proxy uses a self-signed certificate |
 | Missing credentials | Set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add them to config.json |


### PR DESCRIPTION
Route Schwab-facing OAuth and API requests through a configured base URL so schwab-agent can talk to Schwab-compatible proxies without patching endpoint constants.

Add base_url and base_url_insecure config handling, derive the authorize and token endpoints from that base, use a config-owned HTTP client for auth and API flows, honor runtime `--config` and `--token` overrides for auth subcommands, and document the new settings.