### PR TITLE
fix: normalize single-symbol quote response to match multi-symbol shape

### DIFF
--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -118,12 +118,15 @@ func sortedQuoteFieldNames() string {
 }
 
 // quoteSingle fetches and writes a quote for a single symbol.
+// The result is wrapped in a symbol-keyed map so the response shape
+// matches multi-symbol requests (data.SYMBOL.field). This lets agents
+// parse quotes without branching on argument count. See issue #48.
 func quoteSingle(ctx context.Context, c *client.Ref, w io.Writer, symbol string, p client.QuoteParams) error {
 	quote, err := c.Quote(ctx, symbol, p)
 	if err != nil {
 		return err
 	}
-	return output.WriteSuccess(w, quote, output.NewMetadata())
+	return output.WriteSuccess(w, map[string]any{symbol: quote}, output.NewMetadata())
 }
 
 // quoteMulti fetches quotes for multiple symbols, using WritePartial when some are missing.

--- a/internal/commands/quote_test.go
+++ b/internal/commands/quote_test.go
@@ -32,7 +32,11 @@ func TestQuoteGetSingleSymbol(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "AAPL", data["symbol"])
+
+	// Single-symbol response is keyed by symbol, matching multi-symbol shape.
+	aapl, ok := data["AAPL"].(map[string]any)
+	require.True(t, ok, "single-symbol response should be nested under symbol key")
+	assert.Equal(t, "AAPL", aapl["symbol"])
 	assert.NotEmpty(t, envelope.Metadata.Timestamp)
 	assert.Empty(t, envelope.Errors)
 }
@@ -153,7 +157,10 @@ func TestQuoteGetWithFields(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "AAPL", data["symbol"])
+
+	aapl, ok := data["AAPL"].(map[string]any)
+	require.True(t, ok, "single-symbol response should be nested under symbol key")
+	assert.Equal(t, "AAPL", aapl["symbol"])
 }
 
 func TestQuoteGetMultiWithFields(t *testing.T) {
@@ -287,7 +294,10 @@ func TestQuoteGetCommaSeparatedFields(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "AAPL", data["symbol"])
+
+	aapl, ok := data["AAPL"].(map[string]any)
+	require.True(t, ok, "single-symbol response should be nested under symbol key")
+	assert.Equal(t, "AAPL", aapl["symbol"])
 }
 
 func TestQuoteGetFieldsCaseInsensitive(t *testing.T) {


### PR DESCRIPTION
## Summary

- Single-symbol `quote get` responses now nest data under the symbol key (`data.SYMBOL.field`), matching the multi-symbol response shape
- Agents no longer need to branch on argument count when parsing quote responses

**Before:** `{"data": {"symbol": "AAPL", "lastPrice": 150.0}}`
**After:** `{"data": {"AAPL": {"symbol": "AAPL", "lastPrice": 150.0}}}`

Closes #48