### PR TITLE
fix: replace deprecated archives.format with formats list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     main: ./cmd/schwab-agent/
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 # Keyless cosign signing via Sigstore/Fulcio OIDC (no private key needed).


### PR DESCRIPTION
## Summary

- Rename `archives.format` to `archives.formats` (as a list) in `.goreleaser.yml`, fixing the deprecation warning from goreleaser v2.6+

Seen during the v1.1.0 release build: https://github.com/major/schwab-agent/actions/runs/24898660103/job/72910200277

Reference: https://goreleaser.com/deprecations#archivesformat