### PR TITLE
feat: accept --order-id for order commands

### DIFF
--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -198,11 +198,13 @@ schwab-agent order list --from 2025-01-01 --to 2025-01-31`,
 // orderGetCommand returns a single order by account and ID.
 func orderGetCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:      "get",
-		Usage:     "Get an order by ID",
-		UsageText: "schwab-agent order get 1234567890",
+		Name:  "get",
+		Usage: "Get an order by ID",
+		UsageText: `schwab-agent order get 1234567890
+schwab-agent order get --order-id 1234567890`,
 		ArgsUsage: "<order-id>",
 		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "order-id", Usage: "Order ID"},
 			&cli.StringFlag{Name: "account", Usage: "Account hash value"},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -390,11 +392,13 @@ func orderPreviewCommand(c *client.Ref, configPath string, w io.Writer) *cli.Com
 // orderCancelCommand cancels an existing order.
 func orderCancelCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:      "cancel",
-		Usage:     "Cancel an order",
-		UsageText: "schwab-agent order cancel 1234567890 --confirm",
+		Name:  "cancel",
+		Usage: "Cancel an order",
+		UsageText: `schwab-agent order cancel 1234567890 --confirm
+schwab-agent order cancel --order-id 1234567890 --confirm`,
 		ArgsUsage: "<order-id>",
 		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "order-id", Usage: "Order ID"},
 			&cli.BoolFlag{Name: "confirm", Usage: "Confirm cancellation"},
 			&cli.StringFlag{Name: "account", Usage: "Account hash value"},
 		},
@@ -429,11 +433,13 @@ func orderCancelCommand(c *client.Ref, configPath string, w io.Writer) *cli.Comm
 // orderReplaceCommand replaces an existing order with an equity order payload.
 func orderReplaceCommand(c *client.Ref, configPath string, w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:      "replace",
-		Usage:     "Replace an order with a new equity order spec",
-		UsageText: "schwab-agent order replace 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY --confirm",
+		Name:  "replace",
+		Usage: "Replace an order with a new equity order spec",
+		UsageText: `schwab-agent order replace 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY --confirm
+schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY --confirm`,
 		ArgsUsage: "<order-id>",
 		Flags: append(equityOrderFlags(),
+			&cli.StringFlag{Name: "order-id", Usage: "Order ID"},
 			&cli.BoolFlag{Name: "confirm", Usage: "Confirm replacement"},
 			&cli.StringFlag{Name: "account", Usage: "Account hash value"},
 		),
@@ -486,10 +492,12 @@ func orderRepeatCommand(c *client.Ref, configPath string, w io.Writer) *cli.Comm
 		Name:  "repeat",
 		Usage: "Repeat a previous order (fetch, convert, and optionally place)",
 		UsageText: `schwab-agent order repeat 1234567890
+schwab-agent order repeat --order-id 1234567890
 schwab-agent order repeat 1234567890 --preview
 schwab-agent order repeat 1234567890 --confirm`,
 		ArgsUsage: "<order-id>",
 		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "order-id", Usage: "Order ID"},
 			&cli.BoolFlag{Name: "build", Usage: "Output reconstructed order request JSON (default)"},
 			&cli.BoolFlag{Name: "preview", Usage: "Preview the order without placing it"},
 			&cli.BoolFlag{Name: "confirm", Usage: "Place the order (requires safety guards)"},
@@ -991,11 +999,16 @@ func requireConfirm(confirmed bool) error {
 	return apperr.NewValidationError(confirmOrderMessage, nil)
 }
 
-// parseRequiredOrderID parses the first positional argument as an order ID.
+// parseRequiredOrderID parses the --order-id flag or first positional argument as an order ID.
 func parseRequiredOrderID(cmd *cli.Command) (int64, error) {
-	value := strings.TrimSpace(cmd.Args().First())
+	// Flag takes priority over positional arg, matching resolveAccount() convention.
+	value := strings.TrimSpace(cmd.String("order-id"))
 	if value == "" {
-		return 0, newValidationError("order-id is required")
+		value = strings.TrimSpace(cmd.Args().First())
+	}
+
+	if value == "" {
+		return 0, newValidationError("order-id is required (provide as positional arg or --order-id flag)")
 	}
 
 	orderID, err := strconv.ParseInt(value, 10, 64)

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -160,7 +160,8 @@ func TestOrderConfirmGate(t *testing.T) {
 func TestOrderPreviewSpecModes(t *testing.T) {
 	t.Parallel()
 
-	previewResponse := models.PreviewOrder{OrderID: new(int64(4242))}
+	orderID := int64(4242)
+	previewResponse := models.PreviewOrder{OrderID: &orderID}
 	var requestBodies []string
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -420,7 +421,8 @@ func TestOrderMutableGuardTakesPriorityOverConfirm(t *testing.T) {
 func TestOrderPreviewNotBlockedByMutableGuard(t *testing.T) {
 	t.Parallel()
 
-	previewResponse := models.PreviewOrder{OrderID: new(int64(9999))}
+	orderID := int64(9999)
+	previewResponse := models.PreviewOrder{OrderID: &orderID}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(previewResponse))
@@ -1759,6 +1761,66 @@ func TestOrderGetSuccess(t *testing.T) {
 	assert.Equal(t, "FILLED", order["status"])
 }
 
+func TestOrderGetOrderIDFlagSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderId":1234567890,"status":"FILLED"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "get", "--order-id", "1234567890")
+
+	// Assert
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1234567890), order["orderId"])
+}
+
+func TestOrderGetOrderIDFlagWinsOverPositional(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderId":1234567890,"status":"FILLED"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "get", "--order-id", "1234567890", "9999999")
+
+	// Assert
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1234567890), order["orderId"])
+}
+
 func TestOrderGetNoAccount(t *testing.T) {
 	t.Parallel()
 
@@ -1789,7 +1851,7 @@ func TestOrderGetMissingOrderID(t *testing.T) {
 	assert.Empty(t, stdout)
 	var validationErr *apperr.ValidationError
 	require.ErrorAs(t, err, &validationErr)
-	assert.Equal(t, "order-id is required", validationErr.Error())
+	assert.Contains(t, validationErr.Error(), "order-id is required")
 }
 
 func TestOrderGetInvalidOrderID(t *testing.T) {
@@ -1832,6 +1894,32 @@ func TestOrderCancelSuccess(t *testing.T) {
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(12345), data["orderId"])
+	assert.Equal(t, true, data["canceled"])
+}
+
+func TestOrderCancelOrderIDFlagSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfigMutable(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "cancel", "--order-id", "1234567890", "--confirm")
+
+	// Assert
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1234567890), data["orderId"])
 	assert.Equal(t, true, data["canceled"])
 }
 
@@ -1930,6 +2018,47 @@ func TestOrderReplaceSuccess(t *testing.T) {
 	assert.Equal(t, true, data["replaced"])
 }
 
+func TestOrderReplaceOrderIDFlagSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfigMutable(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(
+		t,
+		cliClient,
+		configPath,
+		"",
+		"order", "replace",
+		"--order-id", "1234567890",
+		"--symbol", "AAPL",
+		"--action", "BUY",
+		"--quantity", "10",
+		"--type", "LIMIT",
+		"--price", "185.25",
+		"--duration", "DAY",
+		"--session", "NORMAL",
+		"--confirm",
+	)
+
+	// Assert
+	require.NoError(t, err)
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1234567890), data["orderId"])
+	assert.Equal(t, true, data["replaced"])
+}
+
 func TestOrderReplaceMutableDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -1983,6 +2112,8 @@ func TestParseRequiredOrderID(t *testing.T) {
 	}{
 		{name: "empty", args: []string{"order-test"}, wantError: "order-id is required"},
 		{name: "valid int", args: []string{"order-test", "12345"}, wantID: 12345},
+		{name: "flag valid int", args: []string{"order-test", "--order-id", "67890"}, wantID: 67890},
+		{name: "flag wins over positional", args: []string{"order-test", "--order-id", "67890", "12345"}, wantID: 67890},
 		{name: "invalid non-numeric", args: []string{"order-test", "abc"}, wantError: "order-id must be a valid integer"},
 		{name: "negative int", args: []string{"order-test", "-99"}, wantError: "order-id must be a positive integer"},
 		{name: "zero", args: []string{"order-test", "0"}, wantError: "order-id must be a positive integer"},
@@ -1996,6 +2127,9 @@ func TestParseRequiredOrderID(t *testing.T) {
 			var parsedID int64
 			cmd := &cli.Command{
 				Name: "order-test",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "order-id", Usage: "Order ID"},
+				},
 				Action: func(_ context.Context, cmd *cli.Command) error {
 					var err error
 					parsedID, err = parseRequiredOrderID(cmd)
@@ -2016,7 +2150,7 @@ func TestParseRequiredOrderID(t *testing.T) {
 			require.Error(t, err)
 			var validationErr *apperr.ValidationError
 			require.ErrorAs(t, err, &validationErr)
-			assert.Equal(t, tc.wantError, validationErr.Error())
+			assert.Contains(t, validationErr.Error(), tc.wantError)
 		})
 	}
 }
@@ -2240,13 +2374,14 @@ func TestOrderReplace_InvalidAction(t *testing.T) {
 // validPrimarySpec returns a minimal valid primary order spec for FTS tests.
 func validPrimarySpec(t *testing.T) string {
 	t.Helper()
+	price := 150.0
 
 	return mustMarshalJSON(t, models.OrderRequest{
 		Session:           models.SessionNormal,
 		Duration:          models.DurationDay,
 		OrderType:         models.OrderTypeLimit,
 		OrderStrategyType: models.OrderStrategyTypeSingle,
-		Price:             new(150.0),
+		Price:             &price,
 		OrderLegCollection: []models.OrderLegCollection{
 			{
 				Instruction: models.InstructionBuy,
@@ -2260,13 +2395,14 @@ func validPrimarySpec(t *testing.T) string {
 // validSecondarySpec returns a minimal valid secondary order spec for FTS tests.
 func validSecondarySpec(t *testing.T) string {
 	t.Helper()
+	price := 160.0
 
 	return mustMarshalJSON(t, models.OrderRequest{
 		Session:           models.SessionNormal,
 		Duration:          models.DurationDay,
 		OrderType:         models.OrderTypeLimit,
 		OrderStrategyType: models.OrderStrategyTypeSingle,
-		Price:             new(160.0),
+		Price:             &price,
 		OrderLegCollection: []models.OrderLegCollection{
 			{
 				Instruction: models.InstructionSell,
@@ -2392,6 +2528,7 @@ func TestOrderBuildFTSInvalidJSON(t *testing.T) {
 
 func TestOrderBuildFTSRejectsComplexPrimary(t *testing.T) {
 	t.Parallel()
+	price := 150.0
 
 	// A primary with OrderStrategyType=TRIGGER should be rejected by
 	// ValidateFTSOrder since FTS legs cannot be nested complex orders.
@@ -2400,7 +2537,7 @@ func TestOrderBuildFTSRejectsComplexPrimary(t *testing.T) {
 		Duration:          models.DurationDay,
 		OrderType:         models.OrderTypeLimit,
 		OrderStrategyType: models.OrderStrategyTypeTrigger,
-		Price:             new(150.0),
+		Price:             &price,
 		OrderLegCollection: []models.OrderLegCollection{
 			{
 				Instruction: models.InstructionBuy,
@@ -2697,6 +2834,33 @@ func TestOrderRepeatBuildDefault(t *testing.T) {
 	assert.NotContains(t, stdout, `"orderId"`)
 	assert.NotContains(t, stdout, `"status"`)
 	assert.NotContains(t, stdout, `"filledQuantity"`)
+}
+
+func TestOrderRepeatOrderIDFlagBuild(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(sampleOrderJSON()))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfig(t, "hash123")
+	cliClient := testClient(t, server)
+
+	// Act
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "repeat", "--order-id", "1234567890")
+
+	// Assert
+	require.NoError(t, err)
+	order := decodeOrderRequest(t, stdout)
+	assert.Equal(t, models.OrderTypeLimit, order.OrderType)
+	assert.NotContains(t, stdout, `"orderId"`)
 }
 
 func TestOrderRepeatBuildExplicit(t *testing.T) {
@@ -3130,7 +3294,7 @@ func TestOrderRepeatMissingOrderID(t *testing.T) {
 	assert.Empty(t, stdout)
 	var validationErr *apperr.ValidationError
 	require.ErrorAs(t, err, &validationErr)
-	assert.Equal(t, "order-id is required", validationErr.Error())
+	assert.Contains(t, validationErr.Error(), "order-id is required")
 }
 
 func TestOrderRepeatMultipleModes(t *testing.T) {

--- a/skills/schwab-trade.md
+++ b/skills/schwab-trade.md
@@ -40,8 +40,8 @@ Both are required for any mutable operation (place/cancel/replace):
 | "calendar spread" | `order build calendar --call --open ...` |
 | "diagonal spread" | `order build diagonal --call --open ...` |
 | "collar" | `order build collar --open ...` |
-| "repeat a previous order" | `order repeat <order-id>` |
-| "re-place that order" | `order repeat <order-id> --confirm` |
+| "repeat a previous order" | `order repeat <order-id>` or `order repeat --order-id ID` |
+| "re-place that order" | `order repeat <order-id> --confirm` or `order repeat --order-id ID --confirm` |
 
 ## Listing and Getting Orders
 
@@ -52,6 +52,7 @@ schwab-agent order list --status WORKING --from 2025-01-01 --to 2025-01-31
 schwab-agent order list --status WORKING --status PENDING_ACTIVATION
 schwab-agent order list --status WORKING,FILLED,EXPIRED
 schwab-agent order get <order-id>
+schwab-agent order get --order-id <order-id>
 ```
 
 Flags: `--status` (filter by status, repeatable), `--from`/`--to` (filter by entered time).
@@ -100,7 +101,9 @@ schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type 
 
 ```bash
 schwab-agent order cancel <order-id> --confirm
+schwab-agent order cancel --order-id <order-id> --confirm
 schwab-agent order replace <order-id> --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 205 --confirm
+schwab-agent order replace --order-id <order-id> --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 205 --confirm
 ```
 
 Replace cancels the original and creates a new order (new ID). Only equity order flags accepted. Original order status becomes REPLACED.
@@ -113,9 +116,11 @@ Fetch an existing order, convert it to a submittable request, and optionally pla
 schwab-agent order repeat <order-id>            # Output reconstructed order JSON (default, same as --build)
 schwab-agent order repeat <order-id> --preview   # Preview without placing
 schwab-agent order repeat <order-id> --confirm   # Place the order (requires safety guards)
+schwab-agent order repeat --order-id <order-id>  # Flag form also accepted
 ```
 
 Only one mode flag allowed. `--build`, `--preview`, and `--confirm` are mutually exclusive.
+For order get, cancel, replace, and repeat, `--order-id` takes priority when both the flag and positional order ID are provided.
 
 ## Spec Mode
 


### PR DESCRIPTION
Adds --order-id as an alternative to the positional order ID for order get, cancel, replace, and repeat. The flag wins when both forms are provided, matching the existing account resolution precedence.

Closes #51