### PR TITLE
fix: address CodeRabbit nitpicks from PR #16

### DIFF
--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -12,7 +12,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/urfave/cli/v3"
@@ -121,8 +120,10 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 
 			cfg, err := auth.LoadConfig(resolvedConfigPath)
 			if err != nil {
-				var validationErr *apperr.ValidationError
-				if errors.As(err, &validationErr) && !strings.Contains(validationErr.Message, "Missing required credentials") {
+				// Non-credential validation errors (e.g. invalid base_url) are
+				// returned directly. Missing credentials get wrapped as
+				// AuthRequiredError so the CLI reports exit code 3.
+				if !errors.Is(err, auth.ErrMissingCredentials) {
 					return ctx, err
 				}
 

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -31,17 +31,23 @@ func TestMain(m *testing.M) {
 		"SCHWAB_BASE_URL_INSECURE",
 	}
 
-	original := make(map[string]string, len(envVars))
+	type envState struct {
+		value string
+		set   bool
+	}
+
+	original := make(map[string]envState, len(envVars))
 	for _, key := range envVars {
-		original[key] = os.Getenv(key)
+		value, ok := os.LookupEnv(key)
+		original[key] = envState{value: value, set: ok}
 		_ = os.Unsetenv(key)
 	}
 
 	exitCode := m.Run()
 
 	for _, key := range envVars {
-		if value, ok := original[key]; ok && value != "" {
-			_ = os.Setenv(key, value)
+		if state := original[key]; state.set {
+			_ = os.Setenv(key, state.value)
 		} else {
 			_ = os.Unsetenv(key)
 		}
@@ -170,12 +176,6 @@ func TestBeforeHook_ReturnsValidationErrorForInvalidBaseURLConfig(t *testing.T) 
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	configPath := filepath.Join(tmpDir, "invalid-config.json")
-	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-		CallbackURL:  "https://127.0.0.1:8182",
-		BaseURL:      "https://api.schwabapi.com",
-	}))
 	require.NoError(t, os.WriteFile(configPath, []byte(`{"client_id":"test-client","client_secret":"test-secret","base_url":"://bad"}`), 0o600))
 
 	_, err := runApp(t, "schwab-agent", "--config", configPath, "account")
@@ -297,13 +297,6 @@ func TestBeforeHook_UsesConfiguredProxyForRefreshAndAPIRequests(t *testing.T) {
 
 	configPath := filepath.Join(tmpDir, "schwab-agent", "config.json")
 	tokenPath := filepath.Join(tmpDir, "schwab-agent", "token.json")
-	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
-		ClientID:        "test-client",
-		ClientSecret:    "test-secret",
-		CallbackURL:     "https://127.0.0.1:8182",
-		BaseURL:         "https://placeholder.invalid",
-		BaseURLInsecure: true,
-	}))
 	writeTestToken(t, tokenPath, &auth.TokenFile{
 		CreationTimestamp: time.Now().Add(-time.Hour).Unix(),
 		Token: auth.TokenData{

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -18,6 +18,13 @@ import (
 	"github.com/major/schwab-agent/internal/apperr"
 )
 
+// ErrMissingCredentials is a sentinel error wrapped by the ValidationError
+// returned from LoadConfig when client_id or client_secret are absent. Callers
+// can use errors.Is(err, ErrMissingCredentials) to distinguish missing
+// credentials from other validation failures (e.g., invalid base_url) without
+// matching on error message text.
+var ErrMissingCredentials = errors.New("missing required credentials")
+
 const (
 	defaultBaseURL = "https://api.schwabapi.com"
 )
@@ -197,7 +204,7 @@ func LoadConfig(configPath string) (*Config, error) {
 	if cfg.ClientID == "" || cfg.ClientSecret == "" {
 		return nil, apperr.NewValidationError(
 			"Missing required credentials: set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add client_id and client_secret to the config file",
-			nil,
+			ErrMissingCredentials,
 		)
 	}
 

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -23,17 +23,23 @@ func TestMain(m *testing.M) {
 		"SCHWAB_BASE_URL_INSECURE",
 	}
 
-	original := make(map[string]string, len(envVars))
+	type envState struct {
+		value string
+		set   bool
+	}
+
+	original := make(map[string]envState, len(envVars))
 	for _, key := range envVars {
-		original[key] = os.Getenv(key)
+		value, ok := os.LookupEnv(key)
+		original[key] = envState{value: value, set: ok}
 		_ = os.Unsetenv(key)
 	}
 
 	exitCode := m.Run()
 
 	for _, key := range envVars {
-		if value, ok := original[key]; ok && value != "" {
-			_ = os.Setenv(key, value)
+		if state := original[key]; state.set {
+			_ = os.Setenv(key, state.value)
 		} else {
 			_ = os.Unsetenv(key)
 		}


### PR DESCRIPTION
## Summary

Fixes 4 CodeRabbit nitpicks left on #16 that weren't addressed before merge.

- **Sentinel error**: Added `ErrMissingCredentials` and replaced `strings.Contains()` message-matching with `errors.Is()` for classifying validation errors in the before hook
- **Dead writes**: Removed two `SaveConfig` calls in tests that were immediately overwritten (one by `os.WriteFile`, one after TLS proxy creation)
- **`os.LookupEnv`**: Both `TestMain` functions now use `os.LookupEnv` to correctly distinguish unset env vars from set-to-empty, with a local `envState` struct for save/restore