### PR TITLE
feat: add Windows amd64/arm64 builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,17 +7,21 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
     ldflags:
       - -s -w -X main.version={{.Version}}
     binary: schwab-agent
-    main: ./cmd/schwab-agent/
+    main: ./cmd/schwab-agent
 
 archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 # Keyless cosign signing via Sigstore/Fulcio OIDC (no private key needed).
 # Signs the checksums file only; users verify checksums, then verify SHAs.


### PR DESCRIPTION
## Summary

- Add `windows` to GoReleaser `goos` targets (amd64 + arm64)
- Use `format_overrides` to produce `.zip` archives for Windows (`.tar.gz` for Linux/macOS)
- Remove trailing slash from `main` path for cross-repo consistency
- No workflow changes needed since GoReleaser handles cross-compilation via `CGO_ENABLED=0`