### PR TITLE
fix(orders): support multiple --status values in order list

### DIFF
--- a/internal/client/orders.go
+++ b/internal/client/orders.go
@@ -16,20 +16,23 @@ import (
 
 // OrderListParams holds optional filter parameters for listing orders.
 type OrderListParams struct {
-	Status          string
+	Statuses        []string
 	FromEnteredTime string
 	ToEnteredTime   string
 }
 
-// toQueryParams converts fields to a map for doGet.
+// toQueryParams converts date fields to a map for doGet.
 //
 // The Schwab API requires fromEnteredTime and toEnteredTime as mandatory query
 // parameters in ISO 8601 format. When not provided, fromEnteredTime defaults
 // to 60 days ago and toEnteredTime defaults to now (matching the Python
 // schwab-py client behavior).
+//
+// Status is intentionally omitted here because the Schwab API accepts only a
+// single status value per request. Multiple statuses require separate API calls
+// with merged results, handled by fetchOrders.
 func (p OrderListParams) toQueryParams() map[string]string {
 	params := make(map[string]string)
-	setParam(params, "status", p.Status)
 	params["fromEnteredTime"], params["toEnteredTime"] = defaultDateRange(p.FromEnteredTime, p.ToEnteredTime)
 	return params
 }
@@ -39,23 +42,72 @@ type PlaceOrderResponse struct {
 	OrderID int64
 }
 
+// fetchOrders retrieves orders from the given path, fanning out one API call
+// per status when multiple statuses are requested. The Schwab API accepts only
+// a single status value per request, so multiple statuses require separate
+// calls with merged results.
+//
+// When no statuses are provided, a single unfiltered request is made. When one
+// status is provided, a single filtered request is made. When multiple are
+// provided, one request per status is made and results are merged, deduplicating
+// by OrderID.
+func (c *Client) fetchOrders(ctx context.Context, path string, params OrderListParams) ([]models.Order, error) {
+	baseQuery := params.toQueryParams()
+
+	// Zero or one status: single API call.
+	if len(params.Statuses) <= 1 {
+		if len(params.Statuses) == 1 {
+			baseQuery["status"] = params.Statuses[0]
+		}
+		var result []models.Order
+		if err := c.doGet(ctx, path, baseQuery, &result); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	// Multiple statuses: fan out one call per status, merge and dedup.
+	// An order can only have one status at a time, but we guard against
+	// API edge cases (e.g. status transition mid-request) by deduplicating
+	// on OrderID.
+	//
+	// Initialize as empty (not nil) so JSON serialization produces [] instead
+	// of null when all batches are empty, matching the single-status behavior.
+	seen := make(map[int64]bool)
+	merged := make([]models.Order, 0)
+	for _, status := range params.Statuses {
+		query := make(map[string]string, len(baseQuery)+1)
+		for k, v := range baseQuery {
+			query[k] = v
+		}
+		query["status"] = status
+
+		var batch []models.Order
+		if err := c.doGet(ctx, path, query, &batch); err != nil {
+			return nil, err
+		}
+		for i := range batch {
+			if batch[i].OrderID != nil {
+				if seen[*batch[i].OrderID] {
+					continue
+				}
+				seen[*batch[i].OrderID] = true
+			}
+			merged = append(merged, batch[i])
+		}
+	}
+	return merged, nil
+}
+
 // ListOrders retrieves orders for a specific account, filtered by the given params.
 func (c *Client) ListOrders(ctx context.Context, hashValue string, params OrderListParams) ([]models.Order, error) {
 	path := fmt.Sprintf("/trader/v1/accounts/%s/orders", hashValue)
-	var result []models.Order
-	if err := c.doGet(ctx, path, params.toQueryParams(), &result); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return c.fetchOrders(ctx, path, params)
 }
 
 // AllOrders retrieves orders across all accounts, filtered by the given params.
 func (c *Client) AllOrders(ctx context.Context, params OrderListParams) ([]models.Order, error) {
-	var result []models.Order
-	if err := c.doGet(ctx, "/trader/v1/orders", params.toQueryParams(), &result); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return c.fetchOrders(ctx, "/trader/v1/orders", params)
 }
 
 // GetOrder retrieves a specific order by account hash and order ID.

--- a/internal/client/orders_test.go
+++ b/internal/client/orders_test.go
@@ -84,13 +84,94 @@ func TestListOrders_WithParams(t *testing.T) {
 
 	c := NewClient("test-token", WithBaseURL(srv.URL))
 	result, err := c.ListOrders(context.Background(), "abc123", OrderListParams{
-		Status:          "FILLED",
+		Statuses:        []string{"FILLED"},
 		FromEnteredTime: "2024-01-01T00:00:00.000Z",
 		ToEnteredTime:   "2024-12-31T23:59:59.000Z",
 	})
 
 	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+func TestListOrders_MultipleStatuses(t *testing.T) {
+	// The Schwab API accepts only a single status per request, so multiple
+	// statuses require separate API calls with merged results.
+	workingID := int64(111)
+	filledID := int64(222)
+	workingStatus := models.OrderStatusWorking
+	filledStatus := models.OrderStatusFilled
+
+	var requestCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		status := r.URL.Query().Get("status")
+
+		w.Header().Set("Content-Type", "application/json")
+		switch status {
+		case "WORKING":
+			response := []models.Order{{
+				OrderID:           &workingID,
+				Status:            &workingStatus,
+				OrderType:         models.OrderTypeLimit,
+				OrderStrategyType: models.OrderStrategyTypeSingle,
+			}}
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		case "FILLED":
+			response := []models.Order{{
+				OrderID:           &filledID,
+				Status:            &filledStatus,
+				OrderType:         models.OrderTypeMarket,
+				OrderStrategyType: models.OrderStrategyTypeSingle,
+			}}
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		default:
+			t.Errorf("unexpected status filter: %q", status)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	result, err := c.ListOrders(context.Background(), "abc123", OrderListParams{
+		Statuses: []string{"WORKING", "FILLED"},
+	})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 2, requestCount, "should make one API call per status")
+	require.Len(t, result, 2)
+	assert.Equal(t, int64(111), *result[0].OrderID)
+	assert.Equal(t, int64(222), *result[1].OrderID)
+}
+
+func TestListOrders_MultipleStatuses_Dedup(t *testing.T) {
+	// Guard against the unlikely case where the same order appears in multiple
+	// status responses (e.g. status transition mid-request).
+	orderID := int64(333)
+	workingStatus := models.OrderStatusWorking
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		response := []models.Order{{
+			OrderID:           &orderID,
+			Status:            &workingStatus,
+			OrderType:         models.OrderTypeLimit,
+			OrderStrategyType: models.OrderStrategyTypeSingle,
+		}}
+		require.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer srv.Close()
+
+	// Act
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	result, err := c.ListOrders(context.Background(), "abc123", OrderListParams{
+		Statuses: []string{"WORKING", "PENDING_ACTIVATION"},
+	})
+
+	// Assert - should dedup the duplicate OrderID.
+	require.NoError(t, err)
+	require.Len(t, result, 1, "duplicate OrderID should be deduplicated")
+	assert.Equal(t, int64(333), *result[0].OrderID)
 }
 
 func TestAllOrders_Success(t *testing.T) {

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -95,16 +95,32 @@ func orderListCommand(c *client.Ref, _ string, w io.Writer) *cli.Command {
 		Usage: "List orders",
 		UsageText: `schwab-agent order list
 schwab-agent order list --status FILLED
+schwab-agent order list --status WORKING --status PENDING_ACTIVATION
+schwab-agent order list --status WORKING,PENDING_ACTIVATION
 schwab-agent order list --from 2025-01-01 --to 2025-01-31`,
 		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "status", Usage: "Filter by order status"},
+			&cli.StringSliceFlag{Name: "status", Usage: "Filter by order status (repeatable): WORKING, PENDING_ACTIVATION, FILLED, EXPIRED, CANCELED, REJECTED, etc."},
 			&cli.StringFlag{Name: "from", Usage: "Filter by entered time lower bound"},
 			&cli.StringFlag{Name: "to", Usage: "Filter by entered time upper bound"},
 			&cli.StringFlag{Name: "account", Usage: "Account hash value"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
+			// Split comma-separated values and trim whitespace, matching the
+			// --fields pattern in quote.go. Supports both repeatable flags
+			// (--status WORKING --status FILLED) and comma-separated
+			// (--status WORKING,FILLED).
+			var statuses []string
+			for _, raw := range cmd.StringSlice("status") {
+				for _, part := range strings.Split(raw, ",") {
+					trimmed := strings.TrimSpace(part)
+					if trimmed != "" {
+						statuses = append(statuses, trimmed)
+					}
+				}
+			}
+
 			params := client.OrderListParams{
-				Status:          strings.TrimSpace(cmd.String("status")),
+				Statuses:        statuses,
 				FromEnteredTime: strings.TrimSpace(cmd.String("from")),
 				ToEnteredTime:   strings.TrimSpace(cmd.String("to")),
 			}

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -1467,6 +1467,92 @@ func TestOrderListWithFilters(t *testing.T) {
 	assert.Empty(t, orders)
 }
 
+func TestOrderListMultipleStatuses(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - the Schwab API accepts only one status per request, so multiple
+	// --status flags should produce separate API calls with merged results.
+	var requestStatuses []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/trader/v1/orders", r.URL.Path)
+		status := r.URL.Query().Get("status")
+		requestStatuses = append(requestStatuses, status)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch status {
+		case "WORKING":
+			_, err := w.Write([]byte(`[{"session":"NORMAL","duration":"DAY","orderType":"LIMIT","orderStrategyType":"SINGLE","orderId":111,"status":"WORKING","orderLegCollection":[{"instruction":"BUY","quantity":10,"instrument":{"assetType":"EQUITY","symbol":"AAPL"}}]}]`))
+			require.NoError(t, err)
+		case "FILLED":
+			_, err := w.Write([]byte(`[{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderId":222,"status":"FILLED","orderLegCollection":[{"instruction":"SELL","quantity":5,"instrument":{"assetType":"EQUITY","symbol":"MSFT"}}]}]`))
+			require.NoError(t, err)
+		default:
+			t.Errorf("unexpected status filter: %q", status)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list", "--status", "WORKING", "--status", "FILLED")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, []string{"WORKING", "FILLED"}, requestStatuses, "should fan out one request per status")
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	orders, ok := data["orders"].([]any)
+	require.True(t, ok)
+	require.Len(t, orders, 2)
+
+	first, ok := orders[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(111), first["orderId"])
+	assert.Equal(t, "WORKING", first["status"])
+
+	second, ok := orders[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(222), second["orderId"])
+	assert.Equal(t, "FILLED", second["status"])
+}
+
+func TestOrderListCommaSeparatedStatuses(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - comma-separated statuses should split into separate API calls,
+	// matching the --fields pattern in quote.go.
+	var requestStatuses []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		status := r.URL.Query().Get("status")
+		requestStatuses = append(requestStatuses, status)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list", "--status", "WORKING,FILLED")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, []string{"WORKING", "FILLED"}, requestStatuses, "comma-separated values should produce separate API calls")
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	orders, ok := data["orders"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, orders)
+}
+
 func TestOrderListAPIError(t *testing.T) {
 	t.Parallel()
 

--- a/skills/schwab-trade.md
+++ b/skills/schwab-trade.md
@@ -48,10 +48,14 @@ Both are required for any mutable operation (place/cancel/replace):
 ```bash
 schwab-agent order list
 schwab-agent order list --status WORKING --from 2025-01-01 --to 2025-01-31
+schwab-agent order list --status WORKING --status PENDING_ACTIVATION
+schwab-agent order list --status WORKING,FILLED,EXPIRED
 schwab-agent order get <order-id>
 ```
 
-Flags: `--status` (filter by status), `--from`/`--to` (filter by entered time).
+Flags: `--status` (filter by status, repeatable), `--from`/`--to` (filter by entered time).
+
+The `--status` flag can be repeated or comma-separated to query multiple statuses. The Schwab API only accepts one status per request, so multiple statuses automatically fan out into separate API calls with merged, deduplicated results.
 
 ## Placing Orders
 


### PR DESCRIPTION
## Summary

- `--status` was a `StringFlag`, so repeating it (`--status WORKING --status PENDING_ACTIVATION`) silently kept only the last value. An AI agent missed active stop-loss orders because of this.
- The Schwab API accepts only one status per request, so this fans out separate API calls per status and merges/deduplicates the results by OrderID.
- Supports both repeatable (`--status WORKING --status FILLED`) and comma-separated (`--status WORKING,FILLED`) forms.

## Changes

- **`internal/client/orders.go`**: `OrderListParams.Status string` -> `Statuses []string`. New `fetchOrders()` method handles per-status fan-out with dedup. `ListOrders`/`AllOrders` delegate to it.
- **`internal/commands/order.go`**: `StringFlag` -> `StringSliceFlag` with comma-split support (matches existing `--fields` pattern in `quote.go`).
- **`internal/client/orders_test.go`**: Updated existing param test, added multi-status and dedup tests.
- **`internal/commands/order_test.go`**: Added repeatable and comma-separated multi-status tests.
- **`skills/schwab-trade.md`**: Documented repeatable `--status` with examples.

Closes #31