### PR TITLE
feat: accept symbol as positional arg for quote and history commands

### DIFF
--- a/internal/commands/history.go
+++ b/internal/commands/history.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/output"
@@ -20,13 +21,14 @@ type priceHistoryData struct {
 // HistoryCommand returns the CLI command for price history lookups.
 func HistoryCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:   "history",
-		Usage:  "Retrieve price history for a symbol",
-		Action: requireSubcommand(),
+		Name:           "history",
+		Usage:          "Retrieve price history for a symbol",
+		UsageText:      "schwab-agent history AAPL\nschwab-agent history get AAPL",
+		DefaultCommand: "get",
 		Commands: []*cli.Command{
 			{
-				Name:      "get",
-				Usage:     "Get price history candles for a symbol",
+				Name:  "get",
+				Usage: "Get price history candles for a symbol",
 				UsageText: `schwab-agent history get AAPL
 schwab-agent history get AAPL --period-type day --period 5 --frequency-type minute --frequency 15
 schwab-agent history get AAPL --from 1735689600000 --to 1743379200000`,
@@ -39,21 +41,28 @@ schwab-agent history get AAPL --from 1735689600000 --to 1743379200000`,
 					&cli.StringFlag{Name: "to", Usage: "End date (milliseconds since epoch)"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
+					// Reject extra positional args so "history AAPL MSFT" doesn't
+					// silently drop the second symbol. Only one symbol is supported.
+					args := cmd.Args().Slice()
+					if len(args) > 1 {
+						return apperr.NewValidationError("exactly one symbol is required", nil)
+					}
+
 					symbol := cmd.Args().First()
-				if err := requireArg(symbol, "symbol"); err != nil {
-					return err
-				}
+					if err := requireArg(symbol, "symbol"); err != nil {
+						return err
+					}
 
-				params := client.HistoryParams{
-					PeriodType:    cmd.String("period-type"),
-					Period:        cmd.String("period"),
-					FrequencyType: cmd.String("frequency-type"),
-					Frequency:     cmd.String("frequency"),
-					StartDate:     cmd.String("from"),
-					EndDate:       cmd.String("to"),
-				}
+					params := client.HistoryParams{
+						PeriodType:    cmd.String("period-type"),
+						Period:        cmd.String("period"),
+						FrequencyType: cmd.String("frequency-type"),
+						Frequency:     cmd.String("frequency"),
+						StartDate:     cmd.String("from"),
+						EndDate:       cmd.String("to"),
+					}
 
-				result, err := c.PriceHistory(ctx, symbol, &params)
+					result, err := c.PriceHistory(ctx, symbol, &params)
 					if err != nil {
 						return err
 					}

--- a/internal/commands/history_test.go
+++ b/internal/commands/history_test.go
@@ -35,6 +35,27 @@ func TestHistoryCommand_Get_Success(t *testing.T) {
 	assert.NotEmpty(t, envelope.Metadata.Timestamp)
 }
 
+func TestHistoryCommand_Shorthand_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"symbol":"AAPL","empty":false,"candles":[{"open":148.0,"close":150.25}]}`))
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	cmd := HistoryCommand(testClient(t, srv), &buf)
+	require.NoError(t, runTestCommand(t, cmd, "history", "AAPL"))
+
+	var envelope output.Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.NotNil(t, envelope.Data)
+	assert.NotEmpty(t, envelope.Metadata.Timestamp)
+}
+
 func TestHistoryCommand_Get_WithFlags(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
@@ -97,6 +118,37 @@ func TestHistoryCommand_Get_MissingSymbol(t *testing.T) {
 
 	var valErr *apperr.ValidationError
 	assert.ErrorAs(t, err, &valErr)
+}
+
+func TestHistoryCommand_Get_ExtraArgs(t *testing.T) {
+	server := jsonServer(`{}`)
+	defer server.Close()
+
+	// "history get AAPL MSFT" should reject the extra positional arg
+	// since the command only accepts a single symbol.
+	var buf bytes.Buffer
+	cmd := HistoryCommand(testClient(t, server), &buf)
+	err := runTestCommand(t, cmd, "history", "get", "AAPL", "MSFT")
+	require.Error(t, err)
+
+	var valErr *apperr.ValidationError
+	assert.ErrorAs(t, err, &valErr)
+	assert.Contains(t, err.Error(), "exactly one symbol")
+}
+
+func TestHistoryCommand_Shorthand_ExtraArgs(t *testing.T) {
+	server := jsonServer(`{}`)
+	defer server.Close()
+
+	// "history AAPL MSFT" via shorthand should also reject extra args.
+	var buf bytes.Buffer
+	cmd := HistoryCommand(testClient(t, server), &buf)
+	err := runTestCommand(t, cmd, "history", "AAPL", "MSFT")
+	require.Error(t, err)
+
+	var valErr *apperr.ValidationError
+	assert.ErrorAs(t, err, &valErr)
+	assert.Contains(t, err.Error(), "exactly one symbol")
 }
 
 func TestHistoryCommand_Get_APIError(t *testing.T) {

--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -29,9 +29,10 @@ var validQuoteFields = map[string]bool{
 // QuoteCommand returns the CLI command for stock quote operations.
 func QuoteCommand(c *client.Ref, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:   "quote",
-		Usage:  "Stock quote operations",
-		Action: requireSubcommand(),
+		Name:           "quote",
+		Usage:          "Stock quote operations",
+		UsageText:      "schwab-agent quote AAPL\nschwab-agent quote AAPL MSFT NVDA\nschwab-agent quote get AAPL",
+		DefaultCommand: "get",
 		Commands: []*cli.Command{
 			quoteGetCommand(c, w),
 		},

--- a/internal/commands/quote_test.go
+++ b/internal/commands/quote_test.go
@@ -13,57 +13,77 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestQuoteGetSingleSymbol(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/marketdata/v1/AAPL/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
+func TestQuoteGetSymbols(t *testing.T) {
+	// Table-driven test covering both explicit ("quote get") and shorthand
+	// ("quote") invocation paths for single and multi-symbol lookups.
+	// Keeping them in one table ensures the two routing paths stay in sync.
+	// Single-symbol responses are now normalized to match multi-symbol shape
+	// (keyed by symbol), so all cases use the same expectKeys assertion.
+	tests := []struct {
+		name       string
+		serverPath string
+		serverBody string
+		args       []string
+		expectKeys []string
+	}{
+		{
+			name:       "explicit single symbol",
+			serverPath: "/marketdata/v1/AAPL/quotes",
+			serverBody: `{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`,
+			args:       []string{"quote", "get", "AAPL"},
+			expectKeys: []string{"AAPL"},
+		},
+		{
+			name:       "shorthand single symbol",
+			serverPath: "/marketdata/v1/AAPL/quotes",
+			serverBody: `{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`,
+			args:       []string{"quote", "AAPL"},
+			expectKeys: []string{"AAPL"},
+		},
+		{
+			name:       "explicit multiple symbols",
+			serverPath: "/marketdata/v1/quotes",
+			serverBody: `{"AAPL":{"symbol":"AAPL","lastPrice":150.0},"MSFT":{"symbol":"MSFT","lastPrice":400.0}}`,
+			args:       []string{"quote", "get", "AAPL", "MSFT"},
+			expectKeys: []string{"AAPL", "MSFT"},
+		},
+		{
+			name:       "shorthand multiple symbols",
+			serverPath: "/marketdata/v1/quotes",
+			serverBody: `{"AAPL":{"symbol":"AAPL","lastPrice":150.0},"MSFT":{"symbol":"MSFT","lastPrice":400.0}}`,
+			args:       []string{"quote", "AAPL", "MSFT"},
+			expectKeys: []string{"AAPL", "MSFT"},
+		},
+	}
 
-	var buf bytes.Buffer
-	cmd := QuoteCommand(testClient(t, server), &buf)
-	require.NoError(t, runTestCommand(t, cmd, "quote", "get", "AAPL"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == tt.serverPath {
+					_, _ = w.Write([]byte(tt.serverBody))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer server.Close()
 
-	var envelope output.Envelope
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
-	data, ok := envelope.Data.(map[string]any)
-	require.True(t, ok)
+			var buf bytes.Buffer
+			cmd := QuoteCommand(testClient(t, server), &buf)
+			require.NoError(t, runTestCommand(t, cmd, tt.args...))
 
-	// Single-symbol response is keyed by symbol, matching multi-symbol shape.
-	aapl, ok := data["AAPL"].(map[string]any)
-	require.True(t, ok, "single-symbol response should be nested under symbol key")
-	assert.Equal(t, "AAPL", aapl["symbol"])
-	assert.NotEmpty(t, envelope.Metadata.Timestamp)
-	assert.Empty(t, envelope.Errors)
-}
+			var envelope output.Envelope
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+			data, ok := envelope.Data.(map[string]any)
+			require.True(t, ok)
 
-func TestQuoteGetMultipleSymbols(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/marketdata/v1/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0},"MSFT":{"symbol":"MSFT","lastPrice":400.0}}`))
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	var buf bytes.Buffer
-	cmd := QuoteCommand(testClient(t, server), &buf)
-	require.NoError(t, runTestCommand(t, cmd, "quote", "get", "AAPL", "MSFT"))
-
-	var envelope output.Envelope
-	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
-	data, ok := envelope.Data.(map[string]any)
-	require.True(t, ok)
-	assert.Contains(t, data, "AAPL")
-	assert.Contains(t, data, "MSFT")
-	assert.Empty(t, envelope.Errors)
-	assert.NotEmpty(t, envelope.Metadata.Timestamp)
+			for _, key := range tt.expectKeys {
+				assert.Contains(t, data, key)
+			}
+			assert.Empty(t, envelope.Errors)
+			assert.NotEmpty(t, envelope.Metadata.Timestamp)
+		})
+	}
 }
 
 func TestQuoteGetPartialSuccess(t *testing.T) {


### PR DESCRIPTION
Closes #50.

Allows quote and history to default to their get subcommand when a symbol is passed directly. Existing get forms remain supported, with shorthand tests added for quote and history.