### PR TITLE
chore: add CODEOWNERS for global code review coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners - all PRs require review from at least one.
+* @major @jkoelker


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with `@major` and `@jkoelker` as global owners
- All PRs will auto-request review from both