### PR TITLE
feat: add trailing stop orders and special instructions

### DIFF
--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -402,6 +402,7 @@ func equityOrderFlags() []cli.Flag {
 		&cli.Float64Flag{Name: "activation-price", Usage: "Price that activates the trailing stop"},
 		&cli.StringFlag{Name: "duration", Usage: "Order duration"},
 		&cli.StringFlag{Name: "session", Usage: "Trading session"},
+		&cli.StringFlag{Name: "special-instruction", Usage: "Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE)"},
 	}
 }
 
@@ -419,6 +420,7 @@ func optionOrderFlags() []cli.Flag {
 		&cli.Float64Flag{Name: "price", Usage: "Limit price"},
 		&cli.StringFlag{Name: "duration", Usage: "Order duration"},
 		&cli.StringFlag{Name: "session", Usage: "Trading session"},
+		&cli.StringFlag{Name: "special-instruction", Usage: "Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE)"},
 	}
 }
 
@@ -573,6 +575,11 @@ func parseEquityParams(cmd *cli.Command) (orderbuilder.EquityParams, error) {
 		return orderbuilder.EquityParams{}, err
 	}
 
+	specialInstruction, err := parseSpecialInstruction(cmd.String("special-instruction"))
+	if err != nil {
+		return orderbuilder.EquityParams{}, err
+	}
+
 	return orderbuilder.EquityParams{
 		Symbol:             strings.TrimSpace(cmd.String("symbol")),
 		Action:             action,
@@ -585,6 +592,7 @@ func parseEquityParams(cmd *cli.Command) (orderbuilder.EquityParams, error) {
 		StopPriceLinkType:  stopLinkType,
 		StopType:           stopType,
 		ActivationPrice:    cmd.Float64("activation-price"),
+		SpecialInstruction: specialInstruction,
 		Duration:           duration,
 		Session:            session,
 	}, nil
@@ -617,6 +625,11 @@ func parseOptionParams(cmd *cli.Command) (orderbuilder.OptionParams, error) {
 		return orderbuilder.OptionParams{}, err
 	}
 
+	specialInstruction, err := parseSpecialInstruction(cmd.String("special-instruction"))
+	if err != nil {
+		return orderbuilder.OptionParams{}, err
+	}
+
 	return orderbuilder.OptionParams{
 		Underlying: strings.TrimSpace(cmd.String("underlying")),
 		Expiration: expiration,
@@ -625,9 +638,10 @@ func parseOptionParams(cmd *cli.Command) (orderbuilder.OptionParams, error) {
 		Action:     action,
 		Quantity:   cmd.Float64("quantity"),
 		OrderType:  orderType,
-		Price:      cmd.Float64("price"),
-		Duration:   duration,
-		Session:    session,
+		Price:              cmd.Float64("price"),
+		SpecialInstruction: specialInstruction,
+		Duration:           duration,
+		Session:            session,
 	}, nil
 }
 
@@ -1146,6 +1160,24 @@ func parseStopType(raw string) (models.StopType, error) {
 		return value, nil
 	default:
 		return "", newValidationError("stop-type is invalid")
+	}
+}
+
+// parseSpecialInstruction converts a CLI flag value into a SpecialInstruction constant.
+// Returns an empty value when the flag is not set.
+func parseSpecialInstruction(raw string) (models.SpecialInstruction, error) {
+	if raw == "" {
+		return "", nil
+	}
+
+	value := models.SpecialInstruction(strings.ToUpper(raw))
+	switch value {
+	case models.SpecialInstructionAllOrNone,
+		models.SpecialInstructionDoNotReduce,
+		models.SpecialInstructionAllOrNoneDoNotReduce:
+		return value, nil
+	default:
+		return "", newValidationError("special-instruction is invalid")
 	}
 }
 

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -395,6 +395,11 @@ func equityOrderFlags() []cli.Flag {
 		&cli.StringFlag{Name: "type", Usage: "Order type"},
 		&cli.Float64Flag{Name: "price", Usage: "Limit price"},
 		&cli.Float64Flag{Name: "stop-price", Usage: "Stop price"},
+		&cli.Float64Flag{Name: "stop-offset", Usage: "Trailing stop offset amount"},
+		&cli.StringFlag{Name: "stop-link-basis", Usage: "Trailing stop reference price (LAST, BID, ASK, MARK)"},
+		&cli.StringFlag{Name: "stop-link-type", Usage: "Trailing stop offset type (VALUE, PERCENT, TICK)"},
+		&cli.StringFlag{Name: "stop-type", Usage: "Trailing stop trigger type (STANDARD, BID, ASK, LAST, MARK)"},
+		&cli.Float64Flag{Name: "activation-price", Usage: "Price that activates the trailing stop"},
 		&cli.StringFlag{Name: "duration", Usage: "Order duration"},
 		&cli.StringFlag{Name: "session", Usage: "Trading session"},
 	}
@@ -553,15 +558,35 @@ func parseEquityParams(cmd *cli.Command) (orderbuilder.EquityParams, error) {
 		return orderbuilder.EquityParams{}, err
 	}
 
+	stopLinkBasis, err := parseStopPriceLinkBasis(cmd.String("stop-link-basis"))
+	if err != nil {
+		return orderbuilder.EquityParams{}, err
+	}
+
+	stopLinkType, err := parseStopPriceLinkType(cmd.String("stop-link-type"))
+	if err != nil {
+		return orderbuilder.EquityParams{}, err
+	}
+
+	stopType, err := parseStopType(cmd.String("stop-type"))
+	if err != nil {
+		return orderbuilder.EquityParams{}, err
+	}
+
 	return orderbuilder.EquityParams{
-		Symbol:    strings.TrimSpace(cmd.String("symbol")),
-		Action:    action,
-		Quantity:  cmd.Float64("quantity"),
-		OrderType: orderType,
-		Price:     cmd.Float64("price"),
-		StopPrice: cmd.Float64("stop-price"),
-		Duration:  duration,
-		Session:   session,
+		Symbol:             strings.TrimSpace(cmd.String("symbol")),
+		Action:             action,
+		Quantity:           cmd.Float64("quantity"),
+		OrderType:          orderType,
+		Price:              cmd.Float64("price"),
+		StopPrice:          cmd.Float64("stop-price"),
+		StopPriceOffset:    cmd.Float64("stop-offset"),
+		StopPriceLinkBasis: stopLinkBasis,
+		StopPriceLinkType:  stopLinkType,
+		StopType:           stopType,
+		ActivationPrice:    cmd.Float64("activation-price"),
+		Duration:           duration,
+		Session:            session,
 	}, nil
 }
 
@@ -780,6 +805,8 @@ func parseOrderType(raw string, fallback models.OrderType) (models.OrderType, er
 		models.OrderTypeLimit,
 		models.OrderTypeStop,
 		models.OrderTypeStopLimit,
+		models.OrderTypeTrailingStop,
+		models.OrderTypeTrailingStopLimit,
 		models.OrderTypeNetDebit,
 		models.OrderTypeNetCredit,
 		models.OrderTypeNetZero:
@@ -1058,6 +1085,68 @@ func parsePutCall(call, put bool) (models.PutCall, error) {
 	}
 
 	return models.PutCallPut, nil
+}
+
+// parseStopPriceLinkBasis converts CLI input to a stop price link basis enum.
+// Defaults to LAST when empty, which is the most common trailing stop reference.
+func parseStopPriceLinkBasis(raw string) (models.StopPriceLinkBasis, error) {
+	if strings.TrimSpace(raw) == "" {
+		return models.StopPriceLinkBasisLast, nil
+	}
+
+	value := models.StopPriceLinkBasis(strings.ToUpper(strings.TrimSpace(raw)))
+	switch value {
+	case models.StopPriceLinkBasisManual,
+		models.StopPriceLinkBasisBase,
+		models.StopPriceLinkBasisTrigger,
+		models.StopPriceLinkBasisLast,
+		models.StopPriceLinkBasisBid,
+		models.StopPriceLinkBasisAsk,
+		models.StopPriceLinkBasisAskBid,
+		models.StopPriceLinkBasisMark,
+		models.StopPriceLinkBasisAverage:
+		return value, nil
+	default:
+		return "", newValidationError("stop-link-basis is invalid")
+	}
+}
+
+// parseStopPriceLinkType converts CLI input to a stop price link type enum.
+// Defaults to VALUE when empty, which means the offset is a dollar amount.
+func parseStopPriceLinkType(raw string) (models.StopPriceLinkType, error) {
+	if strings.TrimSpace(raw) == "" {
+		return models.StopPriceLinkTypeValue, nil
+	}
+
+	value := models.StopPriceLinkType(strings.ToUpper(strings.TrimSpace(raw)))
+	switch value {
+	case models.StopPriceLinkTypeValue,
+		models.StopPriceLinkTypePercent,
+		models.StopPriceLinkTypeTick:
+		return value, nil
+	default:
+		return "", newValidationError("stop-link-type is invalid")
+	}
+}
+
+// parseStopType converts CLI input to a stop type enum.
+// Defaults to STANDARD when empty.
+func parseStopType(raw string) (models.StopType, error) {
+	if strings.TrimSpace(raw) == "" {
+		return models.StopTypeStandard, nil
+	}
+
+	value := models.StopType(strings.ToUpper(strings.TrimSpace(raw)))
+	switch value {
+	case models.StopTypeStandard,
+		models.StopTypeBid,
+		models.StopTypeAsk,
+		models.StopTypeLast,
+		models.StopTypeMark:
+		return value, nil
+	default:
+		return "", newValidationError("stop-type is invalid")
+	}
 }
 
 // newValidationError creates a consistent validation error for command parsing.

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -1095,6 +1095,39 @@ func TestOrderBuildParseErrors(t *testing.T) {
 			},
 			wantMsg: "session is invalid",
 		},
+		// parseStopPriceLinkBasis invalid value.
+		{
+			name: "equity invalid stop-link-basis",
+			args: []string{
+				"order", "build", "equity",
+				"--symbol", "AAPL", "--action", "SELL",
+				"--quantity", "10", "--type", "TRAILING_STOP",
+				"--stop-offset", "2.50", "--stop-link-basis", "NOPE",
+			},
+			wantMsg: "stop-link-basis is invalid",
+		},
+		// parseStopPriceLinkType invalid value.
+		{
+			name: "equity invalid stop-link-type",
+			args: []string{
+				"order", "build", "equity",
+				"--symbol", "AAPL", "--action", "SELL",
+				"--quantity", "10", "--type", "TRAILING_STOP",
+				"--stop-offset", "2.50", "--stop-link-type", "NOPE",
+			},
+			wantMsg: "stop-link-type is invalid",
+		},
+		// parseStopType invalid value.
+		{
+			name: "equity invalid stop-type",
+			args: []string{
+				"order", "build", "equity",
+				"--symbol", "AAPL", "--action", "SELL",
+				"--quantity", "10", "--type", "TRAILING_STOP",
+				"--stop-offset", "2.50", "--stop-type", "NOPE",
+			},
+			wantMsg: "stop-type is invalid",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -1128,6 +1128,27 @@ func TestOrderBuildParseErrors(t *testing.T) {
 			},
 			wantMsg: "stop-type is invalid",
 		},
+		// parseSpecialInstruction invalid value.
+		{
+			name: "equity invalid special-instruction",
+			args: []string{
+				"order", "build", "equity",
+				"--symbol", "AAPL", "--action", "BUY",
+				"--quantity", "10", "--special-instruction", "NOPE",
+			},
+			wantMsg: "special-instruction is invalid",
+		},
+		{
+			name: "option invalid special-instruction",
+			args: []string{
+				"order", "build", "option",
+				"--underlying", "AAPL", "--action", "BUY_TO_OPEN",
+				"--call", "--expiration", "2026-06-19",
+				"--strike", "150", "--quantity", "1",
+				"--special-instruction", "NOPE",
+			},
+			wantMsg: "special-instruction is invalid",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/models/order.go
+++ b/internal/models/order.go
@@ -417,6 +417,7 @@ type Order struct {
 	StopType                  *StopType                `json:"stopType,omitempty"`
 	PriceLinkBasis            *PriceLinkBasis          `json:"priceLinkBasis,omitempty"`
 	PriceLinkType             *PriceLinkType           `json:"priceLinkType,omitempty"`
+	PriceOffset               *float64                 `json:"priceOffset,omitempty"`
 	Price                     *float64                 `json:"price,omitempty"`
 	TaxLotMethod              *TaxLotMethod            `json:"taxLotMethod,omitempty"`
 	OrderLegCollection        []OrderLegCollection     `json:"orderLegCollection"`
@@ -455,6 +456,7 @@ type OrderRequest struct {
 	StopType                 *StopType                `json:"stopType,omitempty"`
 	PriceLinkBasis           *PriceLinkBasis          `json:"priceLinkBasis,omitempty"`
 	PriceLinkType            *PriceLinkType           `json:"priceLinkType,omitempty"`
+	PriceOffset              *float64                 `json:"priceOffset,omitempty"`
 	Price                    *float64                 `json:"price,omitempty"`
 	TaxLotMethod             *TaxLotMethod            `json:"taxLotMethod,omitempty"`
 	OrderLegCollection       []OrderLegCollection     `json:"orderLegCollection,omitempty"`

--- a/internal/orderbuilder/equity.go
+++ b/internal/orderbuilder/equity.go
@@ -16,6 +16,14 @@ type EquityParams struct {
 	StopPrice float64
 	Duration  models.Duration
 	Session   models.Session
+
+	// Trailing stop fields. The stop adjusts dynamically via offset
+	// rather than using a fixed StopPrice.
+	StopPriceOffset   float64
+	StopPriceLinkBasis models.StopPriceLinkBasis
+	StopPriceLinkType  models.StopPriceLinkType
+	StopType           models.StopType
+	ActivationPrice    float64
 }
 
 // BuildEquityOrder constructs an OrderRequest for an equity order.
@@ -52,6 +60,30 @@ func applyEquityPriceFields(order *models.OrderRequest, params *EquityParams) {
 	case models.OrderTypeStopLimit:
 		order.Price = ptr(params.Price)
 		order.StopPrice = ptr(params.StopPrice)
+	case models.OrderTypeTrailingStop:
+		applyTrailingStopFields(order, params)
+	case models.OrderTypeTrailingStopLimit:
+		applyTrailingStopFields(order, params)
+
+		// Schwab API uses priceOffset (not price) for trailing stop limit orders.
+		// The offset defines the limit price distance from the triggered stop.
+		// priceLinkBasis/priceLinkType default to the stop price link values.
+		order.PriceOffset = ptr(params.Price)
+		order.PriceLinkBasis = ptr(models.PriceLinkBasis(params.StopPriceLinkBasis))
+		order.PriceLinkType = ptr(models.PriceLinkType(params.StopPriceLinkType))
+	}
+}
+
+// applyTrailingStopFields sets the trailing stop-specific fields shared by
+// TRAILING_STOP and TRAILING_STOP_LIMIT order types.
+func applyTrailingStopFields(order *models.OrderRequest, params *EquityParams) {
+	order.StopPriceOffset = ptr(params.StopPriceOffset)
+	order.StopPriceLinkBasis = ptr(params.StopPriceLinkBasis)
+	order.StopPriceLinkType = ptr(params.StopPriceLinkType)
+	order.StopType = ptr(params.StopType)
+
+	if params.ActivationPrice > 0 {
+		order.ActivationPrice = ptr(params.ActivationPrice)
 	}
 }
 

--- a/internal/orderbuilder/equity.go
+++ b/internal/orderbuilder/equity.go
@@ -17,6 +17,8 @@ type EquityParams struct {
 	Duration  models.Duration
 	Session   models.Session
 
+	SpecialInstruction models.SpecialInstruction
+
 	// Trailing stop fields. The stop adjusts dynamically via offset
 	// rather than using a fixed StopPrice.
 	StopPriceOffset   float64
@@ -46,6 +48,10 @@ func BuildEquityOrder(params *EquityParams) (*models.OrderRequest, error) {
 	}
 
 	applyEquityPriceFields(order, params)
+
+	if params.SpecialInstruction != "" {
+		order.SpecialInstruction = ptr(params.SpecialInstruction)
+	}
 
 	return order, nil
 }

--- a/internal/orderbuilder/equity_test.go
+++ b/internal/orderbuilder/equity_test.go
@@ -189,3 +189,36 @@ func TestBuildEquityOrderSetsTrailingStopLimitFields(t *testing.T) {
 	require.NotNil(t, order.PriceLinkType)
 	assert.Equal(t, models.PriceLinkType(models.StopPriceLinkTypeTick), *order.PriceLinkType)
 }
+
+// TestBuildEquityOrderSetsSpecialInstruction verifies the special instruction
+// field is set on the order when provided.
+func TestBuildEquityOrderSetsSpecialInstruction(t *testing.T) {
+	order, err := BuildEquityOrder(&EquityParams{
+		Symbol:             "AAPL",
+		Action:             models.InstructionBuy,
+		Quantity:           100,
+		OrderType:          models.OrderTypeLimit,
+		Price:              200.00,
+		SpecialInstruction: models.SpecialInstructionAllOrNone,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	require.NotNil(t, order.SpecialInstruction)
+	assert.Equal(t, models.SpecialInstructionAllOrNone, *order.SpecialInstruction)
+}
+
+// TestBuildEquityOrderOmitsSpecialInstructionWhenEmpty verifies the field is
+// nil when no special instruction is provided.
+func TestBuildEquityOrderOmitsSpecialInstructionWhenEmpty(t *testing.T) {
+	order, err := BuildEquityOrder(&EquityParams{
+		Symbol:    "AAPL",
+		Action:    models.InstructionBuy,
+		Quantity:  100,
+		OrderType: models.OrderTypeMarket,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	assert.Nil(t, order.SpecialInstruction)
+}

--- a/internal/orderbuilder/equity_test.go
+++ b/internal/orderbuilder/equity_test.go
@@ -89,3 +89,103 @@ func TestBuildEquityOrderSetsLimitAndStopPrice(t *testing.T) {
 	require.NotNil(t, order.StopPrice)
 	assert.Equal(t, 199.25, *order.StopPrice)
 }
+
+// TestBuildEquityOrderSetsTrailingStopFields verifies trailing stop orders set
+// offset/link/stop-type fields and do not set price or stop price.
+func TestBuildEquityOrderSetsTrailingStopFields(t *testing.T) {
+	order, err := BuildEquityOrder(&EquityParams{
+		Symbol:             "AAPL",
+		Action:             models.InstructionSell,
+		Quantity:           50,
+		OrderType:          models.OrderTypeTrailingStop,
+		StopPriceOffset:    2.50,
+		StopPriceLinkBasis: models.StopPriceLinkBasisLast,
+		StopPriceLinkType:  models.StopPriceLinkTypeValue,
+		StopType:           models.StopTypeStandard,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	assert.Equal(t, models.OrderTypeTrailingStop, order.OrderType)
+
+	// Trailing stop fields must be set.
+	require.NotNil(t, order.StopPriceOffset)
+	assert.Equal(t, 2.50, *order.StopPriceOffset)
+	require.NotNil(t, order.StopPriceLinkBasis)
+	assert.Equal(t, models.StopPriceLinkBasisLast, *order.StopPriceLinkBasis)
+	require.NotNil(t, order.StopPriceLinkType)
+	assert.Equal(t, models.StopPriceLinkTypeValue, *order.StopPriceLinkType)
+	require.NotNil(t, order.StopType)
+	assert.Equal(t, models.StopTypeStandard, *order.StopType)
+
+	// Price and stop price must NOT be set for trailing stop.
+	assert.Nil(t, order.Price)
+	assert.Nil(t, order.StopPrice)
+
+	// Activation price was not provided, so it must be nil.
+	assert.Nil(t, order.ActivationPrice)
+}
+
+// TestBuildEquityOrderSetsTrailingStopWithActivationPrice verifies the optional
+// activation price is set when provided.
+func TestBuildEquityOrderSetsTrailingStopWithActivationPrice(t *testing.T) {
+	order, err := BuildEquityOrder(&EquityParams{
+		Symbol:             "TSLA",
+		Action:             models.InstructionSell,
+		Quantity:           25,
+		OrderType:          models.OrderTypeTrailingStop,
+		StopPriceOffset:    5.00,
+		StopPriceLinkBasis: models.StopPriceLinkBasisBid,
+		StopPriceLinkType:  models.StopPriceLinkTypePercent,
+		StopType:           models.StopTypeBid,
+		ActivationPrice:    150.00,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	require.NotNil(t, order.ActivationPrice)
+	assert.Equal(t, 150.00, *order.ActivationPrice)
+}
+
+// TestBuildEquityOrderSetsTrailingStopLimitFields verifies trailing stop limit
+// orders set both trailing stop fields and the limit price.
+func TestBuildEquityOrderSetsTrailingStopLimitFields(t *testing.T) {
+	order, err := BuildEquityOrder(&EquityParams{
+		Symbol:             "AAPL",
+		Action:             models.InstructionSell,
+		Quantity:           10,
+		OrderType:          models.OrderTypeTrailingStopLimit,
+		Price:              195.00,
+		StopPriceOffset:    3.00,
+		StopPriceLinkBasis: models.StopPriceLinkBasisMark,
+		StopPriceLinkType:  models.StopPriceLinkTypeTick,
+		StopType:           models.StopTypeStandard,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	assert.Equal(t, models.OrderTypeTrailingStopLimit, order.OrderType)
+
+	// Price offset must be set for trailing stop limit (Schwab uses priceOffset,
+	// not price, for the limit component of trailing stop limit orders).
+	require.NotNil(t, order.PriceOffset)
+	assert.Equal(t, 195.00, *order.PriceOffset)
+	assert.Nil(t, order.Price)
+
+	// Trailing stop fields must be set.
+	require.NotNil(t, order.StopPriceOffset)
+	assert.Equal(t, 3.00, *order.StopPriceOffset)
+	require.NotNil(t, order.StopPriceLinkBasis)
+	assert.Equal(t, models.StopPriceLinkBasisMark, *order.StopPriceLinkBasis)
+	require.NotNil(t, order.StopPriceLinkType)
+	assert.Equal(t, models.StopPriceLinkTypeTick, *order.StopPriceLinkType)
+
+	// Stop price must NOT be set (trailing stops use offset, not fixed price).
+	assert.Nil(t, order.StopPrice)
+
+	// Price link fields must mirror stop price link fields for trailing stop limit.
+	require.NotNil(t, order.PriceLinkBasis)
+	assert.Equal(t, models.PriceLinkBasis(models.StopPriceLinkBasisMark), *order.PriceLinkBasis)
+	require.NotNil(t, order.PriceLinkType)
+	assert.Equal(t, models.PriceLinkType(models.StopPriceLinkTypeTick), *order.PriceLinkType)
+}

--- a/internal/orderbuilder/option.go
+++ b/internal/orderbuilder/option.go
@@ -23,8 +23,9 @@ type OptionParams struct {
 	Quantity   float64
 	OrderType  models.OrderType
 	Price      float64
-	Duration   models.Duration
-	Session    models.Session
+	Duration           models.Duration
+	Session            models.Session
+	SpecialInstruction models.SpecialInstruction
 }
 
 // BuildOptionOrder constructs an OrderRequest for an option order.
@@ -59,6 +60,10 @@ func BuildOptionOrder(params *OptionParams) (*models.OrderRequest, error) {
 
 	if params.OrderType == models.OrderTypeLimit {
 		order.Price = ptr(params.Price)
+	}
+
+	if params.SpecialInstruction != "" {
+		order.SpecialInstruction = ptr(params.SpecialInstruction)
 	}
 
 	return order, nil

--- a/internal/orderbuilder/option_test.go
+++ b/internal/orderbuilder/option_test.go
@@ -308,3 +308,42 @@ func TestBuildOptionOrderSetsLimitPrice(t *testing.T) {
 	assert.Equal(t, models.SessionPM, order.Session)
 	assert.Equal(t, "SPY   251219P00450500", order.OrderLegCollection[0].Instrument.Symbol)
 }
+
+// TestBuildOptionOrderSetsSpecialInstruction verifies the special instruction
+// field is set on the order when provided.
+func TestBuildOptionOrderSetsSpecialInstruction(t *testing.T) {
+	order, err := BuildOptionOrder(&OptionParams{
+		Underlying:         "AAPL",
+		Expiration:         time.Date(2025, time.December, 19, 0, 0, 0, 0, time.UTC),
+		Strike:             200.0,
+		PutCall:            models.PutCallCall,
+		Action:             models.InstructionBuyToOpen,
+		Quantity:           5,
+		OrderType:          models.OrderTypeLimit,
+		Price:              4.50,
+		SpecialInstruction: models.SpecialInstructionDoNotReduce,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	require.NotNil(t, order.SpecialInstruction)
+	assert.Equal(t, models.SpecialInstructionDoNotReduce, *order.SpecialInstruction)
+}
+
+// TestBuildOptionOrderOmitsSpecialInstructionWhenEmpty verifies the field is
+// nil when no special instruction is provided.
+func TestBuildOptionOrderOmitsSpecialInstructionWhenEmpty(t *testing.T) {
+	order, err := BuildOptionOrder(&OptionParams{
+		Underlying: "AAPL",
+		Expiration: time.Date(2025, time.December, 19, 0, 0, 0, 0, time.UTC),
+		Strike:     200.0,
+		PutCall:    models.PutCallCall,
+		Action:     models.InstructionBuyToOpen,
+		Quantity:   5,
+		OrderType:  models.OrderTypeMarket,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, order)
+	assert.Nil(t, order.SpecialInstruction)
+}

--- a/internal/orderbuilder/validate.go
+++ b/internal/orderbuilder/validate.go
@@ -32,6 +32,18 @@ func ValidateEquityOrder(params *EquityParams) error {
 		if params.Price == 0 || params.StopPrice == 0 {
 			return validationError("STOP_LIMIT order requires both price and stop price", "Add `--price <amount> --stop-price <amount>`")
 		}
+	case models.OrderTypeTrailingStop:
+		if params.StopPriceOffset <= 0 {
+			return validationError("TRAILING_STOP order requires a stop price offset", "Add `--stop-offset <amount>` to specify how far the stop trails")
+		}
+	case models.OrderTypeTrailingStopLimit:
+		if params.StopPriceOffset <= 0 {
+			return validationError("TRAILING_STOP_LIMIT order requires a stop price offset", "Add `--stop-offset <amount>` to specify how far the stop trails")
+		}
+
+		if params.Price == 0 {
+			return validationError("TRAILING_STOP_LIMIT order requires a limit price", "Add `--price <amount>` to specify the limit price")
+		}
 	}
 
 	return nil
@@ -39,6 +51,14 @@ func ValidateEquityOrder(params *EquityParams) error {
 
 // ValidateOptionOrder validates option order parameters.
 func ValidateOptionOrder(params *OptionParams) error {
+	// Trailing stop orders are only supported for equity orders.
+	if params.OrderType == models.OrderTypeTrailingStop || params.OrderType == models.OrderTypeTrailingStopLimit {
+		return validationError(
+			"trailing stop orders are not supported for options",
+			"Use `order build equity` for trailing stop orders",
+		)
+	}
+
 	if err := validateUnderlying(params.Underlying); err != nil {
 		return err
 	}

--- a/internal/orderbuilder/validate_test.go
+++ b/internal/orderbuilder/validate_test.go
@@ -618,6 +618,37 @@ func TestValidateOptionOrderRejectsNegativeStrike(t *testing.T) {
 	assertValidationError(t, err, "option strike price must be greater than zero", "Add `--strike <price>` with a positive value")
 }
 
+// TestValidateOptionOrderRejectsTrailingStop verifies trailing stop types are rejected for options.
+func TestValidateOptionOrderRejectsTrailingStop(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		orderType models.OrderType
+	}{
+		{name: "TRAILING_STOP", orderType: models.OrderTypeTrailingStop},
+		{name: "TRAILING_STOP_LIMIT", orderType: models.OrderTypeTrailingStopLimit},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateOptionOrder(&OptionParams{
+				Underlying: "AAPL",
+				Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+				Strike:     185,
+				Quantity:   5,
+				Action:     models.InstructionBuyToOpen,
+				OrderType:  tc.orderType,
+			})
+
+			require.Error(t, err)
+			assertValidationError(t, err, "trailing stop orders are not supported for options", "Use `order build equity` for trailing stop orders")
+		})
+	}
+}
+
 // TestValidateOptionOrderAcceptsValidParams verifies valid option order passes.
 func TestValidateOptionOrderAcceptsValidParams(t *testing.T) {
 	t.Parallel()
@@ -855,6 +886,101 @@ func TestValidateEquityOrderRequiresBothPricesForStopLimit(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestValidateEquityOrderRequiresOffsetForTrailingStop verifies TRAILING_STOP requires stop-offset.
+func TestValidateEquityOrderRequiresOffsetForTrailingStop(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateEquityOrder(&EquityParams{
+		Symbol:    "AAPL",
+		Quantity:  10,
+		OrderType: models.OrderTypeTrailingStop,
+	})
+
+	assertValidationError(t, err,
+		"TRAILING_STOP order requires a stop price offset",
+		"Add `--stop-offset <amount>` to specify how far the stop trails",
+	)
+}
+
+// TestValidateEquityOrderRequiresOffsetAndPriceForTrailingStopLimit verifies TRAILING_STOP_LIMIT
+// requires stop-offset and price.
+func TestValidateEquityOrderRequiresOffsetAndPriceForTrailingStopLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		price           float64
+		stopPriceOffset float64
+		wantMsg         string
+		wantDetails     string
+	}{
+		{
+			name:        "missing offset",
+			price:       195.00,
+			wantMsg:     "TRAILING_STOP_LIMIT order requires a stop price offset",
+			wantDetails: "Add `--stop-offset <amount>` to specify how far the stop trails",
+		},
+		{
+			name:            "missing price",
+			stopPriceOffset: 3.00,
+			wantMsg:         "TRAILING_STOP_LIMIT order requires a limit price",
+			wantDetails:     "Add `--price <amount>` to specify the limit price",
+		},
+		{
+			name:    "missing both",
+			wantMsg: "TRAILING_STOP_LIMIT order requires a stop price offset",
+			wantDetails: "Add `--stop-offset <amount>` to specify how far the stop trails",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateEquityOrder(&EquityParams{
+				Symbol:          "AAPL",
+				Quantity:        10,
+				OrderType:       models.OrderTypeTrailingStopLimit,
+				Price:           tt.price,
+				StopPriceOffset: tt.stopPriceOffset,
+			})
+
+			assertValidationError(t, err, tt.wantMsg, tt.wantDetails)
+		})
+	}
+}
+
+// TestValidateEquityOrderAcceptsValidTrailingStop verifies valid trailing stop orders pass validation.
+func TestValidateEquityOrderAcceptsValidTrailingStop(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateEquityOrder(&EquityParams{
+		Symbol:          "AAPL",
+		Action:          models.InstructionSell,
+		Quantity:        10,
+		OrderType:       models.OrderTypeTrailingStop,
+		StopPriceOffset: 2.50,
+	})
+
+	require.NoError(t, err)
+}
+
+// TestValidateEquityOrderAcceptsValidTrailingStopLimit verifies valid trailing stop limit orders pass.
+func TestValidateEquityOrderAcceptsValidTrailingStopLimit(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateEquityOrder(&EquityParams{
+		Symbol:          "AAPL",
+		Action:          models.InstructionSell,
+		Quantity:        10,
+		OrderType:       models.OrderTypeTrailingStopLimit,
+		Price:           195.00,
+		StopPriceOffset: 3.00,
+	})
+
+	require.NoError(t, err)
 }
 
 // TestValidateEquityOrderAcceptsValidMarketOrder verifies market orders pass validation.


### PR DESCRIPTION
## Summary

- Add trailing stop (TRAILING_STOP, TRAILING_STOP_LIMIT) order support for equity orders with new CLI flags: `--stop-offset`, `--stop-link-basis`, `--stop-link-type`, `--stop-type`, `--activation-price`
- Add special instruction support (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) for both equity and option orders via `--special-instruction` flag
- Add `PriceOffset` field to Order/OrderRequest models (required by Schwab API for trailing stop limit orders instead of the `Price` field)

## Details

### Trailing stop orders (commit 1)

Wires up the existing model constants (`OrderTypeTrailingStop`, `OrderTypeTrailingStopLimit`) through the full order pipeline: CLI flags, parsing, validation, building, and price field application.

Key Schwab API discovery: TRAILING_STOP_LIMIT uses `priceOffset` (not `price`) and requires `priceLinkBasis`/`priceLinkType` in addition to stop link fields. This was caught and fixed during live API preview testing.

Defaults: `--stop-link-basis LAST`, `--stop-link-type VALUE`, `--stop-type STANDARD`. Only `--stop-offset` is required.

### Special instructions (commit 2)

Adds `--special-instruction` flag to both equity and option order commands. Wired through params structs and builders. Applied to OrderRequest when non-empty, omitted otherwise.

## Testing

- Unit tests for builder, validation, and CLI parse errors (9 files changed, +512 lines)
- All 6 order types verified against live Schwab API via `order preview` (no real orders placed)
- `make test` and `make lint` pass