### PR TITLE
feat: position list command and order list defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ All command output uses `internal/output` JSON envelopes:
 
 urfave/cli v3. `buildApp()` in main.go constructs the command tree. Before hook skips auth for `auth`, `skills`, `schema`, and `symbol` commands, then loads config + token, refreshes if expired, populates `*client.Ref` for command access.
 
-10 subcommands: auth (setup/login/status), account (list/get/numbers/set-default/transaction), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), schema. Account list/get enriches results with nicknames from the preferences API (best-effort, degrades gracefully).
+11 subcommands: auth (setup/login/status), account (list/get/numbers/set-default/transaction), position (list with --all-accounts/--account), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), schema. Account list/get enriches results with nicknames from the preferences API (best-effort, degrades gracefully). Position list enriches with nicknames and adds computed cost basis / P&L fields. Order list defaults to non-terminal statuses (use --status all for everything).
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ schwab-agent order place --spec @order.json --confirm
 |---|---|
 | `auth` | Login, status, token refresh |
 | `account` | List (with nicknames), get details, set default, transactions |
+| `position` | List positions for one or all accounts (with computed cost basis and P&L) |
 | `quote` | Get quotes for one or more symbols |
 | `order` | List, get, place, preview, build, cancel, replace |
 | `chain` | Option chain data (`get`, `expiration`) |

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -201,6 +201,7 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 		Commands: []*cli.Command{
 			commands.AuthCommand(loadedConfig, tokenPath, w),
 			commands.AccountCommand(apiClient, configPath, w),
+			commands.PositionCommand(apiClient, configPath, w),
 			commands.OrderCommand(apiClient, configPath, w),
 			commands.QuoteCommand(apiClient, w),
 			commands.ChainCommand(apiClient, w),

--- a/internal/commands/AGENTS.md
+++ b/internal/commands/AGENTS.md
@@ -106,6 +106,7 @@ Build tags: `//go:build task16` (auth), `//go:build task17` (account), etc.
 |---|---|---|
 | auth.go | auth | login, status, refresh |
 | account.go | account | list, get, numbers, set-default, transaction (list, get) |
+| position.go | position | list (--all-accounts, --account) |
 | quote.go | quote | get |
 | order.go | order | list, get, place (equity/option/bracket/oco), preview, cancel, replace |
 | order_build.go | order build | equity, option, bracket, oco, vertical, iron-condor, straddle, strangle, covered-call |
@@ -113,6 +114,5 @@ Build tags: `//go:build task16` (auth), `//go:build task17` (account), etc.
 | history.go | history | get |
 | instrument.go | instrument | search, get |
 | market.go | market | hours, movers |
-
 | symbol.go | symbol | build, parse |
 | schema.go | schema | (direct) |

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -88,18 +88,45 @@ func OrderCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	}
 }
 
+// terminalOrderStatuses are order statuses that represent completed/final states.
+// Orders in these statuses are filtered out by default to show only actionable
+// orders. Use --status all to include them.
+var terminalOrderStatuses = map[models.OrderStatus]bool{
+	models.OrderStatusFilled:   true,
+	models.OrderStatusCanceled: true,
+	models.OrderStatusRejected: true,
+	models.OrderStatusExpired:  true,
+	models.OrderStatusReplaced: true,
+}
+
+// filterNonTerminalOrders returns only orders whose status is not terminal.
+// Orders with a nil Status are included (conservative: don't hide unknowns).
+func filterNonTerminalOrders(orders []models.Order) []models.Order {
+	filtered := make([]models.Order, 0, len(orders))
+	for i := range orders {
+		if orders[i].Status == nil || !terminalOrderStatuses[*orders[i].Status] {
+			filtered = append(filtered, orders[i])
+		}
+	}
+	return filtered
+}
+
 // orderListCommand lists orders for a specific account or all accounts.
+// By default, terminal statuses (FILLED, CANCELED, REJECTED, EXPIRED, REPLACED)
+// are filtered out to show only actionable orders. Use --status all to see
+// everything, or --status <STATUS> to filter by specific statuses.
 func orderListCommand(c *client.Ref, _ string, w io.Writer) *cli.Command {
 	return &cli.Command{
 		Name:  "list",
-		Usage: "List orders",
+		Usage: "List orders (defaults to non-terminal statuses)",
 		UsageText: `schwab-agent order list
+schwab-agent order list --status all
 schwab-agent order list --status FILLED
 schwab-agent order list --status WORKING --status PENDING_ACTIVATION
 schwab-agent order list --status WORKING,PENDING_ACTIVATION
 schwab-agent order list --from 2025-01-01 --to 2025-01-31`,
 		Flags: []cli.Flag{
-			&cli.StringSliceFlag{Name: "status", Usage: "Filter by order status (repeatable): WORKING, PENDING_ACTIVATION, FILLED, EXPIRED, CANCELED, REJECTED, etc."},
+			&cli.StringSliceFlag{Name: "status", Usage: "Filter by order status (repeatable, use 'all' for unfiltered): WORKING, PENDING_ACTIVATION, FILLED, EXPIRED, CANCELED, REJECTED, etc."},
 			&cli.StringFlag{Name: "from", Usage: "Filter by entered time lower bound"},
 			&cli.StringFlag{Name: "to", Usage: "Filter by entered time upper bound"},
 			&cli.StringFlag{Name: "account", Usage: "Account hash value"},
@@ -119,25 +146,47 @@ schwab-agent order list --from 2025-01-01 --to 2025-01-31`,
 				}
 			}
 
+			// "all" is a pseudo-status that disables default filtering.
+			// When present, fetch everything without any status filter.
+			showAll := false
+			for _, s := range statuses {
+				if strings.EqualFold(s, "all") {
+					showAll = true
+					break
+				}
+			}
+
+			// When specific statuses are requested (not "all"), pass them
+			// through to the API. When "all" or no statuses, fetch unfiltered.
+			var apiStatuses []string
+			if !showAll {
+				apiStatuses = statuses
+			}
+
 			params := client.OrderListParams{
-				Statuses:        statuses,
+				Statuses:        apiStatuses,
 				FromEnteredTime: strings.TrimSpace(cmd.String("from")),
 				ToEnteredTime:   strings.TrimSpace(cmd.String("to")),
 			}
 
 			account := strings.TrimSpace(cmd.String("account"))
+
+			var orders []models.Order
+			var err error
 			if account == "" {
-				orders, err := c.AllOrders(ctx, params)
-				if err != nil {
-					return err
-				}
-
-				return output.WriteSuccess(w, orderListData{Orders: orders}, output.NewMetadata())
+				orders, err = c.AllOrders(ctx, params)
+			} else {
+				orders, err = c.ListOrders(ctx, account, params)
 			}
-
-			orders, err := c.ListOrders(ctx, account, params)
 			if err != nil {
 				return err
+			}
+
+			// When no statuses were explicitly requested, filter out terminal
+			// orders client-side. This avoids N API calls (one per non-terminal
+			// status) since the Schwab API only accepts one status per request.
+			if len(statuses) == 0 {
+				orders = filterNonTerminalOrders(orders)
 			}
 
 			return output.WriteSuccess(w, orderListData{Orders: orders}, output.NewMetadata())

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -1367,7 +1367,8 @@ func TestOrderBuildSpreadParseErrors(t *testing.T) {
 func TestOrderListAllAccounts(t *testing.T) {
 	t.Parallel()
 
-	// Arrange
+	// Arrange - mix of terminal and non-terminal orders. Default listing
+	// should filter out terminal statuses (FILLED, CANCELED, etc.).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/trader/v1/orders", r.URL.Path)
@@ -1375,7 +1376,11 @@ func TestOrderListAllAccounts(t *testing.T) {
 		assert.NotEmpty(t, r.URL.Query().Get("toEnteredTime"))
 
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`[{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderId":12345,"status":"FILLED","orderLegCollection":[{"instruction":"BUY","quantity":10,"instrument":{"assetType":"EQUITY","symbol":"AAPL"}}]}]`))
+		_, err := w.Write([]byte(`[
+			{"session":"NORMAL","duration":"DAY","orderType":"LIMIT","orderStrategyType":"SINGLE","orderId":111,"status":"WORKING","orderLegCollection":[{"instruction":"BUY","quantity":10,"instrument":{"assetType":"EQUITY","symbol":"AAPL"}}]},
+			{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderId":222,"status":"FILLED","orderLegCollection":[{"instruction":"SELL","quantity":5,"instrument":{"assetType":"EQUITY","symbol":"MSFT"}}]},
+			{"session":"NORMAL","duration":"DAY","orderType":"LIMIT","orderStrategyType":"SINGLE","orderId":333,"status":"QUEUED","orderLegCollection":[{"instruction":"BUY","quantity":20,"instrument":{"assetType":"EQUITY","symbol":"GOOG"}}]}
+		]`))
 		require.NoError(t, err)
 	}))
 	defer server.Close()
@@ -1386,18 +1391,24 @@ func TestOrderListAllAccounts(t *testing.T) {
 	// Act
 	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list")
 
-	// Assert
+	// Assert - FILLED order should be filtered out by default
 	require.NoError(t, err)
 	envelope := decodeEnvelope(t, stdout)
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
 	orders, ok := data["orders"].([]any)
 	require.True(t, ok)
-	require.Len(t, orders, 1)
-	order, ok := orders[0].(map[string]any)
+	require.Len(t, orders, 2, "should exclude terminal FILLED order")
+
+	first, ok := orders[0].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, float64(12345), order["orderId"])
-	assert.Equal(t, "FILLED", order["status"])
+	assert.Equal(t, float64(111), first["orderId"])
+	assert.Equal(t, "WORKING", first["status"])
+
+	second, ok := orders[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(333), second["orderId"])
+	assert.Equal(t, "QUEUED", second["status"])
 }
 
 func TestOrderListWithAccount(t *testing.T) {
@@ -1575,6 +1586,148 @@ func TestOrderListAPIError(t *testing.T) {
 	var httpErr *apperr.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+}
+
+func TestOrderListDefaultFiltersTerminalStatuses(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - return orders in every terminal status plus one non-terminal.
+	// Default listing (no --status flag) should filter out all terminal ones.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[
+			{"orderId":1,"status":"WORKING"},
+			{"orderId":2,"status":"FILLED"},
+			{"orderId":3,"status":"CANCELED"},
+			{"orderId":4,"status":"REJECTED"},
+			{"orderId":5,"status":"EXPIRED"},
+			{"orderId":6,"status":"REPLACED"},
+			{"orderId":7,"status":"QUEUED"},
+			{"orderId":8,"status":"PENDING_ACTIVATION"}
+		]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list")
+
+	// Assert - only non-terminal orders should remain
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	orders, ok := data["orders"].([]any)
+	require.True(t, ok)
+	require.Len(t, orders, 3, "should keep WORKING, QUEUED, PENDING_ACTIVATION")
+
+	expectedIDs := []float64{1, 7, 8}
+	for i, order := range orders {
+		o, ok := order.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, expectedIDs[i], o["orderId"])
+	}
+}
+
+func TestOrderListStatusAllDisablesFiltering(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - --status all should return everything unfiltered.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// "all" is a pseudo-status handled client-side, not sent to the API.
+		assert.Empty(t, r.URL.Query().Get("status"), "should not send 'all' as API status")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[
+			{"orderId":1,"status":"WORKING"},
+			{"orderId":2,"status":"FILLED"},
+			{"orderId":3,"status":"CANCELED"}
+		]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list", "--status", "all")
+
+	// Assert - all orders should appear, no filtering
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	orders, ok := data["orders"].([]any)
+	require.True(t, ok)
+	require.Len(t, orders, 3, "should return all orders when --status all")
+}
+
+func TestOrderListExplicitStatusBypassesDefault(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - when the user explicitly requests a terminal status,
+	// it should be passed to the API and returned without client-side filtering.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "FILLED", r.URL.Query().Get("status"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[{"orderId":1,"status":"FILLED"},{"orderId":2,"status":"FILLED"}]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list", "--status", "FILLED")
+
+	// Assert - explicit status request returns all matching, no default filter
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	orders, ok := data["orders"].([]any)
+	require.True(t, ok)
+	require.Len(t, orders, 2)
+}
+
+func TestOrderListNilStatusIncludedByDefault(t *testing.T) {
+	t.Parallel()
+
+	// Arrange - orders with no status field should be kept (conservative:
+	// don't hide orders with unknown state).
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[
+			{"orderId":1},
+			{"orderId":2,"status":"FILLED"}
+		]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "list")
+
+	// Assert - nil-status order kept, FILLED filtered
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	orders, ok := data["orders"].([]any)
+	require.True(t, ok)
+	require.Len(t, orders, 1)
+	o, ok := orders[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), o["orderId"])
 }
 
 func TestOrderGetSuccess(t *testing.T) {

--- a/internal/commands/position.go
+++ b/internal/commands/position.go
@@ -1,0 +1,270 @@
+package commands
+
+import (
+	"context"
+	"io"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/major/schwab-agent/internal/apperr"
+	"github.com/major/schwab-agent/internal/client"
+	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/output"
+)
+
+// positionEntry enriches a position with account identifiers and computed
+// cost basis / P&L fields that Schwab's API doesn't provide directly.
+type positionEntry struct {
+	AccountNumber   string `json:"accountNumber"`
+	AccountHash     string `json:"accountHash,omitempty"`
+	AccountNickName string `json:"accountNickName,omitempty"`
+
+	models.Position
+
+	// Computed fields derived from the raw position data.
+	TotalCostBasis   *float64 `json:"totalCostBasis,omitempty"`
+	UnrealizedPnL    *float64 `json:"unrealizedPnL,omitempty"`
+	UnrealizedPnLPct *float64 `json:"unrealizedPnLPct,omitempty"`
+}
+
+// positionListData wraps the position list response.
+type positionListData struct {
+	Positions []positionEntry `json:"positions"`
+}
+
+// PositionCommand returns the parent CLI command for position operations.
+func PositionCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
+	return &cli.Command{
+		Name:  "position",
+		Usage: "View positions across accounts",
+		Commands: []*cli.Command{
+			positionListCommand(c, configPath, w),
+		},
+	}
+}
+
+// positionListCommand returns the CLI command for listing positions.
+// Default: single account (resolved via --account flag or config default).
+// With --all-accounts: flattens positions from all linked accounts into a
+// single list with account identifiers on each entry.
+func positionListCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List positions for one or all accounts",
+		UsageText: `schwab-agent position list
+schwab-agent position list --all-accounts
+schwab-agent position list --account HASH`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "all-accounts",
+				Usage: "Show positions across all linked accounts",
+			},
+			&cli.StringFlag{
+				Name:  "account",
+				Usage: "Account hash (overrides config default)",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			if cmd.Bool("all-accounts") && cmd.String("account") != "" {
+				return apperr.NewValidationError("--all-accounts and --account are mutually exclusive", nil)
+			}
+
+			if cmd.Bool("all-accounts") {
+				return listAllAccountPositions(ctx, c, w)
+			}
+
+			return listSingleAccountPositions(ctx, c, configPath, cmd, w)
+		},
+	}
+}
+
+// listAllAccountPositions fetches positions from all linked accounts and
+// returns a flat list with account identifiers and computed P&L fields.
+func listAllAccountPositions(ctx context.Context, c *client.Ref, w io.Writer) error {
+	accounts, err := c.Accounts(ctx, "positions")
+	if err != nil {
+		return err
+	}
+
+	// Map account numbers to hash values so we can include both in the output.
+	// The accounts API returns account numbers but not hashes; the account
+	// numbers API provides the mapping.
+	numbers, err := c.AccountNumbers(ctx)
+	if err != nil {
+		return err
+	}
+
+	numberToHash := make(map[string]string, len(numbers))
+	for _, n := range numbers {
+		numberToHash[n.AccountNumber] = n.HashValue
+	}
+
+	// Enrich with nicknames from user preferences (best-effort).
+	prefs, prefsErr := c.UserPreference(ctx)
+	if prefsErr == nil {
+		enrichAccountsWithPreferences(accounts, prefs)
+	}
+
+	entries := flattenAccountPositions(accounts, numberToHash)
+
+	meta := output.NewMetadata()
+	meta.Returned = len(entries)
+
+	return output.WriteSuccess(w, positionListData{Positions: entries}, meta)
+}
+
+// listSingleAccountPositions fetches positions for a single resolved account.
+func listSingleAccountPositions(
+	ctx context.Context,
+	c *client.Ref,
+	configPath string,
+	cmd *cli.Command,
+	w io.Writer,
+) error {
+	hash, err := resolveAccount(cmd.String("account"), configPath, nil)
+	if err != nil {
+		return err
+	}
+
+	account, err := c.Account(ctx, hash, "positions")
+	if err != nil {
+		return err
+	}
+
+	// Enrich with nickname from user preferences (best-effort).
+	prefs, prefsErr := c.UserPreference(ctx)
+	if prefsErr == nil {
+		enrichAccountWithPreferences(account, prefs)
+	}
+
+	acctNum := ""
+	acctNick := ""
+
+	if account.SecuritiesAccount != nil && account.SecuritiesAccount.AccountNumber != nil {
+		acctNum = *account.SecuritiesAccount.AccountNumber
+	}
+
+	if account.NickName != nil {
+		acctNick = *account.NickName
+	}
+
+	var entries []positionEntry
+
+	if account.SecuritiesAccount != nil {
+		for i := range account.SecuritiesAccount.Positions {
+			entries = append(entries, newPositionEntry(acctNum, hash, acctNick, &account.SecuritiesAccount.Positions[i]))
+		}
+	}
+
+	if entries == nil {
+		entries = []positionEntry{}
+	}
+
+	meta := output.NewMetadata()
+	meta.Account = hash
+	meta.Returned = len(entries)
+
+	return output.WriteSuccess(w, positionListData{Positions: entries}, meta)
+}
+
+// flattenAccountPositions converts a slice of accounts with positions into
+// a flat list of position entries with account identifiers.
+func flattenAccountPositions(accounts []models.Account, numberToHash map[string]string) []positionEntry {
+	var entries []positionEntry
+
+	for _, acct := range accounts {
+		if acct.SecuritiesAccount == nil {
+			continue
+		}
+
+		acctNum := ""
+		acctHash := ""
+		acctNick := ""
+
+		if acct.SecuritiesAccount.AccountNumber != nil {
+			acctNum = *acct.SecuritiesAccount.AccountNumber
+			acctHash = numberToHash[acctNum]
+		}
+
+		if acct.NickName != nil {
+			acctNick = *acct.NickName
+		}
+
+		for i := range acct.SecuritiesAccount.Positions {
+			entries = append(entries, newPositionEntry(acctNum, acctHash, acctNick, &acct.SecuritiesAccount.Positions[i]))
+		}
+	}
+
+	if entries == nil {
+		entries = []positionEntry{}
+	}
+
+	return entries
+}
+
+// newPositionEntry creates a position entry with account identifiers and
+// computed cost basis / P&L fields.
+func newPositionEntry(accountNumber, accountHash, nickName string, pos *models.Position) positionEntry {
+	entry := positionEntry{
+		AccountNumber:   accountNumber,
+		AccountHash:     accountHash,
+		AccountNickName: nickName,
+		Position:        *pos,
+	}
+
+	computePositionFields(&entry)
+
+	return entry
+}
+
+// computePositionFields calculates derived cost basis and P&L values from
+// the raw position data returned by the Schwab API.
+//
+//	totalCostBasis   = averagePrice * (longQuantity + shortQuantity)
+//	unrealizedPnL    = longOpenProfitLoss + shortOpenProfitLoss
+//	unrealizedPnLPct = (unrealizedPnL / totalCostBasis) * 100
+func computePositionFields(e *positionEntry) {
+	// Cost basis: average price * total quantity (long + short).
+	// Positions are typically one-sided (all long or all short), but the API
+	// allows both to be set so we handle the general case.
+	if e.AveragePrice != nil {
+		var qty float64
+		if e.LongQuantity != nil {
+			qty += *e.LongQuantity
+		}
+
+		if e.ShortQuantity != nil {
+			qty += *e.ShortQuantity
+		}
+
+		if qty != 0 {
+			costBasis := *e.AveragePrice * qty
+			e.TotalCostBasis = &costBasis
+		}
+	}
+
+	// Unrealized P&L: sum of long and short open P&L from the API.
+	var pnl float64
+	var hasPnL bool
+
+	if e.LongOpenProfitLoss != nil {
+		pnl += *e.LongOpenProfitLoss
+		hasPnL = true
+	}
+
+	if e.ShortOpenProfitLoss != nil {
+		pnl += *e.ShortOpenProfitLoss
+		hasPnL = true
+	}
+
+	if hasPnL {
+		e.UnrealizedPnL = &pnl
+	}
+
+	// P&L percentage: avoid division by zero on zero-cost positions
+	// (e.g., positions acquired via stock split or transfer).
+	if e.UnrealizedPnL != nil && e.TotalCostBasis != nil && *e.TotalCostBasis != 0 {
+		pct := *e.UnrealizedPnL / *e.TotalCostBasis * 100
+		e.UnrealizedPnLPct = &pct
+	}
+}

--- a/internal/commands/position_test.go
+++ b/internal/commands/position_test.go
@@ -1,0 +1,618 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/major/schwab-agent/internal/apperr"
+	"github.com/major/schwab-agent/internal/client"
+	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/output"
+	"github.com/major/schwab-agent/internal/ptr"
+)
+
+func TestPositionListSingleAccount(t *testing.T) {
+	account := map[string]any{
+		"securitiesAccount": map[string]any{
+			"type":          "MARGIN",
+			"accountNumber": "12345",
+			"positions": []map[string]any{
+				{
+					"longQuantity":       100.0,
+					"averagePrice":       150.0,
+					"marketValue":        16000.0,
+					"longOpenProfitLoss": 1000.0,
+					"instrument":         map[string]any{"symbol": "AAPL", "assetType": "EQUITY"},
+				},
+				{
+					"longQuantity":       50.0,
+					"averagePrice":       200.0,
+					"marketValue":        11000.0,
+					"longOpenProfitLoss": 1000.0,
+					"instrument":         map[string]any{"symbol": "MSFT", "assetType": "EQUITY"},
+				},
+			},
+		},
+	}
+	prefs := map[string]any{
+		"accounts": []map[string]any{
+			{"accountNumber": "12345", "nickName": "My IRA", "primaryAccount": true},
+		},
+	}
+
+	srv := accountMockServer(t, map[string]any{
+		"/trader/v1/accounts/HASH123":  account,
+		"/trader/v1/userPreference":    prefs,
+	})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	configPath := writeAccountTestConfig(t, t.TempDir(), "")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--account", "HASH123"})
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, "HASH123", env.Metadata.Account)
+	assert.Equal(t, 2, env.Metadata.Returned)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+
+	positions, ok := dataMap["positions"].([]any)
+	require.True(t, ok)
+	require.Len(t, positions, 2)
+
+	// Verify first position has account info and computed fields.
+	pos := positions[0].(map[string]any)
+	assert.Equal(t, "12345", pos["accountNumber"])
+	assert.Equal(t, "HASH123", pos["accountHash"])
+	assert.Equal(t, "My IRA", pos["accountNickName"])
+	assert.Equal(t, 15000.0, pos["totalCostBasis"])  // 150 * 100
+	assert.Equal(t, 1000.0, pos["unrealizedPnL"])    // longOpenProfitLoss only
+
+	// Verify instrument came through.
+	inst, ok := pos["instrument"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AAPL", inst["symbol"])
+}
+
+func TestPositionListSingleAccount_UsesConfigDefault(t *testing.T) {
+	account := map[string]any{
+		"securitiesAccount": map[string]any{
+			"type":          "MARGIN",
+			"accountNumber": "12345",
+			"positions": []map[string]any{
+				{
+					"longQuantity": 10.0,
+					"averagePrice": 50.0,
+					"instrument":   map[string]any{"symbol": "VTI", "assetType": "EQUITY"},
+				},
+			},
+		},
+	}
+
+	srv := accountMockServer(t, map[string]any{
+		"/trader/v1/accounts/DEFAULT_HASH": account,
+		"/trader/v1/userPreference":        map[string]any{"accounts": []any{}},
+	})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	configPath := writeAccountTestConfig(t, t.TempDir(), "DEFAULT_HASH")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	// No --account flag: should use config default.
+	err := cmd.Run(context.Background(), []string{"position", "list"})
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, "DEFAULT_HASH", env.Metadata.Account)
+	assert.Equal(t, 1, env.Metadata.Returned)
+}
+
+func TestPositionListAllAccounts(t *testing.T) {
+	accounts := []map[string]any{
+		{
+			"securitiesAccount": map[string]any{
+				"type":          "MARGIN",
+				"accountNumber": "11111",
+				"positions": []map[string]any{
+					{
+						"longQuantity":       100.0,
+						"averagePrice":       150.0,
+						"longOpenProfitLoss": 500.0,
+						"instrument":         map[string]any{"symbol": "AAPL", "assetType": "EQUITY"},
+					},
+				},
+			},
+		},
+		{
+			"securitiesAccount": map[string]any{
+				"type":          "CASH",
+				"accountNumber": "22222",
+				"positions": []map[string]any{
+					{
+						"longQuantity":       200.0,
+						"averagePrice":       50.0,
+						"longOpenProfitLoss": 2000.0,
+						"instrument":         map[string]any{"symbol": "VTI", "assetType": "EQUITY"},
+					},
+					{
+						"shortQuantity":       10.0,
+						"averagePrice":        300.0,
+						"shortOpenProfitLoss": -500.0,
+						"instrument":          map[string]any{"symbol": "TSLA", "assetType": "EQUITY"},
+					},
+				},
+			},
+		},
+	}
+	accountNumbers := []map[string]any{
+		{"accountNumber": "11111", "hashValue": "HASH_A"},
+		{"accountNumber": "22222", "hashValue": "HASH_B"},
+	}
+	prefs := map[string]any{
+		"accounts": []map[string]any{
+			{"accountNumber": "11111", "nickName": "Trading", "primaryAccount": true},
+			{"accountNumber": "22222", "nickName": "Retirement", "primaryAccount": false},
+		},
+	}
+
+	srv := accountMockServer(t, map[string]any{
+		"/trader/v1/accounts":              accounts,
+		"/trader/v1/accounts/accountNumbers": accountNumbers,
+		"/trader/v1/userPreference":        prefs,
+	})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, "", &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--all-accounts"})
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Empty(t, env.Metadata.Account, "all-accounts mode should not set account in metadata")
+	assert.Equal(t, 3, env.Metadata.Returned)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+
+	positions, ok := dataMap["positions"].([]any)
+	require.True(t, ok)
+	require.Len(t, positions, 3)
+
+	// First position: account 11111 / HASH_A / "Trading"
+	pos0 := positions[0].(map[string]any)
+	assert.Equal(t, "11111", pos0["accountNumber"])
+	assert.Equal(t, "HASH_A", pos0["accountHash"])
+	assert.Equal(t, "Trading", pos0["accountNickName"])
+
+	inst0, ok := pos0["instrument"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AAPL", inst0["symbol"])
+
+	// Second position: account 22222 / HASH_B / "Retirement"
+	pos1 := positions[1].(map[string]any)
+	assert.Equal(t, "22222", pos1["accountNumber"])
+	assert.Equal(t, "HASH_B", pos1["accountHash"])
+	assert.Equal(t, "Retirement", pos1["accountNickName"])
+
+	// Third position: short TSLA in account 22222
+	pos2 := positions[2].(map[string]any)
+	assert.Equal(t, "22222", pos2["accountNumber"])
+	assert.Equal(t, -500.0, pos2["unrealizedPnL"])
+
+	inst2, ok := pos2["instrument"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "TSLA", inst2["symbol"])
+}
+
+func TestPositionListAllAccounts_PreferencesFailure(t *testing.T) {
+	accounts := []map[string]any{
+		{
+			"securitiesAccount": map[string]any{
+				"type":          "MARGIN",
+				"accountNumber": "12345",
+				"positions": []map[string]any{
+					{
+						"longQuantity": 10.0,
+						"averagePrice": 100.0,
+						"instrument":   map[string]any{"symbol": "SPY", "assetType": "EQUITY"},
+					},
+				},
+			},
+		},
+	}
+	accountNumbers := []map[string]any{
+		{"accountNumber": "12345", "hashValue": "HASH_X"},
+	}
+
+	// No /trader/v1/userPreference route: will 404.
+	srv := accountMockServer(t, map[string]any{
+		"/trader/v1/accounts":              accounts,
+		"/trader/v1/accounts/accountNumbers": accountNumbers,
+	})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, "", &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--all-accounts"})
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, 1, env.Metadata.Returned)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok, "expected data to be map[string]any")
+	positions, ok := dataMap["positions"].([]any)
+	require.True(t, ok, "expected positions to be []any")
+	pos, ok := positions[0].(map[string]any)
+	require.True(t, ok, "expected position to be map[string]any")
+
+	// Nickname should be absent since preferences failed.
+	_, hasNick := pos["accountNickName"]
+	assert.False(t, hasNick, "nickname should be omitted when preferences fail")
+}
+
+func TestPositionListNoPositions(t *testing.T) {
+	// Account exists but has no positions.
+	account := map[string]any{
+		"securitiesAccount": map[string]any{
+			"type":          "MARGIN",
+			"accountNumber": "12345",
+		},
+	}
+
+	srv := accountMockServer(t, map[string]any{
+		"/trader/v1/accounts/HASH123":  account,
+		"/trader/v1/userPreference":    map[string]any{"accounts": []any{}},
+	})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	configPath := writeAccountTestConfig(t, t.TempDir(), "")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--account", "HASH123"})
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, 0, env.Metadata.Returned)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok, "expected data to be map[string]any")
+	positions, ok := dataMap["positions"].([]any)
+	require.True(t, ok, "expected positions to be []any")
+	assert.Empty(t, positions, "empty positions should return empty array, not null")
+}
+
+func TestPositionListMutuallyExclusiveFlags(t *testing.T) {
+	// --all-accounts and --account should not be used together.
+	srv := accountMockServer(t, map[string]any{})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	configPath := writeAccountTestConfig(t, t.TempDir(), "HASH123")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--all-accounts", "--account", "HASH456"})
+	require.Error(t, err)
+
+	var ve *apperr.ValidationError
+	require.ErrorAs(t, err, &ve, "should return ValidationError for mutually exclusive flags")
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestPositionListNoAccountConfigured(t *testing.T) {
+	srv := accountMockServer(t, map[string]any{})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	// Config with no default account.
+	configPath := writeAccountTestConfig(t, t.TempDir(), "")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list"})
+	require.Error(t, err, "should error when no account is specified or configured")
+}
+
+func TestPositionListRequestsPositionsField(t *testing.T) {
+	// Verify the client sends ?fields=positions to the API.
+	var capturedFields string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/trader/v1/accounts/HASH123":
+			capturedFields = r.URL.Query().Get("fields")
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"securitiesAccount": map[string]any{
+					"type":          "MARGIN",
+					"accountNumber": "12345",
+				},
+			}))
+		case "/trader/v1/userPreference":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"accounts": []any{}}))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	configPath := writeAccountTestConfig(t, t.TempDir(), "")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--account", "HASH123"})
+	require.NoError(t, err)
+	assert.Equal(t, "positions", capturedFields)
+}
+
+func TestComputePositionFields(t *testing.T) {
+	t.Run("long position with P&L", func(t *testing.T) {
+		entry := positionEntry{
+			Position: models.Position{
+				AveragePrice:       ptr.To(150.0),
+				LongQuantity:       ptr.To(100.0),
+				LongOpenProfitLoss: ptr.To(1000.0),
+			},
+		}
+		computePositionFields(&entry)
+
+		require.NotNil(t, entry.TotalCostBasis)
+		assert.Equal(t, 15000.0, *entry.TotalCostBasis)
+
+		require.NotNil(t, entry.UnrealizedPnL)
+		assert.Equal(t, 1000.0, *entry.UnrealizedPnL)
+
+		require.NotNil(t, entry.UnrealizedPnLPct)
+		assert.InDelta(t, 6.6667, *entry.UnrealizedPnLPct, 0.001)
+	})
+
+	t.Run("short position with P&L", func(t *testing.T) {
+		entry := positionEntry{
+			Position: models.Position{
+				AveragePrice:        ptr.To(300.0),
+				ShortQuantity:       ptr.To(10.0),
+				ShortOpenProfitLoss: ptr.To(-500.0),
+			},
+		}
+		computePositionFields(&entry)
+
+		require.NotNil(t, entry.TotalCostBasis)
+		assert.Equal(t, 3000.0, *entry.TotalCostBasis)
+
+		require.NotNil(t, entry.UnrealizedPnL)
+		assert.Equal(t, -500.0, *entry.UnrealizedPnL)
+
+		require.NotNil(t, entry.UnrealizedPnLPct)
+		assert.InDelta(t, -16.6667, *entry.UnrealizedPnLPct, 0.001)
+	})
+
+	t.Run("both long and short P&L", func(t *testing.T) {
+		entry := positionEntry{
+			Position: models.Position{
+				AveragePrice:        ptr.To(100.0),
+				LongQuantity:        ptr.To(50.0),
+				ShortQuantity:       ptr.To(10.0),
+				LongOpenProfitLoss:  ptr.To(500.0),
+				ShortOpenProfitLoss: ptr.To(-200.0),
+			},
+		}
+		computePositionFields(&entry)
+
+		require.NotNil(t, entry.TotalCostBasis)
+		assert.Equal(t, 6000.0, *entry.TotalCostBasis) // 100 * (50 + 10)
+
+		require.NotNil(t, entry.UnrealizedPnL)
+		assert.Equal(t, 300.0, *entry.UnrealizedPnL) // 500 + (-200)
+
+		require.NotNil(t, entry.UnrealizedPnLPct)
+		assert.InDelta(t, 5.0, *entry.UnrealizedPnLPct, 0.001) // 300/6000*100
+	})
+
+	t.Run("nil averagePrice skips cost basis", func(t *testing.T) {
+		entry := positionEntry{
+			Position: models.Position{
+				LongQuantity:       ptr.To(100.0),
+				LongOpenProfitLoss: ptr.To(500.0),
+			},
+		}
+		computePositionFields(&entry)
+
+		assert.Nil(t, entry.TotalCostBasis)
+		require.NotNil(t, entry.UnrealizedPnL)
+		assert.Equal(t, 500.0, *entry.UnrealizedPnL)
+		// No P&L pct because no cost basis.
+		assert.Nil(t, entry.UnrealizedPnLPct)
+	})
+
+	t.Run("zero quantity skips cost basis", func(t *testing.T) {
+		entry := positionEntry{
+			Position: models.Position{
+				AveragePrice: ptr.To(150.0),
+				// No quantity fields set (both nil, default to 0).
+			},
+		}
+		computePositionFields(&entry)
+
+		assert.Nil(t, entry.TotalCostBasis)
+	})
+
+	t.Run("no P&L fields", func(t *testing.T) {
+		entry := positionEntry{
+			Position: models.Position{
+				AveragePrice: ptr.To(150.0),
+				LongQuantity: ptr.To(100.0),
+			},
+		}
+		computePositionFields(&entry)
+
+		require.NotNil(t, entry.TotalCostBasis)
+		assert.Equal(t, 15000.0, *entry.TotalCostBasis)
+		assert.Nil(t, entry.UnrealizedPnL)
+		assert.Nil(t, entry.UnrealizedPnLPct)
+	})
+
+	t.Run("all fields nil", func(t *testing.T) {
+		entry := positionEntry{}
+		computePositionFields(&entry)
+
+		assert.Nil(t, entry.TotalCostBasis)
+		assert.Nil(t, entry.UnrealizedPnL)
+		assert.Nil(t, entry.UnrealizedPnLPct)
+	})
+}
+
+func TestFlattenAccountPositions(t *testing.T) {
+	accounts := []models.Account{
+		{
+			SecuritiesAccount: &models.SecuritiesAccount{
+				AccountNumber: ptr.To("11111"),
+				Positions: []models.Position{
+					{
+						LongQuantity: ptr.To(100.0),
+						AveragePrice: ptr.To(50.0),
+						Instrument:   &models.AccountsInstrument{Symbol: ptr.To("AAPL")},
+					},
+				},
+			},
+			NickName: ptr.To("Trading"),
+		},
+		{
+			// Account with no SecuritiesAccount: should be skipped.
+			SecuritiesAccount: nil,
+		},
+		{
+			SecuritiesAccount: &models.SecuritiesAccount{
+				AccountNumber: ptr.To("22222"),
+				Positions: []models.Position{
+					{
+						ShortQuantity: ptr.To(5.0),
+						AveragePrice:  ptr.To(200.0),
+						Instrument:    &models.AccountsInstrument{Symbol: ptr.To("TSLA")},
+					},
+				},
+			},
+		},
+	}
+
+	numberToHash := map[string]string{
+		"11111": "HASH_A",
+		"22222": "HASH_B",
+	}
+
+	entries := flattenAccountPositions(accounts, numberToHash)
+	require.Len(t, entries, 2)
+
+	assert.Equal(t, "11111", entries[0].AccountNumber)
+	assert.Equal(t, "HASH_A", entries[0].AccountHash)
+	assert.Equal(t, "Trading", entries[0].AccountNickName)
+	assert.Equal(t, "AAPL", *entries[0].Instrument.Symbol)
+
+	assert.Equal(t, "22222", entries[1].AccountNumber)
+	assert.Equal(t, "HASH_B", entries[1].AccountHash)
+	assert.Empty(t, entries[1].AccountNickName)
+	assert.Equal(t, "TSLA", *entries[1].Instrument.Symbol)
+}
+
+func TestFlattenAccountPositions_Empty(t *testing.T) {
+	entries := flattenAccountPositions(nil, nil)
+	require.NotNil(t, entries, "should return empty slice, not nil")
+	assert.Empty(t, entries)
+}
+
+func TestPositionListComputedFieldsInOutput(t *testing.T) {
+	// End-to-end test verifying computed fields appear in the JSON output.
+	account := map[string]any{
+		"securitiesAccount": map[string]any{
+			"type":          "MARGIN",
+			"accountNumber": "12345",
+			"positions": []map[string]any{
+				{
+					"longQuantity":       100.0,
+					"averagePrice":       150.0,
+					"longOpenProfitLoss": 1500.0,
+					"marketValue":        16500.0,
+					"instrument":         map[string]any{"symbol": "AAPL", "assetType": "EQUITY"},
+				},
+			},
+		},
+	}
+
+	srv := accountMockServer(t, map[string]any{
+		"/trader/v1/accounts/HASH123":  account,
+		"/trader/v1/userPreference":    map[string]any{"accounts": []any{}},
+	})
+	defer srv.Close()
+
+	c := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(srv.URL))}
+	configPath := writeAccountTestConfig(t, t.TempDir(), "")
+
+	var buf bytes.Buffer
+	cmd := PositionCommand(c, configPath, &buf)
+	cmd.ExitErrHandler = noopExitHandler
+
+	err := cmd.Run(context.Background(), []string{"position", "list", "--account", "HASH123"})
+	require.NoError(t, err)
+
+	// Decode the raw JSON to verify computed fields are present.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &raw))
+
+	dataMap, ok := raw["data"].(map[string]any)
+	require.True(t, ok, "expected data to be map[string]any")
+	positions, ok := dataMap["positions"].([]any)
+	require.True(t, ok, "expected positions to be []any")
+	pos, ok := positions[0].(map[string]any)
+	require.True(t, ok, "expected position to be map[string]any")
+
+	assert.Equal(t, 15000.0, pos["totalCostBasis"])                     // 150 * 100
+	assert.Equal(t, 1500.0, pos["unrealizedPnL"])                       // longOpenProfitLoss
+	assert.InDelta(t, 10.0, pos["unrealizedPnLPct"].(float64), 0.001)  // 1500/15000*100
+
+	// Original API fields should still be present.
+	assert.Equal(t, 100.0, pos["longQuantity"])
+	assert.Equal(t, 150.0, pos["averagePrice"])
+	assert.Equal(t, 16500.0, pos["marketValue"])
+}
+
+// Suppress unused import warnings for output package.
+var _ = output.Envelope{}

--- a/skills/schwab-read.md
+++ b/skills/schwab-read.md
@@ -87,6 +87,27 @@ schwab-agent account set-default <hash>      # Set default account
 
 Account list and get enrich results with nicknames from the preferences API (best-effort, degrades gracefully).
 
+## Positions
+
+Flat position list with account identifiers and computed cost basis / P&L fields. Uses the configured default account unless `--account` or `--all-accounts` is specified.
+
+```bash
+schwab-agent position list                   # Default account positions
+schwab-agent position list --account HASH    # Specific account
+schwab-agent position list --all-accounts    # All linked accounts
+```
+
+Each position includes the original API fields plus computed fields:
+
+| Field | Description |
+|-------|-------------|
+| `accountNumber` | Account number |
+| `accountHash` | Account hash value |
+| `accountNickName` | Nickname from preferences (if available) |
+| `totalCostBasis` | averagePrice * (longQuantity + shortQuantity) |
+| `unrealizedPnL` | longOpenProfitLoss + shortOpenProfitLoss |
+| `unrealizedPnLPct` | (unrealizedPnL / totalCostBasis) * 100 |
+
 ## Instruments
 
 ```bash
@@ -131,6 +152,8 @@ Movers flags: `--sort` (VOLUME, TRADES, PERCENT_CHANGE_UP, PERCENT_CHANGE_DOWN),
 | "Near-the-money AAPL options" | `chain get AAPL --strike-range NTM` |
 | "Theoretical pricing for AAPL" | `chain get AAPL --strategy ANALYTICAL --volatility 30 --days-to-expiration 45` |
 | "Last 3 months daily prices" | `history get AAPL --period-type month --period 3` |
+| "What positions do I have?" | `position list` |
+| "Show all positions across accounts" | `position list --all-accounts` |
 | "Show my accounts with positions" | `account list --positions` |
 | "What accounts do I have?" | `account numbers` |
 | "Find a stock by name" | `instrument search "Apple" --projection symbol-search` |

--- a/skills/schwab-trade.md
+++ b/skills/schwab-trade.md
@@ -46,7 +46,8 @@ Both are required for any mutable operation (place/cancel/replace):
 ## Listing and Getting Orders
 
 ```bash
-schwab-agent order list
+schwab-agent order list                                    # Non-terminal orders only (default)
+schwab-agent order list --status all                       # All orders including filled/canceled
 schwab-agent order list --status WORKING --from 2025-01-01 --to 2025-01-31
 schwab-agent order list --status WORKING --status PENDING_ACTIVATION
 schwab-agent order list --status WORKING,FILLED,EXPIRED
@@ -54,6 +55,8 @@ schwab-agent order get <order-id>
 ```
 
 Flags: `--status` (filter by status, repeatable), `--from`/`--to` (filter by entered time).
+
+By default, `order list` filters out terminal statuses (FILLED, CANCELED, REJECTED, EXPIRED, REPLACED) to show only actionable orders. Use `--status all` to see everything, or pass explicit statuses to override the default.
 
 The `--status` flag can be repeated or comma-separated to query multiple statuses. The Schwab API only accepts one status per request, so multiple statuses automatically fan out into separate API calls with merged, deduplicated results.
 


### PR DESCRIPTION
## Summary

- Add `position list` command with `--all-accounts` and `--account` flags, computed cost basis / P&L fields, and account nickname enrichment (#38, #40)
- Default `order list` to non-terminal statuses (filters out FILLED, CANCELED, REJECTED, EXPIRED, REPLACED); use `--status all` for unfiltered (#41)
- Update skills files, AGENTS.md, and README

Closes #38
Closes #40
Closes #41