### PR TITLE
refactor: consolidate ptr[T] into shared internal/ptr package

### DIFF
--- a/internal/client/accounts_test.go
+++ b/internal/client/accounts_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestAccountNumbers_Success(t *testing.T) {
@@ -82,14 +83,14 @@ func TestAccounts_Success(t *testing.T) {
 		response := []models.Account{
 			{
 				SecuritiesAccount: &models.SecuritiesAccount{
-					Type:          ptr("MARGIN"),
-					AccountNumber: ptr("123456789"),
+					Type:          ptr.To("MARGIN"),
+					AccountNumber: ptr.To("123456789"),
 				},
 			},
 			{
 				SecuritiesAccount: &models.SecuritiesAccount{
-					Type:          ptr("CASH"),
-					AccountNumber: ptr("987654321"),
+					Type:          ptr.To("CASH"),
+					AccountNumber: ptr.To("987654321"),
 				},
 			},
 		}
@@ -149,8 +150,8 @@ func TestAccount_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.Account{
 			SecuritiesAccount: &models.SecuritiesAccount{
-				Type:          ptr("MARGIN"),
-				AccountNumber: ptr("123456789"),
+				Type:          ptr.To("MARGIN"),
+				AccountNumber: ptr.To("123456789"),
 			},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -193,15 +194,15 @@ func TestAccounts_WithPositionsField(t *testing.T) {
 		response := []models.Account{
 			{
 				SecuritiesAccount: &models.SecuritiesAccount{
-					Type:          ptr("MARGIN"),
-					AccountNumber: ptr("123456789"),
+					Type:          ptr.To("MARGIN"),
+					AccountNumber: ptr.To("123456789"),
 					Positions: []models.Position{
 						{
-							LongQuantity: ptr(float64(100)),
-							MarketValue:  ptr(15000.00),
+							LongQuantity: ptr.To(float64(100)),
+							MarketValue:  ptr.To(15000.00),
 							Instrument: &models.AccountsInstrument{
-								Symbol:    ptr("AAPL"),
-								AssetType: ptr("EQUITY"),
+								Symbol:    ptr.To("AAPL"),
+								AssetType: ptr.To("EQUITY"),
 							},
 						},
 					},
@@ -246,16 +247,16 @@ func TestAccount_WithPositionsField(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.Account{
 			SecuritiesAccount: &models.SecuritiesAccount{
-				Type:          ptr("MARGIN"),
-				AccountNumber: ptr("123456789"),
+				Type:          ptr.To("MARGIN"),
+				AccountNumber: ptr.To("123456789"),
 				Positions: []models.Position{
 					{
-						LongQuantity:  ptr(float64(50)),
-						ShortQuantity: ptr(float64(0)),
-						MarketValue:   ptr(8500.00),
+						LongQuantity:  ptr.To(float64(50)),
+						ShortQuantity: ptr.To(float64(0)),
+						MarketValue:   ptr.To(8500.00),
 						Instrument: &models.AccountsInstrument{
-							Symbol:    ptr("MSFT"),
-							AssetType: ptr("EQUITY"),
+							Symbol:    ptr.To("MSFT"),
+							AssetType: ptr.To("EQUITY"),
 						},
 					},
 				},
@@ -280,22 +281,22 @@ func TestAccount_WithComplexData(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.Account{
 			SecuritiesAccount: &models.SecuritiesAccount{
-				Type:          ptr("MARGIN"),
-				AccountNumber: ptr("123456789"),
-				RoundTrips:    ptr(5),
-				IsForeign:     ptr(false),
+				Type:          ptr.To("MARGIN"),
+				AccountNumber: ptr.To("123456789"),
+				RoundTrips:    ptr.To(5),
+				IsForeign:     ptr.To(false),
 				CurrentBalances: &models.MarginBalance{
-					CashBalance:    ptr(50000.00),
-					BuyingPower:    ptr(100000.00),
-					EquityPercentage: ptr(0.75),
+					CashBalance:    ptr.To(50000.00),
+					BuyingPower:    ptr.To(100000.00),
+					EquityPercentage: ptr.To(0.75),
 				},
 				Positions: []models.Position{
 					{
-						LongQuantity: ptr(float64(100)),
-						MarketValue:  ptr(15000.00),
+						LongQuantity: ptr.To(float64(100)),
+						MarketValue:  ptr.To(15000.00),
 						Instrument: &models.AccountsInstrument{
-							Symbol:    ptr("AAPL"),
-							AssetType: ptr("EQUITY"),
+							Symbol:    ptr.To("AAPL"),
+							AssetType: ptr.To("EQUITY"),
 						},
 					},
 				},
@@ -379,7 +380,3 @@ func TestAccount_BearerTokenAuth(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// ptr returns a pointer to the provided value (generic test helper).
-func ptr[T any](v T) *T {
-	return &v
-}

--- a/internal/client/chains_test.go
+++ b/internal/client/chains_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestOptionChain_Success(t *testing.T) {
@@ -22,10 +23,10 @@ func TestOptionChain_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		response := models.OptionChain{
-			Symbol:          ptr("AAPL"),
-			Status:          ptr("SUCCESS"),
-			UnderlyingPrice: ptr(150.25),
-			IsDelayed:       ptr(false),
+			Symbol:          ptr.To("AAPL"),
+			Status:          ptr.To("SUCCESS"),
+			UnderlyingPrice: ptr.To(150.25),
+			IsDelayed:       ptr.To(false),
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
 	}))
@@ -52,7 +53,7 @@ func TestOptionChain_AllParams(t *testing.T) {
 		assert.Equal(t, "2025-06-30", q.Get("toDate"))
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(models.OptionChain{Symbol: ptr("AAPL")}))
+		require.NoError(t, json.NewEncoder(w).Encode(models.OptionChain{Symbol: ptr.To("AAPL")}))
 	}))
 	defer srv.Close()
 
@@ -84,7 +85,7 @@ func TestOptionChain_AdvancedParams(t *testing.T) {
 		assert.Equal(t, "45", q.Get("daysToExpiration"))
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(models.OptionChain{Symbol: ptr("AAPL")}))
+		require.NoError(t, json.NewEncoder(w).Encode(models.OptionChain{Symbol: ptr.To("AAPL")}))
 	}))
 	defer srv.Close()
 
@@ -125,7 +126,7 @@ func TestOptionChain_EmptyParams(t *testing.T) {
 		assert.Empty(t, q.Get("daysToExpiration"))
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(models.OptionChain{Symbol: ptr("AAPL")}))
+		require.NoError(t, json.NewEncoder(w).Encode(models.OptionChain{Symbol: ptr.To("AAPL")}))
 	}))
 	defer srv.Close()
 
@@ -140,15 +141,15 @@ func TestOptionChain_WithCallExpDateMap(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.OptionChain{
-			Symbol: ptr("AAPL"),
+			Symbol: ptr.To("AAPL"),
 			CallExpDateMap: map[string]map[string][]*models.OptionContract{
 				"2025-06-20:30": {
 					"150.0": {
 						{
-							Symbol:      ptr("AAPL_062025C150"),
-							StrikePrice: ptr(150.0),
-							Bid:         ptr(5.50),
-							Ask:         ptr(5.80),
+							Symbol:      ptr.To("AAPL_062025C150"),
+							StrikePrice: ptr.To(150.0),
+							Bid:         ptr.To(5.50),
+							Ask:         ptr.To(5.80),
 						},
 					},
 				},

--- a/internal/client/history_test.go
+++ b/internal/client/history_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestPriceHistory_Success(t *testing.T) {
@@ -22,24 +23,24 @@ func TestPriceHistory_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		response := models.CandleList{
-			Symbol: ptr("AAPL"),
-			Empty:  ptr(false),
+			Symbol: ptr.To("AAPL"),
+			Empty:  ptr.To(false),
 			Candles: []models.Candle{
 				{
-					Open:     ptr(148.00),
-					High:     ptr(152.00),
-					Low:      ptr(147.50),
-					Close:    ptr(150.25),
-				Volume:   ptr(int64(45000000)),
-				Datetime: ptr(int64(1700000000000)),
+					Open:     ptr.To(148.00),
+					High:     ptr.To(152.00),
+					Low:      ptr.To(147.50),
+					Close:    ptr.To(150.25),
+				Volume:   ptr.To(int64(45000000)),
+				Datetime: ptr.To(int64(1700000000000)),
 				},
 				{
-					Open:     ptr(150.50),
-					High:     ptr(153.00),
-					Low:      ptr(149.00),
-					Close:    ptr(151.75),
-				Volume:   ptr(int64(42000000)),
-				Datetime: ptr(int64(1700086400000)),
+					Open:     ptr.To(150.50),
+					High:     ptr.To(153.00),
+					Low:      ptr.To(149.00),
+					Close:    ptr.To(151.75),
+				Volume:   ptr.To(int64(42000000)),
+				Datetime: ptr.To(int64(1700086400000)),
 				},
 			},
 		}
@@ -72,7 +73,7 @@ func TestPriceHistory_AllParams(t *testing.T) {
 		assert.Equal(t, "1700100000000", q.Get("endDate"))
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(models.CandleList{Symbol: ptr("AAPL")}))
+		require.NoError(t, json.NewEncoder(w).Encode(models.CandleList{Symbol: ptr.To("AAPL")}))
 	}))
 	defer srv.Close()
 
@@ -101,7 +102,7 @@ func TestPriceHistory_DateParams(t *testing.T) {
 		assert.Empty(t, q.Get("period"))
 
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(models.CandleList{Symbol: ptr("AAPL")}))
+		require.NoError(t, json.NewEncoder(w).Encode(models.CandleList{Symbol: ptr.To("AAPL")}))
 	}))
 	defer srv.Close()
 
@@ -119,8 +120,8 @@ func TestPriceHistory_EmptyCandles(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.CandleList{
-			Symbol:  ptr("AAPL"),
-			Empty:   ptr(true),
+			Symbol:  ptr.To("AAPL"),
+			Empty:   ptr.To(true),
 			Candles: []models.Candle{},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))

--- a/internal/client/instruments_test.go
+++ b/internal/client/instruments_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestSearchInstruments_Success(t *testing.T) {
@@ -25,11 +26,11 @@ func TestSearchInstruments_Success(t *testing.T) {
 		response := models.InstrumentResponse{
 			Instruments: []models.Instrument{
 				{
-					Cusip:       ptr("037833100"),
-					Symbol:      ptr("AAPL"),
-					Description: ptr("Apple Inc"),
-					Exchange:    ptr("NASDAQ"),
-					AssetType:   ptr("EQUITY"),
+					Cusip:       ptr.To("037833100"),
+					Symbol:      ptr.To("AAPL"),
+					Description: ptr.To("Apple Inc"),
+					Exchange:    ptr.To("NASDAQ"),
+					AssetType:   ptr.To("EQUITY"),
 				},
 			},
 		}
@@ -55,9 +56,9 @@ func TestSearchInstruments_MultipleResults(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.InstrumentResponse{
 			Instruments: []models.Instrument{
-				{Symbol: ptr("AAPL"), Description: ptr("Apple Inc")},
-				{Symbol: ptr("AAL"), Description: ptr("American Airlines")},
-				{Symbol: ptr("AAXJ"), Description: ptr("iShares MSCI All Country Asia")},
+				{Symbol: ptr.To("AAPL"), Description: ptr.To("Apple Inc")},
+				{Symbol: ptr.To("AAL"), Description: ptr.To("American Airlines")},
+				{Symbol: ptr.To("AAXJ"), Description: ptr.To("iShares MSCI All Country Asia")},
 			},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -96,11 +97,11 @@ func TestGetInstrument_Success(t *testing.T) {
 		response := models.InstrumentResponse{
 			Instruments: []models.Instrument{
 				{
-					Cusip:       ptr("037833100"),
-					Symbol:      ptr("AAPL"),
-					Description: ptr("Apple Inc"),
-					Exchange:    ptr("NASDAQ"),
-					AssetType:   ptr("EQUITY"),
+					Cusip:       ptr.To("037833100"),
+					Symbol:      ptr.To("AAPL"),
+					Description: ptr.To("Apple Inc"),
+					Exchange:    ptr.To("NASDAQ"),
+					AssetType:   ptr.To("EQUITY"),
 				},
 			},
 		}

--- a/internal/client/markets_test.go
+++ b/internal/client/markets_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestMarkets_Success(t *testing.T) {
@@ -28,16 +29,16 @@ func TestMarkets_Success(t *testing.T) {
 		response := map[string]map[string]models.MarketHours{
 			"equity": {
 				"EQ": {
-					MarketType: ptr("EQUITY"),
-					IsOpen:     ptr(true),
-					Date:       ptr("2025-04-21"),
+					MarketType: ptr.To("EQUITY"),
+					IsOpen:     ptr.To(true),
+					Date:       ptr.To("2025-04-21"),
 				},
 			},
 			"option": {
 				"EQO": {
-					MarketType: ptr("OPTION"),
-					IsOpen:     ptr(true),
-					Date:       ptr("2025-04-21"),
+					MarketType: ptr.To("OPTION"),
+					IsOpen:     ptr.To(true),
+					Date:       ptr.To("2025-04-21"),
 				},
 			},
 		}
@@ -83,15 +84,15 @@ func TestMarket_Success(t *testing.T) {
 		response := map[string]map[string]models.MarketHours{
 			"equity": {
 				"EQ": {
-					MarketType:  ptr("EQUITY"),
-					ProductName: ptr("equity"),
-					IsOpen:      ptr(true),
-					Date:        ptr("2025-04-21"),
+					MarketType:  ptr.To("EQUITY"),
+					ProductName: ptr.To("equity"),
+					IsOpen:      ptr.To(true),
+					Date:        ptr.To("2025-04-21"),
 					SessionHours: &models.SessionHours{
 						RegularMarket: []models.MarketSession{
 							{
-								Start: ptr("2025-04-21T09:30:00-04:00"),
-								End:   ptr("2025-04-21T16:00:00-04:00"),
+								Start: ptr.To("2025-04-21T09:30:00-04:00"),
+								End:   ptr.To("2025-04-21T16:00:00-04:00"),
 							},
 						},
 					},

--- a/internal/client/movers_test.go
+++ b/internal/client/movers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestMovers_Success(t *testing.T) {
@@ -23,26 +24,26 @@ func TestMovers_Success(t *testing.T) {
 		response := models.ScreenerResponse{
 			Screeners: []models.Screener{
 				{
-					Symbol:           ptr("AAPL"),
-					Description:      ptr("Apple Inc"),
-					LastPrice:        ptr(150.25),
-					NetChange:        ptr(2.50),
-					NetPercentChange: ptr(0.0169),
-				Volume:           ptr(int64(12000000)),
-				TotalVolume:      ptr(int64(45000000)),
-				Trades:           ptr(int64(100000)),
-					MarketShare:      ptr(26.67),
+					Symbol:           ptr.To("AAPL"),
+					Description:      ptr.To("Apple Inc"),
+					LastPrice:        ptr.To(150.25),
+					NetChange:        ptr.To(2.50),
+					NetPercentChange: ptr.To(0.0169),
+				Volume:           ptr.To(int64(12000000)),
+				TotalVolume:      ptr.To(int64(45000000)),
+				Trades:           ptr.To(int64(100000)),
+					MarketShare:      ptr.To(26.67),
 				},
 				{
-					Symbol:           ptr("NVDA"),
-					Description:      ptr("NVIDIA Corp"),
-					LastPrice:        ptr(850.50),
-					NetChange:        ptr(15.00),
-					NetPercentChange: ptr(0.0179),
-				Volume:           ptr(int64(8000000)),
-				TotalVolume:      ptr(int64(30000000)),
-				Trades:           ptr(int64(75000)),
-					MarketShare:      ptr(26.67),
+					Symbol:           ptr.To("NVDA"),
+					Description:      ptr.To("NVIDIA Corp"),
+					LastPrice:        ptr.To(850.50),
+					NetChange:        ptr.To(15.00),
+					NetPercentChange: ptr.To(0.0179),
+				Volume:           ptr.To(int64(8000000)),
+				TotalVolume:      ptr.To(int64(30000000)),
+				Trades:           ptr.To(int64(75000)),
+					MarketShare:      ptr.To(26.67),
 				},
 			},
 		}

--- a/internal/client/orders_test.go
+++ b/internal/client/orders_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 // testOrderRequest creates a simple test order request fixture.
@@ -238,7 +239,7 @@ func TestPreviewOrder_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		commValue := 0.65
 		response := models.PreviewOrder{
-			OrderID: ptr(int64(11111)),
+			OrderID: ptr.To(int64(11111)),
 			CommissionAndFee: &models.CommissionAndFee{
 				Commission: &models.CommissionDetail{
 					CommissionLegs: []models.CommissionLeg{

--- a/internal/client/preferences_test.go
+++ b/internal/client/preferences_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestUserPreference_Success(t *testing.T) {
@@ -23,39 +24,39 @@ func TestUserPreference_Success(t *testing.T) {
 		response := models.UserPreference{
 			Accounts: []models.UserPreferenceAccount{
 				{
-					AccountNumber:      ptr("123456789"),
-					PrimaryAccount:     ptr(true),
-					Type:                ptr("MARGIN"),
-					NickName:           ptr("Main Account"),
-					AccountColor:       ptr("COLOR_BLUE"),
-					DisplayAcctId:      ptr("X123"),
-					AutoPositionEffect: ptr(true),
+					AccountNumber:      ptr.To("123456789"),
+					PrimaryAccount:     ptr.To(true),
+					Type:                ptr.To("MARGIN"),
+					NickName:           ptr.To("Main Account"),
+					AccountColor:       ptr.To("COLOR_BLUE"),
+					DisplayAcctId:      ptr.To("X123"),
+					AutoPositionEffect: ptr.To(true),
 				},
 				{
-					AccountNumber:      ptr("987654321"),
-					PrimaryAccount:     ptr(false),
-					Type:                ptr("CASH"),
-					NickName:           ptr("Savings Account"),
-					AccountColor:       ptr("COLOR_GREEN"),
-					DisplayAcctId:      ptr("X456"),
-					AutoPositionEffect: ptr(false),
+					AccountNumber:      ptr.To("987654321"),
+					PrimaryAccount:     ptr.To(false),
+					Type:                ptr.To("CASH"),
+					NickName:           ptr.To("Savings Account"),
+					AccountColor:       ptr.To("COLOR_GREEN"),
+					DisplayAcctId:      ptr.To("X456"),
+					AutoPositionEffect: ptr.To(false),
 				},
 			},
 			Offers: []models.Offer{
 				{
-					ID:          ptr("offer-001"),
-					Name:        ptr("Premium Features"),
-					Description: ptr("Access to advanced tools"),
-					Status:      ptr("ACTIVE"),
+					ID:          ptr.To("offer-001"),
+					Name:        ptr.To("Premium Features"),
+					Description: ptr.To("Access to advanced tools"),
+					Status:      ptr.To("ACTIVE"),
 				},
 			},
 			StreamerInfo: []models.StreamerInfo{
 				{
-					StreamerURL: ptr("https://streamer.schwab.com"),
-					Token:       ptr("streamer-token-xyz"),
-					TokenExpTime: ptr(int64(1705363200)),
-					AppID:       ptr("app-123"),
-					ACL:         ptr("ACCT"),
+					StreamerURL: ptr.To("https://streamer.schwab.com"),
+					Token:       ptr.To("streamer-token-xyz"),
+					TokenExpTime: ptr.To(int64(1705363200)),
+					AppID:       ptr.To("app-123"),
+					ACL:         ptr.To("ACCT"),
 				},
 			},
 		}
@@ -108,7 +109,7 @@ func TestUserPreference_WithMinimalData(t *testing.T) {
 		response := models.UserPreference{
 			Accounts: []models.UserPreferenceAccount{
 				{
-					AccountNumber: ptr("123456789"),
+					AccountNumber: ptr.To("123456789"),
 				},
 			},
 		}
@@ -147,29 +148,29 @@ func TestUserPreference_WithComplexStreamerInfo(t *testing.T) {
 		response := models.UserPreference{
 			Accounts: []models.UserPreferenceAccount{
 				{
-					AccountNumber:      ptr("123456789"),
-					PrimaryAccount:     ptr(true),
-					Type:                ptr("MARGIN"),
-					NickName:           ptr("Trading Account"),
-					AccountColor:       ptr("COLOR_RED"),
-					DisplayAcctId:      ptr("X789"),
-					AutoPositionEffect: ptr(true),
+					AccountNumber:      ptr.To("123456789"),
+					PrimaryAccount:     ptr.To(true),
+					Type:                ptr.To("MARGIN"),
+					NickName:           ptr.To("Trading Account"),
+					AccountColor:       ptr.To("COLOR_RED"),
+					DisplayAcctId:      ptr.To("X789"),
+					AutoPositionEffect: ptr.To(true),
 				},
 			},
 			StreamerInfo: []models.StreamerInfo{
 				{
-					StreamerURL:  ptr("https://streamer1.schwab.com"),
-					Token:        ptr("token-abc123"),
-					TokenExpTime: ptr(int64(1705363200)),
-					AppID:        ptr("app-001"),
-					ACL:          ptr("ACCT,QUOTE"),
+					StreamerURL:  ptr.To("https://streamer1.schwab.com"),
+					Token:        ptr.To("token-abc123"),
+					TokenExpTime: ptr.To(int64(1705363200)),
+					AppID:        ptr.To("app-001"),
+					ACL:          ptr.To("ACCT,QUOTE"),
 				},
 				{
-					StreamerURL:  ptr("https://streamer2.schwab.com"),
-					Token:        ptr("token-def456"),
-					TokenExpTime: ptr(int64(1705449600)),
-					AppID:        ptr("app-002"),
-					ACL:          ptr("ACCT"),
+					StreamerURL:  ptr.To("https://streamer2.schwab.com"),
+					Token:        ptr.To("token-def456"),
+					TokenExpTime: ptr.To(int64(1705449600)),
+					AppID:        ptr.To("app-002"),
+					ACL:          ptr.To("ACCT"),
 				},
 			},
 		}

--- a/internal/client/quotes_test.go
+++ b/internal/client/quotes_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestQuotes_Success(t *testing.T) {
@@ -23,19 +24,19 @@ func TestQuotes_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]*models.QuoteEquity{
 			"AAPL": {
-				Symbol: ptr("AAPL"),
+				Symbol: ptr.To("AAPL"),
 				Quote: &models.QuoteData{
-					LastPrice: ptr(150.25),
-					BidPrice:  ptr(150.20),
-					AskPrice:  ptr(150.30),
+					LastPrice: ptr.To(150.25),
+					BidPrice:  ptr.To(150.20),
+					AskPrice:  ptr.To(150.30),
 				},
 			},
 			"NVDA": {
-				Symbol: ptr("NVDA"),
+				Symbol: ptr.To("NVDA"),
 				Quote: &models.QuoteData{
-					LastPrice: ptr(850.50),
-					BidPrice:  ptr(850.40),
-					AskPrice:  ptr(850.60),
+					LastPrice: ptr.To(850.50),
+					BidPrice:  ptr.To(850.40),
+					AskPrice:  ptr.To(850.60),
 				},
 			},
 		}
@@ -96,15 +97,15 @@ func TestQuote_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]*models.QuoteEquity{
 			"AAPL": {
-				Symbol: ptr("AAPL"),
+				Symbol: ptr.To("AAPL"),
 				Quote: &models.QuoteData{
-					LastPrice:   ptr(150.25),
-					BidPrice:    ptr(150.20),
-					AskPrice:    ptr(150.30),
-					TotalVolume: ptr(int64(45000000)),
+					LastPrice:   ptr.To(150.25),
+					BidPrice:    ptr.To(150.20),
+					AskPrice:    ptr.To(150.30),
+					TotalVolume: ptr.To(int64(45000000)),
 				},
 				Reference: &models.QuoteReference{
-					Description: ptr("Apple Inc"),
+					Description: ptr.To("Apple Inc"),
 				},
 			},
 		}

--- a/internal/client/transactions_test.go
+++ b/internal/client/transactions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 func TestTransactions_Success(t *testing.T) {
@@ -27,20 +28,20 @@ func TestTransactions_Success(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := []models.Transaction{
 			{
-				ActivityID:  ptr(int64(1001)),
-				Time:        ptr("2024-01-15T10:30:00Z"),
+				ActivityID:  ptr.To(int64(1001)),
+				Time:        ptr.To("2024-01-15T10:30:00Z"),
 				Type:        transactionTypePtr(models.TransactionTypeTrade),
-				Status:      ptr("FILLED"),
-				Description: ptr("BUY 100 AAPL"),
-				NetAmount:   ptr(-15000.00),
+				Status:      ptr.To("FILLED"),
+				Description: ptr.To("BUY 100 AAPL"),
+				NetAmount:   ptr.To(-15000.00),
 			},
 			{
-				ActivityID:  ptr(int64(1002)),
-				Time:        ptr("2024-01-16T14:45:00Z"),
+				ActivityID:  ptr.To(int64(1002)),
+				Time:        ptr.To("2024-01-16T14:45:00Z"),
 				Type:        transactionTypePtr(models.TransactionTypeDividend),
-				Status:      ptr("SETTLED"),
-				Description: ptr("DIVIDEND AAPL"),
-				NetAmount:   ptr(50.00),
+				Status:      ptr.To("SETTLED"),
+				Description: ptr.To("DIVIDEND AAPL"),
+				NetAmount:   ptr.To(50.00),
 			},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -70,9 +71,9 @@ func TestTransactions_WithTypeFilter(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := []models.Transaction{
 			{
-				ActivityID:  ptr(int64(1001)),
+				ActivityID:  ptr.To(int64(1001)),
 				Type:        transactionTypePtr(models.TransactionTypeTrade),
-				Description: ptr("BUY 100 AAPL"),
+				Description: ptr.To("BUY 100 AAPL"),
 			},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -101,9 +102,9 @@ func TestTransactions_WithDateFilters(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		response := []models.Transaction{
 			{
-				ActivityID:  ptr(int64(1001)),
-				Time:        ptr("2024-01-15T10:30:00Z"),
-				Description: ptr("BUY 100 AAPL"),
+				ActivityID:  ptr.To(int64(1001)),
+				Time:        ptr.To("2024-01-15T10:30:00Z"),
+				Description: ptr.To("BUY 100 AAPL"),
 			},
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
@@ -164,12 +165,12 @@ func TestTransaction_Success(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		response := models.Transaction{
-			ActivityID:  ptr(int64(1001)),
-			Time:        ptr("2024-01-15T10:30:00Z"),
+			ActivityID:  ptr.To(int64(1001)),
+			Time:        ptr.To("2024-01-15T10:30:00Z"),
 			Type:        transactionTypePtr(models.TransactionTypeTrade),
-			Status:      ptr("FILLED"),
-			Description: ptr("BUY 100 AAPL"),
-			NetAmount:   ptr(-15000.00),
+			Status:      ptr.To("FILLED"),
+			Description: ptr.To("BUY 100 AAPL"),
+			NetAmount:   ptr.To(-15000.00),
 		}
 		require.NoError(t, json.NewEncoder(w).Encode(response))
 	}))
@@ -189,29 +190,29 @@ func TestTransaction_WithComplexData(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := models.Transaction{
-			ActivityID:     ptr(int64(1001)),
-			Time:           ptr("2024-01-15T10:30:00Z"),
+			ActivityID:     ptr.To(int64(1001)),
+			Time:           ptr.To("2024-01-15T10:30:00Z"),
 			Type:           transactionTypePtr(models.TransactionTypeTrade),
-			Status:         ptr("FILLED"),
-			Description:    ptr("BUY 100 AAPL"),
-			NetAmount:      ptr(-15000.00),
-			AccountNumber:  ptr("123456789"),
-			SubAccount:     ptr("CASH"),
-			ActivityType:   ptr("ORDER"),
-			OrderID:        ptr(int64(5001)),
-			PositionID:     ptr(int64(9001)),
-			TradeDate:      ptr("2024-01-15"),
-			SettlementDate: ptr("2024-01-17"),
+			Status:         ptr.To("FILLED"),
+			Description:    ptr.To("BUY 100 AAPL"),
+			NetAmount:      ptr.To(-15000.00),
+			AccountNumber:  ptr.To("123456789"),
+			SubAccount:     ptr.To("CASH"),
+			ActivityType:   ptr.To("ORDER"),
+			OrderID:        ptr.To(int64(5001)),
+			PositionID:     ptr.To(int64(9001)),
+			TradeDate:      ptr.To("2024-01-15"),
+			SettlementDate: ptr.To("2024-01-17"),
 			TransferItems: []models.TransferItem{
 				{
 					Instrument: &models.TransferInstrument{
-						AssetType:   ptr("EQUITY"),
-						Symbol:      ptr("AAPL"),
-						Description: ptr("Apple Inc"),
+						AssetType:   ptr.To("EQUITY"),
+						Symbol:      ptr.To("AAPL"),
+						Description: ptr.To("Apple Inc"),
 					},
-				Position:         ptr(float64(100)),
-				PositionEffect:   ptr("OPENING"),
-				PositionQuantity: ptr(float64(100)),
+				Position:         ptr.To(float64(100)),
+				PositionEffect:   ptr.To("OPENING"),
+				PositionQuantity: ptr.To(float64(100)),
 				},
 			},
 		}

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/orderbuilder"
 	"github.com/major/schwab-agent/internal/output"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 // testFutureExpTime is a future expiration date for option tests. Computed once
@@ -160,7 +161,7 @@ func TestOrderConfirmGate(t *testing.T) {
 func TestOrderPreviewSpecModes(t *testing.T) {
 	t.Parallel()
 
-	previewResponse := models.PreviewOrder{OrderID: ptr(int64(4242))}
+	previewResponse := models.PreviewOrder{OrderID: ptr.To(int64(4242))}
 	var requestBodies []string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -420,7 +421,7 @@ func TestOrderMutableGuardTakesPriorityOverConfirm(t *testing.T) {
 func TestOrderPreviewNotBlockedByMutableGuard(t *testing.T) {
 	t.Parallel()
 
-	previewResponse := models.PreviewOrder{OrderID: ptr(int64(9999))}
+	previewResponse := models.PreviewOrder{OrderID: ptr.To(int64(9999))}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(previewResponse))
@@ -542,10 +543,6 @@ func TestOrderPlaceOCOPipeline(t *testing.T) {
 	assert.Equal(t, float64(55555), data["orderId"])
 }
 
-// ptr returns a pointer to the provided value (generic test helper).
-func ptr[T any](v T) *T {
-	return &v
-}
 
 // --- Spread build tests (iron condor, vertical, strangle, straddle, covered call) ---
 //

--- a/internal/orderbuilder/complex.go
+++ b/internal/orderbuilder/complex.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 // OCOParams holds parameters for building a standalone one-cancels-other order.
@@ -59,11 +60,11 @@ func BuildBracketOrder(params *BracketParams) (*models.OrderRequest, error) {
 	}
 
 	if params.OrderType == models.OrderTypeLimit || params.OrderType == models.OrderTypeStopLimit {
-		order.Price = ptr(params.Price)
+		order.Price = ptr.To(params.Price)
 	}
 
 	if params.OrderType == models.OrderTypeStop || params.OrderType == models.OrderTypeStopLimit {
-		order.StopPrice = ptr(params.Price)
+		order.StopPrice = ptr.To(params.Price)
 	}
 
 	return order, nil
@@ -117,7 +118,7 @@ func buildOCOLimitExit(params *OCOParams) models.OrderRequest {
 		Duration:          params.Duration,
 		OrderType:         models.OrderTypeLimit,
 		OrderStrategyType: models.OrderStrategyTypeSingle,
-		Price:             ptr(params.TakeProfit),
+		Price:             ptr.To(params.TakeProfit),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildEquityLeg(params.Symbol, params.Action, params.Quantity),
 		},
@@ -131,7 +132,7 @@ func buildOCOStopExit(params *OCOParams) models.OrderRequest {
 		Duration:          params.Duration,
 		OrderType:         models.OrderTypeStop,
 		OrderStrategyType: models.OrderStrategyTypeSingle,
-		StopPrice:         ptr(params.StopLoss),
+		StopPrice:         ptr.To(params.StopLoss),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildEquityLeg(params.Symbol, params.Action, params.Quantity),
 		},
@@ -180,7 +181,7 @@ func buildTakeProfitOrder(params *BracketParams, exitInstruction models.Instruct
 		Duration:          params.Duration,
 		OrderType:         models.OrderTypeLimit,
 		OrderStrategyType: models.OrderStrategyTypeSingle,
-		Price:             ptr(params.TakeProfit),
+		Price:             ptr.To(params.TakeProfit),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildEquityLeg(params.Symbol, exitInstruction, params.Quantity),
 		},
@@ -194,7 +195,7 @@ func buildStopLossOrder(params *BracketParams, exitInstruction models.Instructio
 		Duration:          params.Duration,
 		OrderType:         models.OrderTypeStop,
 		OrderStrategyType: models.OrderStrategyTypeSingle,
-		StopPrice:         ptr(params.StopLoss),
+		StopPrice:         ptr.To(params.StopLoss),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildEquityLeg(params.Symbol, exitInstruction, params.Quantity),
 		},

--- a/internal/orderbuilder/complex_test.go
+++ b/internal/orderbuilder/complex_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -428,7 +429,7 @@ func TestBuildFTSOrderStructure(t *testing.T) {
 		Session:   models.SessionNormal,
 		Duration:  models.DurationDay,
 		OrderType: models.OrderTypeLimit,
-		Price:     ptr(150.0),
+		Price:     ptr.To(150.0),
 		OrderLegCollection: []models.OrderLegCollection{
 			{
 				Instruction: models.InstructionBuy,
@@ -442,7 +443,7 @@ func TestBuildFTSOrderStructure(t *testing.T) {
 		Session:   models.SessionNormal,
 		Duration:  models.DurationDay,
 		OrderType: models.OrderTypeStop,
-		StopPrice: ptr(140.0),
+		StopPrice: ptr.To(140.0),
 		OrderLegCollection: []models.OrderLegCollection{
 			{
 				Instruction: models.InstructionSell,
@@ -504,7 +505,7 @@ func TestBuildFTSOrderPreservesOriginalFields(t *testing.T) {
 			Session:   models.SessionNormal,
 			Duration:  models.DurationDay,
 			OrderType: models.OrderTypeLimit,
-			Price:     ptr(200.0),
+			Price:     ptr.To(200.0),
 			OrderLegCollection: []models.OrderLegCollection{
 				{Instruction: models.InstructionSell, Quantity: 50},
 			},

--- a/internal/orderbuilder/equity.go
+++ b/internal/orderbuilder/equity.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 // EquityParams holds parameters for building an equity order.
@@ -56,11 +57,11 @@ func BuildEquityOrder(params *EquityParams) (*models.OrderRequest, error) {
 	applyEquityPriceFields(order, params)
 
 	if params.SpecialInstruction != "" {
-		order.SpecialInstruction = ptr(params.SpecialInstruction)
+		order.SpecialInstruction = ptr.To(params.SpecialInstruction)
 	}
 
 	if params.Destination != "" {
-		order.RequestedDestination = ptr(params.Destination)
+		order.RequestedDestination = ptr.To(params.Destination)
 	}
 
 	// Market-style orders have no price to link against, so reject price-link fields early.
@@ -77,11 +78,11 @@ func BuildEquityOrder(params *EquityParams) (*models.OrderRequest, error) {
 	// the stop price link values in applyEquityPriceFields - these explicit
 	// fields are set afterwards and will override those derived values.
 	if params.PriceLinkBasis != "" {
-		order.PriceLinkBasis = ptr(params.PriceLinkBasis)
+		order.PriceLinkBasis = ptr.To(params.PriceLinkBasis)
 	}
 
 	if params.PriceLinkType != "" {
-		order.PriceLinkType = ptr(params.PriceLinkType)
+		order.PriceLinkType = ptr.To(params.PriceLinkType)
 	}
 
 	return order, nil
@@ -91,12 +92,12 @@ func BuildEquityOrder(params *EquityParams) (*models.OrderRequest, error) {
 func applyEquityPriceFields(order *models.OrderRequest, params *EquityParams) {
 	switch params.OrderType {
 	case models.OrderTypeLimit:
-		order.Price = ptr(params.Price)
+		order.Price = ptr.To(params.Price)
 	case models.OrderTypeStop:
-		order.StopPrice = ptr(params.StopPrice)
+		order.StopPrice = ptr.To(params.StopPrice)
 	case models.OrderTypeStopLimit:
-		order.Price = ptr(params.Price)
-		order.StopPrice = ptr(params.StopPrice)
+		order.Price = ptr.To(params.Price)
+		order.StopPrice = ptr.To(params.StopPrice)
 	case models.OrderTypeTrailingStop:
 		applyTrailingStopFields(order, params)
 	case models.OrderTypeTrailingStopLimit:
@@ -105,12 +106,12 @@ func applyEquityPriceFields(order *models.OrderRequest, params *EquityParams) {
 		// Schwab API uses priceOffset (not price) for trailing stop limit orders.
 		// The offset defines the limit price distance from the triggered stop.
 		// priceLinkBasis/priceLinkType default to the stop price link values.
-		order.PriceOffset = ptr(params.Price)
-		order.PriceLinkBasis = ptr(models.PriceLinkBasis(params.StopPriceLinkBasis))
-		order.PriceLinkType = ptr(models.PriceLinkType(params.StopPriceLinkType))
+		order.PriceOffset = ptr.To(params.Price)
+		order.PriceLinkBasis = ptr.To(models.PriceLinkBasis(params.StopPriceLinkBasis))
+		order.PriceLinkType = ptr.To(models.PriceLinkType(params.StopPriceLinkType))
 	case models.OrderTypeLimitOnClose:
 		// LOC orders require a limit price, similar to LIMIT orders
-		order.Price = ptr(params.Price)
+		order.Price = ptr.To(params.Price)
 		// MOC (MARKET_ON_CLOSE) orders don't require any price fields
 	}
 }
@@ -118,17 +119,13 @@ func applyEquityPriceFields(order *models.OrderRequest, params *EquityParams) {
 // applyTrailingStopFields sets the trailing stop-specific fields shared by
 // TRAILING_STOP and TRAILING_STOP_LIMIT order types.
 func applyTrailingStopFields(order *models.OrderRequest, params *EquityParams) {
-	order.StopPriceOffset = ptr(params.StopPriceOffset)
-	order.StopPriceLinkBasis = ptr(params.StopPriceLinkBasis)
-	order.StopPriceLinkType = ptr(params.StopPriceLinkType)
-	order.StopType = ptr(params.StopType)
+	order.StopPriceOffset = ptr.To(params.StopPriceOffset)
+	order.StopPriceLinkBasis = ptr.To(params.StopPriceLinkBasis)
+	order.StopPriceLinkType = ptr.To(params.StopPriceLinkType)
+	order.StopType = ptr.To(params.StopType)
 
 	if params.ActivationPrice > 0 {
-		order.ActivationPrice = ptr(params.ActivationPrice)
+		order.ActivationPrice = ptr.To(params.ActivationPrice)
 	}
 }
 
-// ptr returns a pointer to the provided value.
-func ptr[T any](v T) *T {
-	return &v
-}

--- a/internal/orderbuilder/option.go
+++ b/internal/orderbuilder/option.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 const optionContractMultiplier = 100.0
@@ -65,15 +66,15 @@ func BuildOptionOrder(params *OptionParams) (*models.OrderRequest, error) {
 	}
 
 	if params.OrderType == models.OrderTypeLimit {
-		order.Price = ptr(params.Price)
+		order.Price = ptr.To(params.Price)
 	}
 
 	if params.SpecialInstruction != "" {
-		order.SpecialInstruction = ptr(params.SpecialInstruction)
+		order.SpecialInstruction = ptr.To(params.SpecialInstruction)
 	}
 
 	if params.Destination != "" {
-		order.RequestedDestination = ptr(params.Destination)
+		order.RequestedDestination = ptr.To(params.Destination)
 	}
 
 	// Market-style orders have no price to link against, so reject price-link fields early.
@@ -86,11 +87,11 @@ func BuildOptionOrder(params *OptionParams) (*models.OrderRequest, error) {
 	}
 
 	if params.PriceLinkBasis != "" {
-		order.PriceLinkBasis = ptr(params.PriceLinkBasis)
+		order.PriceLinkBasis = ptr.To(params.PriceLinkBasis)
 	}
 
 	if params.PriceLinkType != "" {
-		order.PriceLinkType = ptr(params.PriceLinkType)
+		order.PriceLinkType = ptr.To(params.PriceLinkType)
 	}
 
 	return order, nil

--- a/internal/orderbuilder/spread.go
+++ b/internal/orderbuilder/spread.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/ptr"
 )
 
 // VerticalParams holds parameters for building a vertical spread order.
@@ -44,7 +45,7 @@ func BuildVerticalOrder(params *VerticalParams) (*models.OrderRequest, error) {
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildOptionLeg(&optionLegParams{
 				Underlying: params.Underlying, Expiration: params.Expiration,
@@ -135,7 +136,7 @@ func BuildIronCondorOrder(params *IronCondorParams) (*models.OrderRequest, error
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildOptionLeg(&optionLegParams{
 				Underlying: params.Underlying, Expiration: params.Expiration,
@@ -195,7 +196,7 @@ func BuildStraddleOrder(params *StraddleParams) (*models.OrderRequest, error) {
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildOptionLeg(&optionLegParams{
 				Underlying: params.Underlying, Expiration: params.Expiration,
@@ -246,7 +247,7 @@ func BuildStrangleOrder(params *StrangleParams) (*models.OrderRequest, error) {
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildOptionLeg(&optionLegParams{
 				Underlying: params.Underlying, Expiration: params.Expiration,
@@ -323,7 +324,7 @@ func BuildCoveredCallOrder(params *CoveredCallParams) (*models.OrderRequest, err
 		OrderType:                models.OrderTypeNetDebit,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			buildEquityLeg(params.Underlying, models.InstructionBuy, params.Quantity*optionContractMultiplier),
 			buildOptionLeg(&optionLegParams{
@@ -378,7 +379,7 @@ func BuildCalendarOrder(params *CalendarParams) (*models.OrderRequest, error) {
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			// Far leg (bought when opening) listed first for consistency
 			// with how Schwab displays calendar spreads.
@@ -440,7 +441,7 @@ func BuildDiagonalOrder(params *DiagonalParams) (*models.OrderRequest, error) {
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			// Far leg (bought when opening) listed first.
 			buildOptionLeg(&optionLegParams{
@@ -515,7 +516,7 @@ func BuildCollarOrder(params *CollarParams) (*models.OrderRequest, error) {
 		OrderType:                orderType,
 		ComplexOrderStrategyType: &complexType,
 		OrderStrategyType:        models.OrderStrategyTypeSingle,
-		Price:                    ptr(params.Price),
+		Price:                    ptr.To(params.Price),
 		OrderLegCollection: []models.OrderLegCollection{
 			// Leg 1: Equity shares.
 			buildEquityLeg(params.Underlying, equityInstruction, params.Quantity*optionContractMultiplier),

--- a/internal/ptr/ptr.go
+++ b/internal/ptr/ptr.go
@@ -1,0 +1,6 @@
+// Package ptr provides a generic helper for creating pointers to values.
+package ptr
+
+// To returns a pointer to the given value. Useful for initializing
+// pointer fields in struct literals.
+func To[T any](v T) *T { return &v }


### PR DESCRIPTION
## Summary

- Move generic pointer helper `ptr[T]` from 3 duplicate definitions into new `internal/ptr.To[T]` package
- Update 241 call sites across 16 files (orderbuilder, client tests, command tests)
- Remove local definitions from `equity.go`, `order_test.go`, and `accounts_test.go`