### PR TITLE
Fix misleading error when subcommand is missing or unknown

### DIFF
--- a/internal/commands/account.go
+++ b/internal/commands/account.go
@@ -41,8 +41,9 @@ type transactionGetData struct {
 // The --account flag overrides the default account hash for all subcommands.
 func AccountCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "account",
-		Usage: "Manage Schwab trading accounts",
+		Name:   "account",
+		Usage:  "Manage Schwab trading accounts",
+		Action: requireSubcommand(),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "account",
@@ -229,8 +230,9 @@ func enrichAccountsWithPreferences(accounts []models.Account, prefs *models.User
 // and inherit the --account flag.
 func accountTransactionCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "transaction",
-		Usage: "List and look up account transactions",
+		Name:   "transaction",
+		Usage:  "List and look up account transactions",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			{
 				Name:  "list",

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -91,8 +91,9 @@ func AuthCommand(cfg *auth.Config, tokenPath string, w io.Writer) *cli.Command {
 // Tests call this directly with custom deps; production goes through AuthCommand.
 func newAuthCommand(cfg *auth.Config, tokenPath string, w io.Writer, deps authDeps) *cli.Command {
 	return &cli.Command{
-		Name:  "auth",
-		Usage: "Authentication commands",
+		Name:   "auth",
+		Usage:  "Authentication commands",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			authLoginCommand(cfg, tokenPath, w, deps),
 			authStatusCommand(cfg, tokenPath, w, deps),

--- a/internal/commands/chain.go
+++ b/internal/commands/chain.go
@@ -13,8 +13,9 @@ import (
 // ChainCommand returns the CLI command for option chain operations.
 func ChainCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "chain",
-		Usage: "Option chain operations",
+		Name:   "chain",
+		Usage:  "Option chain operations",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			chainGetCommand(c, w),
 			chainExpirationCommand(c, w),

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -1,8 +1,11 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	"github.com/urfave/cli/v3"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
@@ -72,6 +75,37 @@ func validEnumString[T ~string](valid []T) string {
 	}
 
 	return strings.Join(s, ", ")
+}
+
+// requireSubcommand returns a cli.ActionFunc that rejects direct invocation of
+// a parent command with a clear error. Without this, urfave/cli produces a
+// confusing "No help topic for '<arg>'" message when the user omits the
+// subcommand (e.g. "quote AAPL" instead of "quote get AAPL").
+func requireSubcommand() cli.ActionFunc {
+	return func(_ context.Context, cmd *cli.Command) error {
+		names := make([]string, 0, len(cmd.Commands))
+		for _, sub := range cmd.Commands {
+			// Skip auto-registered help and any explicitly hidden subcommands
+			// so users see only the real, invokable commands.
+			if sub.Hidden || sub.Name == "help" {
+				continue
+			}
+			names = append(names, sub.Name)
+		}
+		list := strings.Join(names, ", ")
+
+		if arg := cmd.Args().First(); arg != "" {
+			return apperr.NewValidationError(
+				fmt.Sprintf("unknown command %q for %q; available subcommands: %s", arg, cmd.Name, list),
+				nil,
+			)
+		}
+
+		return apperr.NewValidationError(
+			fmt.Sprintf("%q requires a subcommand: %s", cmd.Name, list),
+			nil,
+		)
+	}
 }
 
 // newValidationError creates a consistent validation error for command parsing.

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -2,11 +2,15 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 )
 
@@ -29,4 +33,47 @@ func jsonServer(body string) *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	}))
+}
+
+func TestRequireSubcommand(t *testing.T) {
+	// Arrange - build a parent command with two subcommands
+	parent := &cli.Command{
+		Name:   "parent",
+		Action: requireSubcommand(),
+		Commands: []*cli.Command{
+			{Name: "alpha", Usage: "first subcommand"},
+			{Name: "beta", Usage: "second subcommand"},
+		},
+	}
+
+	t.Run("unknown argument produces validation error", func(t *testing.T) {
+		// Act
+		err := runTestCommand(t, parent, "parent", "bogus")
+
+		// Assert
+		var valErr *apperr.ValidationError
+		require.ErrorAs(t, err, &valErr)
+		assert.Contains(t, valErr.Error(), `unknown command "bogus" for "parent"`)
+		assert.Contains(t, valErr.Error(), "alpha, beta")
+	})
+
+	t.Run("no argument produces validation error", func(t *testing.T) {
+		// Act
+		err := runTestCommand(t, parent, "parent")
+
+		// Assert
+		var valErr *apperr.ValidationError
+		require.ErrorAs(t, err, &valErr)
+		assert.Contains(t, valErr.Error(), `"parent" requires a subcommand`)
+		assert.Contains(t, valErr.Error(), "alpha, beta")
+	})
+
+	t.Run("valid subcommand is not rejected", func(t *testing.T) {
+		// Act
+		err := runTestCommand(t, parent, "parent", "alpha")
+
+		// Assert - no ValidationError means requireSubcommand didn't fire
+		var valErr *apperr.ValidationError
+		assert.False(t, errors.As(err, &valErr), "valid subcommand should not produce ValidationError")
+	})
 }

--- a/internal/commands/history.go
+++ b/internal/commands/history.go
@@ -20,8 +20,9 @@ type priceHistoryData struct {
 // HistoryCommand returns the CLI command for price history lookups.
 func HistoryCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "history",
-		Usage: "Retrieve price history for a symbol",
+		Name:   "history",
+		Usage:  "Retrieve price history for a symbol",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			{
 				Name:      "get",

--- a/internal/commands/instrument.go
+++ b/internal/commands/instrument.go
@@ -24,8 +24,9 @@ type instrumentGetData struct {
 // InstrumentCommand returns the CLI command for instrument search and lookup.
 func InstrumentCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "instrument",
-		Usage: "Search and look up instruments",
+		Name:   "instrument",
+		Usage:  "Search and look up instruments",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			{
 				Name:      "search",

--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -23,8 +23,9 @@ type moversData struct {
 // MarketCommand returns the CLI command for market hours and movers lookups.
 func MarketCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "market",
-		Usage: "Market hours and top movers",
+		Name:   "market",
+		Usage:  "Market hours and top movers",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			{
 				Name:      "hours",

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -73,8 +73,9 @@ const mutableDisabledMessage = `Mutable operations are disabled by default. ` +
 // OrderCommand returns the parent order command and all nested order workflows.
 func OrderCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "order",
-		Usage: "List, build, preview, place, cancel, and replace orders",
+		Name:   "order",
+		Usage:  "List, build, preview, place, cancel, and replace orders",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			orderListCommand(c, configPath, w),
 			orderGetCommand(c, configPath, w),

--- a/internal/commands/order_build.go
+++ b/internal/commands/order_build.go
@@ -52,8 +52,9 @@ func makeBuildOrderCommand[P any](
 // orderBuildCommand returns the parent build command for offline order construction.
 func orderBuildCommand(w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "build",
-		Usage: "Build order request JSON without calling the API",
+		Name:   "build",
+		Usage:  "Build order request JSON without calling the API",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			makeBuildOrderCommand(w, "equity", "Build an equity order request",
 				"schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 150.00 --duration DAY",

--- a/internal/commands/position.go
+++ b/internal/commands/position.go
@@ -35,8 +35,9 @@ type positionListData struct {
 // PositionCommand returns the parent CLI command for position operations.
 func PositionCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "position",
-		Usage: "View positions across accounts",
+		Name:   "position",
+		Usage:  "View positions across accounts",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			positionListCommand(c, configPath, w),
 		},

--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -29,8 +29,9 @@ var validQuoteFields = map[string]bool{
 // QuoteCommand returns the CLI command for stock quote operations.
 func QuoteCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "quote",
-		Usage: "Stock quote operations",
+		Name:   "quote",
+		Usage:  "Stock quote operations",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			quoteGetCommand(c, w),
 		},

--- a/internal/commands/symbol.go
+++ b/internal/commands/symbol.go
@@ -26,8 +26,9 @@ type symbolResult struct {
 // These are pure computation commands that do not require API authentication.
 func SymbolCommand(w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "symbol",
-		Usage: "Option symbol utilities (build and parse OCC symbols)",
+		Name:   "symbol",
+		Usage:  "Option symbol utilities (build and parse OCC symbols)",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 			symbolBuildCommand(w),
 			symbolParseCommand(w),

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -194,8 +194,9 @@ func makeSimpleTACommand(cfg simpleTAConfig, c *client.Ref, w io.Writer) *cli.Co
 // TACommand returns the CLI command for technical analysis indicators.
 func TACommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:  "ta",
-		Usage: "Technical analysis indicators",
+		Name:   "ta",
+		Usage:  "Technical analysis indicators",
+		Action: requireSubcommand(),
 		Commands: []*cli.Command{
 		makeSimpleTACommand(simpleTAConfig{
 			name:  "sma",


### PR DESCRIPTION
## Summary

- Adds `requireSubcommand()` helper that returns a `ValidationError` with available subcommands listed
- Wires the helper into all 13 parent commands that previously lacked an `Action` handler
- Before: `schwab-agent quote OUST` produced `No help topic for 'OUST'`
- After: `unknown command "OUST" for "quote"; available subcommands: get`

Closes #43

## Test plan

- `make test` passes (new `TestRequireSubcommand` covers both unknown-arg and no-arg cases)
- `make lint` clean
- Manual: `go run ./cmd/schwab-agent quote OUST` returns validation error with subcommand list
- Manual: `go run ./cmd/schwab-agent quote` returns "requires a subcommand" with list