### PR TITLE
docs(skills): refactor skill files for token efficiency and accuracy

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -2,33 +2,25 @@
 
 CLI tool for AI agents to trade via Charles Schwab APIs. Single binary, JSON output.
 
-> **Disclaimer:** This project is not affiliated with, endorsed by, or sponsored by Charles Schwab & Co., Inc. or any of its subsidiaries. "Schwab" and "thinkorswim" are trademarks of Charles Schwab & Co., Inc.
-
-## Install
-
-```bash
-go install github.com/major/schwab-agent/cmd/schwab-agent@latest
-```
-
-Pre-built binaries for Linux and macOS (amd64/arm64) are on the [releases page](https://github.com/major/schwab-agent/releases).
-
 ## Skill Files
 
 | File | Covers |
 |------|--------|
 | schwab-config-auth.md | Authentication, configuration, environment variables |
-| schwab-read.md | Quotes, option chains, price history, accounts, instruments, transactions, movers, market hours, option symbol build/parse |
-| schwab-trade.md | Order placement, preview, cancel, replace, safety workflow |
-| schwab-order-builder.md | Order construction: equity, option, bracket, OCO, vertical, iron condor, straddle, strangle, covered call |
-| schwab-ta.md | Technical analysis indicators: SMA, EMA, RSI, MACD, ATR, Bollinger Bands, Stochastic, ADX, VWAP, HV |
+| schwab-read.md | Quotes, option chains, chain expirations, price history, accounts, instruments, transactions, movers, market hours, option symbol build/parse |
+| schwab-trade.md | Order listing, placement, preview, cancel, replace, repeat, safety workflow |
+| schwab-order-builder.md | Order construction: equity, option, bracket, OCO, vertical, iron condor, straddle, strangle, covered call, collar, calendar, diagonal, FTS |
+| schwab-ta.md | Technical analysis: SMA, EMA, RSI, MACD, ATR, Bollinger Bands, Stochastic, ADX, VWAP, HV, expected move |
 
 ## Output Format
 
-All commands return JSON.
+All commands return JSON envelopes (except `schema`, `order build`, `symbol build/parse` which return raw JSON).
 
-- Success: `{"data": ..., "metadata": {...}}`
-- Errors: `{"error": {"code": ..., "message": ..., "details": ...}}`
+- Success: `{"data": ..., "metadata": {"timestamp": "..."}}`
+- Error: `{"error": {"code": "...", "message": "...", "details": "..."}}`
 - Partial: `{"data": ..., "errors": [...], "metadata": {...}}`
+
+Error codes: AUTH_REQUIRED, AUTH_EXPIRED, AUTH_CALLBACK, ORDER_REJECTED, SYMBOL_NOT_FOUND, ACCOUNT_NOT_FOUND, HTTP_ERROR, VALIDATION_ERROR, ORDER_BUILD_ERROR
 
 ## Global Flags
 

--- a/skills/schwab-config-auth.md
+++ b/skills/schwab-config-auth.md
@@ -1,73 +1,50 @@
 # Configuration and Authentication
 
-schwab-agent uses OAuth2 to authenticate with the Schwab API. Credentials are stored in a local config file and tokens are refreshed automatically.
-
-## Login
-
-Start the OAuth2 flow. Opens a browser for Schwab authentication, receives the callback, and stores tokens locally. Tokens are refreshed automatically before expiration.
+## Auth Commands
 
 ```bash
-schwab-agent auth login
+schwab-agent auth login              # Start OAuth2 flow (opens browser, stores tokens)
+schwab-agent auth login --no-browser # Print auth URL instead of opening browser
+schwab-agent auth status             # Check token and refresh token expiration
+schwab-agent auth refresh            # Force token refresh without re-authenticating
 ```
 
-## Status
-
-Check current token expiration and refresh token staleness:
-
-```bash
-schwab-agent auth status
-```
-
-## Refresh
-
-Force a token refresh without re-authenticating:
-
-```bash
-schwab-agent auth refresh
-```
+Auth commands skip the global auth check (no existing token needed to run them).
 
 ## Configuration
 
-Config file location: `~/.config/schwab-agent/config.json`
+Config file: `~/.config/schwab-agent/config.json`
 
 | Field | Description |
 |-------|-------------|
 | `client_id` | Schwab app client ID |
 | `client_secret` | Schwab app client secret |
-| `base_url` | Outbound base URL for REST API calls and OAuth authorize/token requests (default: `https://api.schwabapi.com`) |
-| `base_url_insecure` | Set to `true` to skip TLS verification for outbound proxy calls that use a local self-signed certificate |
-| `callback_url` | OAuth2 callback URL (default: https://127.0.0.1:8182) |
+| `base_url` | Outbound base URL for REST API and OAuth requests (default: `https://api.schwabapi.com`). Derives authorize, token, and API endpoints. |
+| `base_url_insecure` | Skip TLS verification for outbound calls (for local proxies with self-signed certs) |
+| `callback_url` | OAuth2 callback URL (default: `https://127.0.0.1:8182`) |
 | `default_account` | Default account hash for commands that need an account |
-| `i-also-like-to-live-dangerously` | Set to true to enable mutable operations (order placement, cancel, replace) |
+| `i-also-like-to-live-dangerously` | Enable mutable operations (order place/cancel/replace) |
 
-`base_url` is the single source of truth for outbound Schwab traffic. `schwab-agent` derives the OAuth authorize URL (`<base_url>/v1/oauth/authorize`) and token/refresh URL (`<base_url>/v1/oauth/token`) from it, and also uses the same base URL for authenticated REST API requests.
-
-Default callback URL: `https://127.0.0.1:8182`
-
-Set a default account to avoid passing `--account` on every command:
-
-```bash
-schwab-agent account set-default <hash-value>
-```
+Set a default account: `schwab-agent account set-default <hash-value>`
 
 ## Environment Variables
 
-Environment variables take priority over config file values.
+Override config file values (higher priority).
 
-| Variable | Description |
-|----------|-------------|
-| `SCHWAB_CLIENT_ID` | Override client ID from config file |
-| `SCHWAB_CLIENT_SECRET` | Override client secret from config file |
-| `SCHWAB_BASE_URL` | Override outbound REST/OAuth base URL |
-| `SCHWAB_BASE_URL_INSECURE` | Override insecure TLS mode for local self-signed proxies (`true`/`false`) |
-| `SCHWAB_CALLBACK_URL` | Override callback URL (default: https://127.0.0.1:8182) |
+| Variable | Overrides |
+|----------|-----------|
+| `SCHWAB_CLIENT_ID` | `client_id` |
+| `SCHWAB_CLIENT_SECRET` | `client_secret` |
+| `SCHWAB_BASE_URL` | `base_url` |
+| `SCHWAB_BASE_URL_INSECURE` | `base_url_insecure` |
+| `SCHWAB_CALLBACK_URL` | `callback_url` |
 
 ## Troubleshooting
 
 | Problem | Fix |
 |---------|-----|
-| "auth required" error | Run `schwab-agent auth login` to get new tokens |
-| "auth expired" error | Refresh token is stale (>6.5 days old), run `schwab-agent auth login` again |
-| "callback error" | Check callback URL matches Schwab app settings (default: https://127.0.0.1:8182) |
-| TLS/certificate error with a local proxy | Set `base_url` to the proxy URL and `base_url_insecure` / `SCHWAB_BASE_URL_INSECURE` to `true` if the proxy uses a self-signed certificate |
-| Missing credentials | Set SCHWAB_CLIENT_ID and SCHWAB_CLIENT_SECRET env vars, or add them to config.json |
+| "auth required" | Run `schwab-agent auth login` |
+| "auth expired" | Refresh token stale (>6.5 days), run `auth login` again |
+| "callback error" | Verify callback URL matches Schwab app settings |
+| TLS/certificate error with proxy | Set `base_url` to proxy URL, enable `base_url_insecure` |
+| Missing credentials | Set `SCHWAB_CLIENT_ID` and `SCHWAB_CLIENT_SECRET` env vars, or add to config.json |

--- a/skills/schwab-order-builder.md
+++ b/skills/schwab-order-builder.md
@@ -1,74 +1,34 @@
 # Order Construction
 
-Build order JSON payloads offline without making API calls. Use these builders to inspect payloads before placing, or pipe output to `order place --spec -` or `order preview --spec -`.
+`order build` outputs raw JSON (not envelope-wrapped) and makes no API call. Pipe output to `order place --spec - --confirm` or `order preview --spec -`.
 
-## Building Orders Offline
-
-`order build` outputs raw JSON (not envelope-wrapped) and makes no API call. Useful for inspecting the payload before placing.
+## Equity Orders
 
 ```bash
 schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --duration DAY
 ```
 
-Sub-types: equity, option, bracket, oco, vertical, iron-condor, straddle, strangle, covered-call, calendar, diagonal, collar.
+## Option Orders
+
+```bash
+schwab-agent order build option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
+```
 
 ## Bracket Orders
 
-Bracket orders combine an entry with one or two automatic exit orders.
-
-### Entry with take-profit + stop-loss
+Entry + automatic exit orders. At least one of `--take-profit` or `--stop-loss` required. Exit instructions auto-inverted (BUY entry becomes SELL exit). Cancel cascades to children. Replace not supported for brackets.
 
 ```bash
-schwab-agent order place bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120 --confirm
+schwab-agent order build bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
 ```
-
-### Entry with stop-loss only (protective stop)
-
-Buy a stock and automatically place a stop-loss that activates when the entry fills. No need to wait for fill and manually add a stop.
-
-```bash
-schwab-agent order place bracket --symbol NVDA --action BUY --quantity 10 --type LIMIT --price 130 --stop-loss 120 --confirm
-```
-
-### Entry with take-profit only
-
-```bash
-schwab-agent order place bracket --symbol NVDA --action BUY --quantity 10 --type LIMIT --price 130 --take-profit 150 --confirm
-```
-
-At least one of `--take-profit` or `--stop-loss` is required. Exit instructions are auto-inverted (BUY entry becomes SELL exit). Canceling cascades to all child orders. Replace is not supported for brackets - cancel and re-place instead.
 
 ## OCO Orders (One-Cancels-Other)
 
-OCO orders are for **existing positions**. Unlike bracket orders (which include an entry leg), OCO places exit orders against shares or options you already hold. When one exit fills, the other is automatically canceled.
-
-### Full OCO (take-profit + stop-loss)
+For **existing positions** only (no entry leg). When one exit fills, the other is canceled. At least one of `--take-profit` or `--stop-loss` required.
 
 ```bash
-schwab-agent order place oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140 --confirm
+schwab-agent order build oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
 ```
-
-### Stop-loss only
-
-```bash
-schwab-agent order place oco --symbol AAPL --action SELL --quantity 50 --stop-loss 140 --confirm
-```
-
-### Take-profit only
-
-```bash
-schwab-agent order place oco --symbol AAPL --action SELL --quantity 50 --take-profit 160 --confirm
-```
-
-### Closing a short position
-
-For shorts, the action is BUY and price relationships are inverted (take-profit below current price, stop-loss above):
-
-```bash
-schwab-agent order place oco --symbol TSLA --action BUY --quantity 25 --take-profit 100 --stop-loss 200 --confirm
-```
-
-### OCO vs Bracket
 
 | | Bracket | OCO |
 |---|---|---|
@@ -76,179 +36,147 @@ schwab-agent order place oco --symbol TSLA --action BUY --quantity 25 --take-pro
 | Use case | New position + automatic exits | Protect existing position |
 | Structure | TRIGGER -> OCO/SINGLE | OCO (two SINGLE children) or standalone SINGLE |
 
-At least one of `--take-profit` or `--stop-loss` is required. Price validation ensures take-profit and stop-loss are on the correct side (SELL: TP > SL; BUY: TP < SL).
+For shorts, action is BUY and price relationships invert (take-profit below, stop-loss above current price).
 
 ## Multi-Leg Option Strategies
 
-Named strategy builders that encode all the domain knowledge (instructions, order type, OCC symbols) so the LLM doesn't have to. Build offline, then place via spec mode.
+All output raw JSON. Place via: `schwab-agent order build <type> ... | schwab-agent order place --spec - --confirm`
 
-### Covered Call (IMPORTANT: read carefully)
+### Covered Call
 
-There are two different situations for covered calls:
+**Selling a call against shares you ALREADY OWN**: use regular option command (`order place option --action SELL_TO_OPEN --call ...`).
 
-**Selling a call against shares you ALREADY OWN** - this is just a single-leg option sell. Use the regular option command:
-
-```bash
-schwab-agent order place option --underlying F --expiration 2026-06-18 --strike 14 --call \
-  --action SELL_TO_OPEN --quantity 1 --type LIMIT --price 0.50 --confirm
-```
-
-**Buying shares AND selling a call in one atomic order** (new position) - use `covered-call`:
+**Buying shares AND selling a call in one atomic order** (new position):
 
 ```bash
-schwab-agent order build covered-call --underlying F --expiration 2026-06-18 --strike 14 \
-  --quantity 1 --price 12.00 | schwab-agent order preview --spec -
+schwab-agent order build covered-call --underlying F --expiration 2026-06-18 --strike 14 --quantity 1 --price 12.00
 ```
 
-- `--quantity 1` = 100 shares + 1 call contract (1 contract always = 100 shares)
-- `--price` = net debit (what you pay total per share after subtracting call premium)
-- Always NET_DEBIT, always BUY shares + SELL_TO_OPEN call
-- Uses Schwab's `COVERED` complex order strategy type
+`--quantity 1` = 100 shares + 1 call contract. `--price` = net debit per share after call premium. Always NET_DEBIT, BUY shares + SELL_TO_OPEN call.
 
 ### Vertical Spread
 
-Two-leg spread (bull call, bear call, bull put, bear put). Order type auto-determined from strikes.
-
 ```bash
-# Bull call spread (debit): buy lower strike, sell higher strike
-schwab-agent order build vertical --underlying F --expiration 2026-06-18 \
-  --long-strike 12 --short-strike 14 --call --open --quantity 1 --price 0.50
-
-# Bear put spread (debit): buy higher strike, sell lower strike
-schwab-agent order build vertical --underlying F --expiration 2026-06-18 \
-  --long-strike 14 --short-strike 12 --put --open --quantity 1 --price 0.50
+schwab-agent order build vertical --underlying F --expiration 2026-06-18 --long-strike 12 --short-strike 14 --call --open --quantity 1 --price 0.50
 ```
 
-- `--long-strike` = the strike you're buying, `--short-strike` = the strike you're selling
-- `--open` / `--close` controls TO_OPEN vs TO_CLOSE instructions
-- NET_DEBIT or NET_CREDIT is auto-determined from strike relationship
+`--long-strike` = strike bought, `--short-strike` = strike sold. NET_DEBIT or NET_CREDIT auto-determined from strike relationship.
 
 ### Iron Condor
 
-Four-leg strategy. Strikes must be ordered: put-long < put-short < call-short < call-long.
+Strikes must be ordered: put-long < put-short < call-short < call-long. Opening = NET_CREDIT.
 
 ```bash
-schwab-agent order build iron-condor --underlying F --expiration 2026-06-18 \
-  --put-long-strike 9 --put-short-strike 10 --call-short-strike 14 --call-long-strike 15 \
-  --open --quantity 1 --price 0.50
+schwab-agent order build iron-condor --underlying F --expiration 2026-06-18 --put-long-strike 9 --put-short-strike 10 --call-short-strike 14 --call-long-strike 15 --open --quantity 1 --price 0.50
 ```
-
-- Opening = NET_CREDIT (collecting premium), closing = NET_DEBIT
 
 ### Straddle
 
-Two legs at the same strike (one call + one put).
+Same strike, one call + one put.
 
 ```bash
-# Long straddle (buy both)
-schwab-agent order build straddle --underlying F --expiration 2026-06-18 \
-  --strike 12 --buy --open --quantity 1 --price 1.50
-
-# Short straddle (sell both)
-schwab-agent order build straddle --underlying F --expiration 2026-06-18 \
-  --strike 12 --sell --open --quantity 1 --price 1.50
+schwab-agent order build straddle --underlying F --expiration 2026-06-18 --strike 12 --buy --open --quantity 1 --price 1.50
 ```
 
 ### Strangle
 
-Two legs at different strikes (one call + one put).
+Different strikes, one call + one put.
 
 ```bash
-schwab-agent order build strangle --underlying F --expiration 2026-06-18 \
-  --call-strike 14 --put-strike 10 --buy --open --quantity 1 --price 0.50
+schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-strike 14 --put-strike 10 --buy --open --quantity 1 --price 0.50
 ```
 
 ### Calendar Spread
 
-Sells a near-term option and buys a longer-term option at the same strike. Useful for income strategies and volatility plays.
+Same strike, different expirations. Sells near-term, buys far-term.
 
 ```bash
-schwab-agent order build calendar --underlying F \
-  --near-expiration 2026-05-16 --far-expiration 2026-07-17 --strike 12 --call \
-  --open --quantity 1 --price 0.50
+schwab-agent order build calendar --underlying F --near-expiration 2026-05-16 --far-expiration 2026-07-17 --strike 12 --call --open --quantity 1 --price 0.50
 ```
-
-- `--near-expiration` = the expiration being sold (must be earlier than far)
-- `--far-expiration` = the expiration being bought (must be later than near)
-- `--strike` = same strike for both legs
-- `--call` / `--put` = contract type
-- `--open` / `--close` controls TO_OPEN vs TO_CLOSE instructions
 
 ### Diagonal Spread
 
-Like a calendar spread but with different strikes per leg. Combines time decay and directional bias.
+Different strikes AND different expirations.
 
 ```bash
-schwab-agent order build diagonal --underlying F \
-  --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 \
-  --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50
+schwab-agent order build diagonal --underlying F --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50
 ```
-
-- `--near-strike` = strike being sold (near-term)
-- `--far-strike` = strike being bought (far-term)
-- `--near-expiration` = near-term expiration (must be earlier than far)
-- `--far-expiration` = far-term expiration (must be later than near)
-- `--call` / `--put` = contract type
-- `--open` / `--close` controls TO_OPEN vs TO_CLOSE instructions
 
 ### Collar
 
-Protective collar: long stock + long put + short call. Limits downside while capping upside.
+Long stock + long put + short call. Limits downside, caps upside.
 
 ```bash
-schwab-agent order build collar --underlying F --put-strike 10 --call-strike 14 \
-  --expiration 2026-06-18 --quantity 1 --open --price 12.00
+schwab-agent order build collar --underlying F --put-strike 10 --call-strike 14 --expiration 2026-06-18 --quantity 1 --open --price 12.00
 ```
 
-- `--quantity 1` = 100 shares + 1 put contract + 1 call contract
-- `--put-strike` = protective put strike (downside protection)
-- `--call-strike` = covered call strike (upside cap)
-- `--expiration` = same expiration for both options
-- `--open` / `--close` controls TO_OPEN vs TO_CLOSE instructions
-- `--price` = net debit (what you pay total per share)
-- Uses Schwab's `COLLAR_WITH_STOCK` complex order strategy type
+`--quantity 1` = 100 shares + 1 put + 1 call. `--price` = net debit per share.
 
-### Placing Multi-Leg Orders
+### First-Triggers-Second (FTS)
 
-All multi-leg builders output raw JSON. To place, pipe through spec mode:
+Combine two order specs: primary order triggers secondary on fill.
 
 ```bash
-schwab-agent order build vertical ... | schwab-agent order place --spec - --confirm
+schwab-agent order build fts --primary @entry.json --secondary @exit.json
+schwab-agent order build fts --primary '{"orderType":"LIMIT",...}' --secondary '{"orderType":"STOP",...}'
 ```
 
-To preview first (recommended):
-
-```bash
-schwab-agent order build vertical ... | schwab-agent order preview --spec -
-```
+Both `--primary` and `--secondary` required. Accept inline JSON, `@file`, or `-` for stdin.
 
 ## Flags Reference
 
+### Core Flags
+
+| Flag | Values | Used with |
+|------|--------|-----------|
+| `--symbol` | Stock ticker | equity, bracket, oco |
+| `--action` | BUY, SELL, BUY_TO_OPEN, BUY_TO_CLOSE, SELL_TO_OPEN, SELL_TO_CLOSE | all |
+| `--quantity` | Number of shares/contracts | all |
+| `--type` | MARKET, LIMIT, STOP, STOP_LIMIT, TRAILING_STOP | equity, bracket |
+| `--price` | Limit price or net debit/credit | LIMIT, STOP_LIMIT, multi-leg |
+| `--stop-price` | Stop trigger price | STOP, STOP_LIMIT |
+| `--duration` | DAY, GOOD_TILL_CANCEL, FILL_OR_KILL, IMMEDIATE_OR_CANCEL, END_OF_WEEK, END_OF_MONTH, NEXT_END_OF_MONTH | all |
+| `--session` | NORMAL, AM, PM, SEAMLESS | all |
+
+### Exit Flags
+
 | Flag | Description | Used with |
 |------|-------------|-----------|
-| `--symbol` | Stock ticker | equity, bracket |
-| `--action` | BUY, SELL, BUY_TO_OPEN, SELL_TO_CLOSE, etc. | all |
-| `--quantity` | Number of shares or contracts | all |
-| `--type` | MARKET, LIMIT, STOP, STOP_LIMIT | equity, bracket |
-| `--price` | Limit price | LIMIT, STOP_LIMIT |
-| `--stop-price` | Stop trigger price | STOP, STOP_LIMIT |
 | `--take-profit` | Take-profit price (at least one exit required) | bracket, oco |
 | `--stop-loss` | Stop-loss price (at least one exit required) | bracket, oco |
-| `--underlying` | Underlying symbol | option, multi-leg strategies |
-| `--expiration` | Option expiration (YYYY-MM-DD) | option, multi-leg strategies |
+
+### Option Flags
+
+| Flag | Description | Used with |
+|------|-------------|-----------|
+| `--underlying` | Underlying symbol | option, all multi-leg |
+| `--expiration` | Expiration date YYYY-MM-DD | option, vertical, iron-condor, straddle, strangle, covered-call, collar |
 | `--strike` | Strike price | option, straddle, covered-call, calendar |
-| `--call` / `--put` | Contract type | option, vertical, calendar, diagonal |
+| `--call` / `--put` | Contract type (mutually exclusive) | option, vertical, calendar, diagonal |
 | `--buy` / `--sell` | Direction | straddle, strangle |
 | `--open` / `--close` | Opening or closing position | vertical, iron-condor, straddle, strangle, calendar, diagonal, collar |
-| `--long-strike` / `--short-strike` | Strikes for legs being bought/sold | vertical |
-| `--call-strike` / `--put-strike` | Separate strikes per leg | strangle, iron-condor, collar |
-| `--near-strike` / `--far-strike` | Strikes for near/far legs | diagonal |
-| `--near-expiration` / `--far-expiration` | Expirations for near/far legs | calendar, diagonal |
-| `--put-strike` / `--call-strike` | Put and call strikes | collar |
-| `--destination` | Exchange routing (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) | equity, option |
-| `--price-link-basis` | Price link basis (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) | equity, option |
-| `--price-link-type` | Price link type (VALUE, PERCENT, TICK) | equity, option |
-| `--confirm` | Actually execute (omit to preview) | all mutable |
-| `--account` | Account hash (uses default if set) | all |
-| `--session` | NORMAL, AM, PM, SEAMLESS | all |
-| `--duration` | DAY, GOOD_TILL_CANCEL, FILL_OR_KILL, IMMEDIATE_OR_CANCEL, END_OF_WEEK, END_OF_MONTH, NEXT_END_OF_MONTH | all |
+| `--long-strike` / `--short-strike` | Strikes bought/sold | vertical |
+| `--call-strike` / `--put-strike` | Per-leg strikes | strangle, iron-condor, collar |
+| `--near-strike` / `--far-strike` | Near/far leg strikes | diagonal |
+| `--near-expiration` / `--far-expiration` | Near/far leg expirations | calendar, diagonal |
+| `--put-long-strike` / `--put-short-strike` | Put wing strikes | iron-condor |
+| `--call-short-strike` / `--call-long-strike` | Call wing strikes | iron-condor |
+
+### Trailing Stop Flags
+
+| Flag | Values | Default |
+|------|--------|---------|
+| `--stop-offset` | Trailing stop offset amount | - |
+| `--stop-link-basis` | LAST, BID, ASK, MARK | LAST |
+| `--stop-link-type` | VALUE, PERCENT, TICK | VALUE |
+| `--stop-type` | STANDARD, BID, ASK, LAST, MARK | STANDARD |
+| `--activation-price` | Price that activates the trailing stop | - |
+
+### Advanced Flags
+
+| Flag | Values | Used with |
+|------|--------|-----------|
+| `--special-instruction` | ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE | equity, option |
+| `--destination` | INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO | equity, option |
+| `--price-link-basis` | MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE | equity, option |
+| `--price-link-type` | VALUE, PERCENT, TICK | equity, option |

--- a/skills/schwab-read.md
+++ b/skills/schwab-read.md
@@ -1,72 +1,44 @@
 # Market Data and Account Information
 
-Read-only commands for quotes, option chains, price history, accounts, instruments, transactions, movers, market hours, and option symbol utilities. None of these commands modify your account.
+Read-only commands. None of these modify your account.
 
 ## Option Symbols
 
-Build and parse OCC-format option symbols locally (no API call, no authentication required).
-
-### Build a symbol
+Build and parse OCC-format option symbols locally (no API call, no auth required).
 
 ```bash
 schwab-agent symbol build --underlying AAPL --expiration 2025-06-20 --strike 200 --call
-schwab-agent symbol build --underlying SPY --expiration 2025-12-19 --strike 450.50 --put
-```
-
-| Flag | Description |
-|------|-------------|
-| `--underlying` | Underlying stock ticker (required) |
-| `--expiration` | Expiration date in YYYY-MM-DD format (required) |
-| `--strike` | Strike price (required) |
-| `--call` | Call contract |
-| `--put` | Put contract |
-
-One of `--call` or `--put` is required (mutually exclusive).
-
-### Parse a symbol
-
-```bash
 schwab-agent symbol parse "AAPL  250620C00200000"
 ```
 
-Takes a single OCC symbol (21 characters, space-padded underlying) and returns its components.
+Flags: `--underlying` (req), `--expiration YYYY-MM-DD` (req), `--strike` (req), `--call`/`--put` (one required, mutually exclusive).
 
-### Output format
-
-Both subcommands return the same JSON shape:
+Output (both subcommands, raw JSON not envelope-wrapped):
 
 ```json
-{
-  "data": {
-    "symbol": "AAPL  250620C00200000",
-    "underlying": "AAPL",
-    "expiration": "2025-06-20",
-    "put_call": "CALL",
-    "strike": 200
-  },
-  "metadata": {"timestamp": "..."}
-}
+{"symbol": "AAPL  250620C00200000", "underlying": "AAPL", "expiration": "2025-06-20", "put_call": "CALL", "strike": 200}
 ```
 
 ## Quotes
 
 ```bash
 schwab-agent quote get AAPL
-schwab-agent quote get AAPL NVDA TSLA MSFT
+schwab-agent quote get AAPL NVDA TSLA --fields quote,fundamental --indicative
 ```
 
-Key output fields: last price, bid/ask, volume, 52-week high/low, PE ratio, dividend yield, market cap.
+| Flag | Description |
+|------|-------------|
+| `--fields` | Repeatable or comma-separated: quote, fundamental, extended, reference, regular |
+| `--indicative` | Request indicative (non-tradeable) quotes |
+
+Multi-symbol requests use partial response if some symbols are missing. Key output fields: last price, bid/ask, volume, 52-week high/low, PE ratio, dividend yield, market cap.
 
 ## Option Chains
 
 ```bash
 schwab-agent chain get AAPL
-schwab-agent chain get AAPL --type CALL
-schwab-agent chain get AAPL --type PUT --from-date 2026-05-01 --to-date 2026-05-31
-schwab-agent chain get AAPL --strike-count 5
-schwab-agent chain get AAPL --strike 150.0 --strike-range NTM
+schwab-agent chain get AAPL --type CALL --strike-count 5 --from-date 2026-05-01 --to-date 2026-05-31
 schwab-agent chain get AAPL --strategy ANALYTICAL --volatility 30.5 --underlying-price 148.50 --interest-rate 4.5 --days-to-expiration 45
-schwab-agent chain get AAPL --include-underlying-quote
 schwab-agent chain expiration AAPL
 ```
 
@@ -74,17 +46,18 @@ schwab-agent chain expiration AAPL
 |------|-------------|
 | `--type` | CALL, PUT, or ALL (default) |
 | `--strike-count` | Number of strikes above/below ATM |
-| `--from-date` | Filter expirations from date (YYYY-MM-DD) |
-| `--to-date` | Filter expirations to date (YYYY-MM-DD) |
+| `--from-date` / `--to-date` | Filter expirations (YYYY-MM-DD) |
 | `--strategy` | SINGLE, ANALYTICAL, COVERED, etc. |
-| `--include-underlying-quote` | Include underlying quote data in response |
+| `--include-underlying-quote` | Include underlying quote data |
 | `--interval` | Strike interval for spread strategy chains |
-| `--strike` | Filter to a specific strike price |
-| `--strike-range` | Moneyness filter: ITM, NTM, OTM, SAK, SBK, SNK, ALL |
-| `--volatility` | Volatility for theoretical pricing (use with ANALYTICAL strategy) |
-| `--underlying-price` | Override underlying price for theoretical calculations |
-| `--interest-rate` | Interest rate for theoretical pricing calculations |
-| `--days-to-expiration` | Days to expiration for theoretical pricing calculations |
+| `--strike` | Filter to specific strike price |
+| `--strike-range` | ITM, NTM, OTM, SAK, SBK, SNK, ALL |
+| `--volatility` | Volatility for theoretical pricing (with ANALYTICAL) |
+| `--underlying-price` | Override underlying price for theoretical calcs |
+| `--interest-rate` | Interest rate for theoretical pricing |
+| `--days-to-expiration` | DTE for theoretical pricing |
+
+`chain expiration <symbol>` returns available expiration dates without the full chain data.
 
 ## Price History
 
@@ -97,94 +70,72 @@ schwab-agent history get AAPL --from 1704067200000 --to 1713657600000
 | Flag | Description |
 |------|-------------|
 | `--period-type` | day, month, year, ytd |
-| `--period` | Number of periods (e.g., 3 for 3 months) |
+| `--period` | Number of periods |
 | `--frequency-type` | minute, daily, weekly, monthly |
-| `--frequency` | Frequency interval (e.g., 1 for every day) |
-| `--from` | Start time in milliseconds since epoch |
-| `--to` | End time in milliseconds since epoch |
-
-Tip: Convert dates to epoch ms with `date -d "2026-01-01" +%s000` (Linux) or `date -j -f "%Y-%m-%d" "2026-01-01" +%s000` (macOS).
+| `--frequency` | Frequency interval |
+| `--from` / `--to` | Start/end time in milliseconds since epoch |
 
 ## Accounts
 
 ```bash
-schwab-agent account list
-schwab-agent account get <hash-value>
-schwab-agent account numbers
-schwab-agent account set-default <hash-value>
+schwab-agent account list                    # All accounts (enriched with nicknames)
+schwab-agent account list --positions        # Include current positions
+schwab-agent account get <hash> --positions  # Single account with positions
+schwab-agent account numbers                 # Account numbers and hash values
+schwab-agent account set-default <hash>      # Set default account
 ```
 
-Account list and get enrich results with nicknames and primary account flags from the preferences API. This happens automatically and degrades gracefully if the preferences API is unavailable.
+Account list and get enrich results with nicknames from the preferences API (best-effort, degrades gracefully).
 
 ## Instruments
 
 ```bash
-schwab-agent instrument search AAPL
 schwab-agent instrument search AAPL --projection fundamental
 schwab-agent instrument search "Apple" --projection symbol-search
-schwab-agent instrument get 037833100
+schwab-agent instrument get 037833100    # By CUSIP
 ```
 
-| Projection | Description |
-|-----------|-------------|
-| `symbol-search` | Search by symbol or name substring |
-| `symbol-regex` | Search using regex pattern |
-| `desc-search` | Search by description substring |
-| `desc-regex` | Search by description regex |
-| `search` | General search across instruments |
-| `fundamental` | Return fundamental data (PE, dividend, etc.) |
+Projections: symbol-search, symbol-regex, desc-search, desc-regex, search, fundamental.
 
 ## Transactions
 
-Transactions are account-scoped and live under the `account` command. They inherit the `--account` flag from the parent.
+Account-scoped, under the `account` command. Inherits `--account` flag.
 
 ```bash
-schwab-agent account transaction list
-schwab-agent account transaction list --types TRADE
-schwab-agent account transaction list --from 2026-01-01 --to 2026-04-21
+schwab-agent account transaction list --types TRADE --from 2026-01-01 --to 2026-04-21
 schwab-agent account transaction get 123456789
 ```
 
-Flags: `--types` (TRADE/DIVIDEND/etc.), `--from`, `--to`, `--symbol`, `--account` (inherited from parent)
+Flags: `--types` (TRADE, DIVIDEND, etc.), `--from`, `--to`, `--symbol`.
 
 ## Market
 
-### Hours
-
 ```bash
-schwab-agent market hours
-schwab-agent market hours equity
+schwab-agent market hours              # All markets
+schwab-agent market hours equity       # Specific market (equity, option, bond, future, forex)
+schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
+schwab-agent market movers EQUITY_ALL --sort VOLUME --frequency 5
 ```
 
-Available markets: equity, option, bond, future, forex
-
-### Movers
-
-```bash
-schwab-agent market movers '$SPX'
-schwab-agent market movers '$DJI' --sort PERCENT_CHANGE_UP
-schwab-agent market movers EQUITY_ALL --sort VOLUME
-```
-
-Flags: `--sort` (VOLUME/TRADES/PERCENT_CHANGE_UP/PERCENT_CHANGE_DOWN), `--frequency` (0/1/5/10/30/60)
+Movers flags: `--sort` (VOLUME, TRADES, PERCENT_CHANGE_UP, PERCENT_CHANGE_DOWN), `--frequency` (0, 1, 5, 10, 30, 60).
 
 ## Recipes
 
 | Intent | Command |
 |--------|---------|
-| "What's AAPL trading at?" | `schwab-agent quote get AAPL` |
-| "Get quotes for my watchlist" | `schwab-agent quote get AAPL NVDA TSLA MSFT` |
-| "What options expire next month?" | `schwab-agent chain expiration AAPL` |
-| "Show AAPL calls" | `schwab-agent chain get AAPL --type CALL` |
-| "Near-the-money AAPL options" | `schwab-agent chain get AAPL --strike-range NTM` |
-| "Theoretical pricing for AAPL" | `schwab-agent chain get AAPL --strategy ANALYTICAL --volatility 30 --days-to-expiration 45` |
-| "Options at the $150 strike" | `schwab-agent chain get AAPL --strike 150.0` |
-| "Last 3 months daily prices" | `schwab-agent history get AAPL --period-type month --period 3` |
-| "What accounts do I have?" | `schwab-agent account numbers` |
-| "Show my account details" | `schwab-agent account list` |
-| "Find a stock by name" | `schwab-agent instrument search "Apple" --projection symbol-search` |
-| "Show all trades this year" | `schwab-agent account transaction list --types TRADE --from 2026-01-01` |
-| "What are the top movers?" | `schwab-agent market movers $SPX.X` |
-| "Is the market open?" | `schwab-agent market hours equity` |
-| "Build an option symbol" | `schwab-agent symbol build --underlying AAPL --expiration 2025-06-20 --strike 200 --call` |
-| "Parse this OCC symbol" | `schwab-agent symbol parse "AAPL  250620C00200000"` |
+| "What's AAPL trading at?" | `quote get AAPL` |
+| "Get quotes for my watchlist" | `quote get AAPL NVDA TSLA MSFT` |
+| "Fundamental data for AAPL" | `quote get AAPL --fields fundamental` |
+| "What options expire next month?" | `chain expiration AAPL` |
+| "Show AAPL calls" | `chain get AAPL --type CALL` |
+| "Near-the-money AAPL options" | `chain get AAPL --strike-range NTM` |
+| "Theoretical pricing for AAPL" | `chain get AAPL --strategy ANALYTICAL --volatility 30 --days-to-expiration 45` |
+| "Last 3 months daily prices" | `history get AAPL --period-type month --period 3` |
+| "Show my accounts with positions" | `account list --positions` |
+| "What accounts do I have?" | `account numbers` |
+| "Find a stock by name" | `instrument search "Apple" --projection symbol-search` |
+| "Show all trades this year" | `account transaction list --types TRADE --from 2026-01-01` |
+| "What are the top movers?" | `market movers $SPX.X` |
+| "Is the market open?" | `market hours equity` |
+| "Build an option symbol" | `symbol build --underlying AAPL --expiration 2025-06-20 --strike 200 --call` |
+| "Parse this OCC symbol" | `symbol parse "AAPL  250620C00200000"` |

--- a/skills/schwab-ta.md
+++ b/skills/schwab-ta.md
@@ -4,8 +4,6 @@ Eleven indicators computed locally from Schwab price history. Pattern: `schwab-a
 
 ## Shared Flags
 
-All indicators accept these flags:
-
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--interval` | daily | daily, weekly, 1min, 5min, 15min, 30min |
@@ -13,65 +11,25 @@ All indicators accept these flags:
 
 Most indicators also accept `--period` (lookback window). Exceptions noted below.
 
-## Indicators
+## Standard Indicators
 
-### SMA - Simple Moving Average
+All use `--period` for lookback window. Output is a time series with `datetime` plus indicator-specific keys.
 
-```bash
-schwab-agent ta sma AAPL
-schwab-agent ta sma AAPL --period 200 --interval daily --points 10
-```
+| Indicator | Command | Period Default | Output Keys | Interpretation |
+|-----------|---------|---------------|-------------|----------------|
+| SMA | `ta sma` | 20 | `sma` | Simple moving average |
+| EMA | `ta ema` | 20 | `ema` | Exponential moving average |
+| RSI | `ta rsi` | 14 | `rsi` | 0-100. >70 overbought, <30 oversold |
+| ATR | `ta atr` | 14 | `atr` | Volatility in price units. Higher = wider swings |
+| ADX | `ta adx` | 14 | `adx`, `plus_di`, `minus_di` | >25 trending, <20 ranging. plus/minus_di show directional bias |
 
-`--period` default: 20
+Example: `schwab-agent ta rsi AAPL --period 9 --interval 5min --points 20`
 
-### EMA - Exponential Moving Average
+## MACD - Moving Average Convergence/Divergence
 
-```bash
-schwab-agent ta ema AAPL
-schwab-agent ta ema AAPL --period 26 --interval daily --points 5
-```
-
-`--period` default: 20
-
-### RSI - Relative Strength Index
-
-Values 0-100. Above 70 = conventionally overbought, below 30 = oversold.
+Uses `--fast`/`--slow`/`--signal` instead of `--period`.
 
 ```bash
-schwab-agent ta rsi AAPL
-schwab-agent ta rsi AAPL --period 9 --interval daily --points 20
-```
-
-`--period` default: 14
-
-### ATR - Average True Range
-
-Measures volatility in price units (not percent). Higher ATR = wider daily swings.
-
-```bash
-schwab-agent ta atr AAPL
-schwab-agent ta atr AAPL --period 7 --interval daily --points 5
-```
-
-`--period` default: 14
-
-### ADX - Average Directional Index
-
-Trend strength (not direction). `plus_di`/`minus_di` indicate directional bias. Above 25 = trending, below 20 = ranging.
-
-```bash
-schwab-agent ta adx AAPL
-schwab-agent ta adx AAPL --period 14 --interval daily --points 10
-```
-
-`--period` default: 14. Output includes `adx`, `plus_di`, `minus_di`.
-
-### MACD - Moving Average Convergence/Divergence
-
-Uses `--fast`/`--slow`/`--signal` instead of `--period`. Histogram = macd - signal.
-
-```bash
-schwab-agent ta macd AAPL
 schwab-agent ta macd AAPL --fast 12 --slow 26 --signal 9 --points 10
 ```
 
@@ -81,25 +39,19 @@ schwab-agent ta macd AAPL --fast 12 --slow 26 --signal 9 --points 10
 | `--slow` | 26 |
 | `--signal` | 9 |
 
-Output includes `macd`, `signal`, `histogram`.
+Output keys: `macd`, `signal`, `histogram` (histogram = macd - signal).
 
-### BBands - Bollinger Bands
-
-Upper, middle (SMA), lower bands. Price near upper = relatively high, near lower = relatively low.
+## BBands - Bollinger Bands
 
 ```bash
-schwab-agent ta bbands AAPL
 schwab-agent ta bbands AAPL --period 20 --std-dev 2.5 --points 10
 ```
 
-`--period` default: 20. `--std-dev` default: 2.0. Output includes `upper`, `middle`, `lower`.
+`--period` default: 20. `--std-dev` default: 2.0. Output keys: `upper`, `middle`, `lower`. Price near upper = relatively high, near lower = relatively low.
 
-### Stoch - Stochastic Oscillator
-
-Slow %K and %D, both 0-100. Crossovers and extremes (above 80 / below 20) are common signals.
+## Stoch - Stochastic Oscillator
 
 ```bash
-schwab-agent ta stoch AAPL
 schwab-agent ta stoch AAPL --k-period 14 --smooth-k 3 --d-period 3 --points 10
 ```
 
@@ -109,46 +61,41 @@ schwab-agent ta stoch AAPL --k-period 14 --smooth-k 3 --d-period 3 --points 10
 | `--smooth-k` | 3 |
 | `--d-period` | 3 |
 
-Output includes `slowk`, `slowd`.
+Output keys: `slowk`, `slowd`. Both 0-100. Above 80 / below 20 are common signal thresholds.
 
-### VWAP - Volume Weighted Average Price
+## VWAP - Volume Weighted Average Price
 
-Cumulative indicator - no `--period` flag. Only `--interval` and `--points`.
+Cumulative indicator, no `--period` flag. Only `--interval` and `--points`.
 
 ```bash
-schwab-agent ta vwap AAPL
 schwab-agent ta vwap AAPL --interval 5min --points 20
 ```
 
-Output includes `vwap`.
+Output key: `vwap`.
 
-### HV - Historical Volatility
+## HV - Historical Volatility
 
-Returns a scalar summary (not a time series). Includes regime classification.
+Scalar summary (not time series). Includes regime classification.
 
 ```bash
-schwab-agent ta hv AAPL
 schwab-agent ta hv AAPL --period 20 --interval daily
 ```
 
-`--period` default: 20. Output fields: `daily_vol`, `weekly_vol`, `monthly_vol`, `annualized_vol`, `percentile_rank`, `regime` (low/normal/high/extreme), `min_vol`, `max_vol`, `mean_vol`.
+`--period` default: 20. Output keys: `daily_vol`, `weekly_vol`, `monthly_vol`, `annualized_vol`, `percentile_rank`, `regime` (low/normal/high/extreme), `min_vol`, `max_vol`, `mean_vol`.
 
-### Expected Move - ATM Straddle Pricing
+## Expected Move - ATM Straddle Pricing
 
-Returns a scalar summary (not a time series). Fetches ATM options from the chain and computes the expected price range.
+Scalar summary (not time series). Fetches ATM options from the chain and computes expected price range.
 
 ```bash
-schwab-agent ta expected-move AAPL
 schwab-agent ta expected-move AAPL --dte 45
 ```
 
-`--dte` default: 30 (target days to expiration for option selection). Output fields: `underlying_price`, `expiration`, `dte`, `straddle_price`, `expected_move`, `adjusted_move`, `upper_1x`, `lower_1x`, `upper_2x`, `lower_2x`.
+`--dte` default: 30 (target days to expiration). Output keys: `underlying_price`, `expiration`, `dte`, `straddle_price`, `expected_move`, `adjusted_move`, `upper_1x`, `lower_1x`, `upper_2x`, `lower_2x`.
 
 ## Output Format
 
-All indicators return the same envelope. The `values` array contains objects with `datetime` plus indicator-specific fields.
-
-Single-value example (SMA, EMA, RSI, ATR):
+Time series indicators return:
 
 ```json
 {
@@ -157,83 +104,31 @@ Single-value example (SMA, EMA, RSI, ATR):
     "symbol": "AAPL",
     "interval": "daily",
     "period": 20,
-    "values": [
-      {"datetime": "2026-04-18", "sma": 198.42},
-      {"datetime": "2026-04-21", "sma": 199.10}
-    ]
+    "values": [{"datetime": "2026-04-18", "sma": 198.42}]
   },
   "metadata": {"timestamp": "2026-04-22T10:00:00Z"}
 }
 ```
 
-Multi-value examples - value keys by indicator:
-
-| Indicator | Value keys |
-|-----------|------------|
-| ADX | `adx`, `plus_di`, `minus_di` |
-| MACD | `macd`, `signal`, `histogram` |
-| BBands | `upper`, `middle`, `lower` |
-| Stoch | `slowk`, `slowd` |
-
-Scalar output examples (HV, Expected Move):
-
-```json
-{
-  "data": {
-    "indicator": "hv",
-    "symbol": "AAPL",
-    "period": 20,
-    "daily_vol": 1.23,
-    "weekly_vol": 2.75,
-    "monthly_vol": 5.62,
-    "annualized_vol": 19.54,
-    "percentile_rank": 42.0,
-    "regime": "normal",
-    "min_vol": 12.10,
-    "max_vol": 38.90,
-    "mean_vol": 21.30
-  },
-  "metadata": {"timestamp": "2026-04-22T10:00:00Z"}
-}
-```
-
-```json
-{
-  "data": {
-    "indicator": "expected-move",
-    "symbol": "AAPL",
-    "underlying_price": 195.50,
-    "expiration": "2026-05-16",
-    "dte": 24,
-    "straddle_price": 9.80,
-    "expected_move": 9.80,
-    "adjusted_move": 8.33,
-    "upper_1x": 203.83,
-    "lower_1x": 187.17,
-    "upper_2x": 212.16,
-    "lower_2x": 178.84
-  },
-  "metadata": {"timestamp": "2026-04-22T10:00:00Z"}
-}
-```
+Scalar indicators (HV, Expected Move) return fields directly in `data` instead of a `values` array.
 
 ## Recipes
 
 | Intent | Command |
 |--------|---------|
-| "Is AAPL overbought?" | `schwab-agent ta rsi AAPL --points 1` |
-| "20-day moving average for AAPL" | `schwab-agent ta sma AAPL --period 20 --points 1` |
-| "50/200-day SMA crossover check" | `schwab-agent ta sma AAPL --period 50 --points 5` then `--period 200 --points 5` |
-| "MACD signal for AAPL" | `schwab-agent ta macd AAPL --points 5` |
-| "How volatile is AAPL?" | `schwab-agent ta atr AAPL --points 1` |
-| "Is AAPL near its Bollinger Band?" | `schwab-agent ta bbands AAPL --points 1` |
-| "Stochastic reading for AAPL" | `schwab-agent ta stoch AAPL --points 1` |
-| "Is AAPL trending or ranging?" | `schwab-agent ta adx AAPL --points 1` |
-| "EMA crossover (12/26) for AAPL" | `schwab-agent ta ema AAPL --period 12 --points 5` then `--period 26 --points 5` |
-| "Intraday RSI on 5-minute bars" | `schwab-agent ta rsi AAPL --interval 5min --points 20` |
-| "Weekly MACD for NVDA" | `schwab-agent ta macd NVDA --interval weekly --points 10` |
-| "Tighten Bollinger Bands to 1.5 std dev" | `schwab-agent ta bbands AAPL --std-dev 1.5 --points 10` |
-| "VWAP for AAPL intraday" | `schwab-agent ta vwap AAPL --interval 5min --points 20` |
-| "Historical volatility regime for AAPL" | `schwab-agent ta hv AAPL` |
-| "Expected move for AAPL next 30 days" | `schwab-agent ta expected-move AAPL` |
-| "Expected move for AAPL next 45 days" | `schwab-agent ta expected-move AAPL --dte 45` |
+| "Is AAPL overbought?" | `ta rsi AAPL --points 1` |
+| "20-day moving average" | `ta sma AAPL --period 20 --points 1` |
+| "50/200-day SMA crossover" | `ta sma AAPL --period 50 --points 5` then `--period 200 --points 5` |
+| "MACD signal" | `ta macd AAPL --points 5` |
+| "How volatile is AAPL?" | `ta atr AAPL --points 1` |
+| "Near Bollinger Band?" | `ta bbands AAPL --points 1` |
+| "Stochastic reading" | `ta stoch AAPL --points 1` |
+| "Trending or ranging?" | `ta adx AAPL --points 1` |
+| "EMA crossover (12/26)" | `ta ema AAPL --period 12 --points 5` then `--period 26 --points 5` |
+| "Intraday RSI (5min)" | `ta rsi AAPL --interval 5min --points 20` |
+| "Weekly MACD" | `ta macd NVDA --interval weekly --points 10` |
+| "Tight Bollinger Bands" | `ta bbands AAPL --std-dev 1.5 --points 10` |
+| "VWAP intraday" | `ta vwap AAPL --interval 5min --points 20` |
+| "Volatility regime" | `ta hv AAPL` |
+| "Expected move (30 days)" | `ta expected-move AAPL` |
+| "Expected move (45 days)" | `ta expected-move AAPL --dte 45` |

--- a/skills/schwab-trade.md
+++ b/skills/schwab-trade.md
@@ -1,113 +1,109 @@
 # Trading and Order Management
 
-Place, preview, cancel, and replace orders. For order construction details (bracket, OCO, multi-leg strategies, flags), see `schwab-order-builder.md`.
-
-## Safety Workflow
-
-Follow this sequence before placing any real order:
-
-1. Check current price: `schwab-agent quote get <symbol>`
-2. Build the order JSON: `schwab-agent order build equity --symbol <SYM> --action BUY --quantity 10 --type LIMIT --price 200`
-3. Preview (pipe build output): `schwab-agent order build equity --symbol <SYM> --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -`
-4. Place with confirmation: `schwab-agent order place equity --symbol <SYM> --action BUY --quantity 10 --type LIMIT --price 200 --confirm`
-5. Verify status: `schwab-agent order list --status WORKING`
+Place, preview, cancel, replace, and repeat orders. For order construction details (multi-leg strategies, builder flags), see `schwab-order-builder.md`.
 
 ## Safety Requirements
 
-- Config flag: `"i-also-like-to-live-dangerously": true` must be set in config
-- CLI flag: `--confirm` must be passed on every mutable command
-- Both are required. Without both, the command will fail with a validation error.
+Both are required for any mutable operation (place/cancel/replace):
+
+1. Config: `"i-also-like-to-live-dangerously": true` in config file
+2. CLI: `--confirm` flag on the command
+
+## Safety Workflow
+
+1. Check price: `schwab-agent quote get <symbol>`
+2. Build order JSON: `schwab-agent order build equity --symbol SYM --action BUY --quantity 10 --type LIMIT --price 200`
+3. Preview: `schwab-agent order build equity ... | schwab-agent order preview --spec -`
+4. Place: `schwab-agent order place equity --symbol SYM --action BUY --quantity 10 --type LIMIT --price 200 --confirm`
+5. Verify: `schwab-agent order list --status WORKING`
 
 ## Intent Mapping
 
-| User says | Order type | Command |
-|-----------|-----------|---------|
-| "buy at current price" | MARKET | `order place equity --type MARKET` (or omit --type) |
-| "buy at $X or less" | LIMIT | `order place equity --type LIMIT --price X` |
-| "sell if it drops to $X" | STOP | `order place equity --type STOP --stop-price X` |
-| "sell at $X but not below $Y" | STOP_LIMIT | `order place equity --type STOP_LIMIT --stop-price X --price Y` |
-| "buy with protection" | BRACKET (full) | `order place bracket --take-profit X --stop-loss Y` |
-| "buy with a safety net" | BRACKET (stop only) | `order place bracket --stop-loss Y` |
-| "buy with a profit target" | BRACKET (TP only) | `order place bracket --take-profit X` |
-| "set take-profit and stop-loss" (already own shares) | OCO | `order place oco --action SELL --take-profit X --stop-loss Y` |
-| "protect my position" (existing shares) | OCO (stop only) | `order place oco --action SELL --stop-loss Y` |
-| "set a profit target" (existing shares) | OCO (TP only) | `order place oco --action SELL --take-profit X` |
-| "buy calls/puts" | OPTION | `order place option --underlying SYM --call/--put ...` |
-| "sell covered calls" (already own shares) | OPTION (single leg) | `order place option --action SELL_TO_OPEN --call ...` |
-| "buy stock and sell a call" (new position) | COVERED | `order build covered-call ...` then place via spec |
-| "bull call spread" | VERTICAL | `order build vertical --call --open --long-strike X --short-strike Y` |
-| "iron condor" | IRON_CONDOR | `order build iron-condor --open ...` |
-| "buy a straddle" | STRADDLE | `order build straddle --buy --open ...` |
-| "buy a strangle" | STRANGLE | `order build strangle --buy --open ...` |
-
-## Scenario Recipes
-
-### Buy at market price
-
-```bash
-schwab-agent order place equity --symbol AAPL --action BUY --quantity 10 --confirm
-```
-
-### Buy with a limit price
-
-```bash
-schwab-agent order place equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --confirm
-```
-
-### Sell with a stop
-
-```bash
-schwab-agent order place equity --symbol TSLA --action SELL --quantity 5 --type STOP --stop-price 150 --confirm
-```
-
-### Buy options
-
-```bash
-schwab-agent order place option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --confirm
-```
-
-### Preview before placing
-
-Preview requires `--spec` with JSON input. Use `order build` to generate the JSON, then pipe it:
-
-```bash
-schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
-```
-
-### Cancel an order
-
-```bash
-schwab-agent order cancel 12345 --confirm
-```
-
-### Replace an order
-
-Replace cancels the original order and creates a new one with a different ID. Only equity orders can be replaced.
-
-```bash
-schwab-agent order replace <order-id> --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 205 --confirm
-# Original order → status: REPLACED. Use `order list --status WORKING` to find the new order ID.
-```
+| User says | Command |
+|-----------|---------|
+| "buy at current price" | `order place equity --action BUY --type MARKET` |
+| "buy at $X or less" | `order place equity --action BUY --type LIMIT --price X` |
+| "sell if it drops to $X" | `order place equity --action SELL --type STOP --stop-price X` |
+| "sell at $X but not below $Y" | `order place equity --action SELL --type STOP_LIMIT --stop-price X --price Y` |
+| "trailing stop" | `order place equity --action SELL --type TRAILING_STOP --stop-offset 2.50` |
+| "buy with protection" | `order place bracket --action BUY --take-profit X --stop-loss Y` |
+| "buy with a safety net" | `order place bracket --action BUY --stop-loss Y` |
+| "set take-profit and stop-loss" (own shares) | `order place oco --action SELL --take-profit X --stop-loss Y` |
+| "protect my position" (own shares) | `order place oco --action SELL --stop-loss Y` |
+| "buy calls/puts" | `order place option --underlying SYM --call/--put --action BUY_TO_OPEN` |
+| "sell covered calls" (own shares) | `order place option --action SELL_TO_OPEN --call ...` |
+| "buy stock and sell a call" (new) | `order build covered-call ...` then place via spec |
+| "bull call spread" | `order build vertical --call --open --long-strike X --short-strike Y` |
+| "iron condor" | `order build iron-condor --open ...` |
+| "straddle" | `order build straddle --buy --open ...` |
+| "strangle" | `order build strangle --buy --open ...` |
+| "calendar spread" | `order build calendar --call --open ...` |
+| "diagonal spread" | `order build diagonal --call --open ...` |
+| "collar" | `order build collar --open ...` |
+| "repeat a previous order" | `order repeat <order-id>` |
+| "re-place that order" | `order repeat <order-id> --confirm` |
 
 ## Listing and Getting Orders
 
 ```bash
 schwab-agent order list
-schwab-agent order list --status WORKING
+schwab-agent order list --status WORKING --from 2025-01-01 --to 2025-01-31
 schwab-agent order get <order-id>
 ```
 
-## Spec Mode
+Flags: `--status` (filter by status), `--from`/`--to` (filter by entered time).
 
-Pass a raw JSON order payload directly instead of using flags:
+## Placing Orders
 
 ```bash
-# Inline JSON
+# Equity
+schwab-agent order place equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --confirm
+
+# Option
+schwab-agent order place option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --confirm
+
+# Bracket (entry + automatic exits)
+schwab-agent order place bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120 --confirm
+
+# OCO (exit orders for existing position)
+schwab-agent order place oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140 --confirm
+```
+
+## Preview
+
+Preview requires `--spec` with JSON input. Pipe from `order build`:
+
+```bash
+schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
+```
+
+## Cancel and Replace
+
+```bash
+schwab-agent order cancel <order-id> --confirm
+schwab-agent order replace <order-id> --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 205 --confirm
+```
+
+Replace cancels the original and creates a new order (new ID). Only equity order flags accepted. Original order status becomes REPLACED.
+
+## Repeat
+
+Fetch an existing order, convert it to a submittable request, and optionally place it:
+
+```bash
+schwab-agent order repeat <order-id>            # Output reconstructed order JSON (default, same as --build)
+schwab-agent order repeat <order-id> --preview   # Preview without placing
+schwab-agent order repeat <order-id> --confirm   # Place the order (requires safety guards)
+```
+
+Only one mode flag allowed. `--build`, `--preview`, and `--confirm` are mutually exclusive.
+
+## Spec Mode
+
+Pass raw JSON order payload directly instead of using flags:
+
+```bash
 schwab-agent order place --spec '{"orderType": "LIMIT", ...}' --confirm
-
-# From file
 schwab-agent order place --spec @order.json --confirm
-
-# From stdin
 cat order.json | schwab-agent order place --spec - --confirm
 ```


### PR DESCRIPTION
## Summary

- Rewrite all 6 skill files to reduce token usage (920 -> 659 lines, -28%) while adding 12 previously undocumented commands and flags
- Consolidate simple TA indicators into a single reference table, reorganize order builder flags into logical sections, compact flag tables and trim redundant prose
- Add missing docs for: `order repeat`, `order build fts`, `chain expiration`, `--fields`/`--indicative` on quote, `--positions` on account, trailing stop flags, `--special-instruction`, `--destination`, `--price-link-basis/type`, `--no-browser` on auth