### PR TITLE
feat(orders): accept GTC, FOK, IOC as duration aliases

### DIFF
--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -1098,7 +1098,22 @@ func parseOrderType(raw string, fallback models.OrderType) (models.OrderType, er
 }
 
 // parseDuration converts CLI input to a duration enum.
+// Supports standard trading abbreviations: GTC (GOOD_TILL_CANCEL),
+// FOK (FILL_OR_KILL), and IOC (IMMEDIATE_OR_CANCEL).
 func parseDuration(raw string) (models.Duration, error) {
+	upper := strings.ToUpper(strings.TrimSpace(raw))
+
+	// Resolve common trading abbreviations before standard enum validation.
+	// These are universal across brokers and trading platforms.
+	switch upper {
+	case "GTC":
+		return models.DurationGoodTillCancel, nil
+	case "FOK":
+		return models.DurationFillOrKill, nil
+	case "IOC":
+		return models.DurationImmediateOrCancel, nil
+	}
+
 	return parseEnum(raw, validDurations, "", "duration")
 }
 

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -2385,6 +2385,102 @@ func TestParseOrderType(t *testing.T) {
 	}
 }
 
+// TestParseDuration verifies duration parsing including GTC/FOK/IOC aliases.
+func TestParseDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    models.Duration
+		wantErr bool
+	}{
+		{
+			name:    "DAY full name",
+			input:   "DAY",
+			want:    models.DurationDay,
+			wantErr: false,
+		},
+		{
+			name:    "GOOD_TILL_CANCEL full name",
+			input:   "GOOD_TILL_CANCEL",
+			want:    models.DurationGoodTillCancel,
+			wantErr: false,
+		},
+		{
+			name:    "GTC alias",
+			input:   "GTC",
+			want:    models.DurationGoodTillCancel,
+			wantErr: false,
+		},
+		{
+			name:    "FILL_OR_KILL full name",
+			input:   "FILL_OR_KILL",
+			want:    models.DurationFillOrKill,
+			wantErr: false,
+		},
+		{
+			name:    "FOK alias",
+			input:   "FOK",
+			want:    models.DurationFillOrKill,
+			wantErr: false,
+		},
+		{
+			name:    "IMMEDIATE_OR_CANCEL full name",
+			input:   "IMMEDIATE_OR_CANCEL",
+			want:    models.DurationImmediateOrCancel,
+			wantErr: false,
+		},
+		{
+			name:    "IOC alias",
+			input:   "IOC",
+			want:    models.DurationImmediateOrCancel,
+			wantErr: false,
+		},
+		{
+			name:    "case insensitive alias",
+			input:   "gtc",
+			want:    models.DurationGoodTillCancel,
+			wantErr: false,
+		},
+		{
+			name:    "empty string returns empty default",
+			input:   "",
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "whitespace returns empty default",
+			input:   "   ",
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name:    "invalid duration",
+			input:   "FOREVER",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseDuration(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				var validationErr *apperr.ValidationError
+				require.True(t, errors.As(err, &validationErr))
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
 // --- order repeat tests ---
 
 // sampleOrderJSON returns a JSON string for a filled order response. Includes

--- a/skills/schwab-order-builder.md
+++ b/skills/schwab-order-builder.md
@@ -135,7 +135,7 @@ Both `--primary` and `--secondary` required. Accept inline JSON, `@file`, or `-`
 | `--type` | MARKET, LIMIT, STOP, STOP_LIMIT, TRAILING_STOP | equity, bracket |
 | `--price` | Limit price or net debit/credit | LIMIT, STOP_LIMIT, multi-leg |
 | `--stop-price` | Stop trigger price | STOP, STOP_LIMIT |
-| `--duration` | DAY, GOOD_TILL_CANCEL, FILL_OR_KILL, IMMEDIATE_OR_CANCEL, END_OF_WEEK, END_OF_MONTH, NEXT_END_OF_MONTH | all |
+| `--duration` | DAY, GOOD_TILL_CANCEL (or GTC), FILL_OR_KILL (or FOK), IMMEDIATE_OR_CANCEL (or IOC), END_OF_WEEK, END_OF_MONTH, NEXT_END_OF_MONTH | all |
 | `--session` | NORMAL, AM, PM, SEAMLESS | all |
 
 ### Exit Flags

--- a/skills/schwab-trade.md
+++ b/skills/schwab-trade.md
@@ -57,6 +57,18 @@ Flags: `--status` (filter by status, repeatable), `--from`/`--to` (filter by ent
 
 The `--status` flag can be repeated or comma-separated to query multiple statuses. The Schwab API only accepts one status per request, so multiple statuses automatically fan out into separate API calls with merged, deduplicated results.
 
+## Duration Aliases
+
+Standard trading abbreviations are accepted for `--duration`:
+
+| Alias | Expands to |
+|-------|------------|
+| GTC | GOOD_TILL_CANCEL |
+| FOK | FILL_OR_KILL |
+| IOC | IMMEDIATE_OR_CANCEL |
+
+`DAY` is already short, so no alias needed. Case-insensitive.
+
 ## Placing Orders
 
 ```bash


### PR DESCRIPTION
## Summary

- Accept standard trading abbreviations for `--duration`: GTC (GOOD_TILL_CANCEL), FOK (FILL_OR_KILL), IOC (IMMEDIATE_OR_CANCEL)
- Follows the existing MOC/LOC alias pattern in `parseOrderType`
- Table-driven `TestParseDuration` covers all aliases, case insensitivity, empty/whitespace defaults, and invalid input
- Skill files updated to document the aliases

Closes #35