### PR TITLE
fix: improve missing order place subcommand error

### DIFF
--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -80,16 +80,7 @@ func validEnumString[T ~string](valid []T) string {
 // subcommand (e.g. "quote AAPL" instead of "quote get AAPL").
 func requireSubcommand() cli.ActionFunc {
 	return func(_ context.Context, cmd *cli.Command) error {
-		names := make([]string, 0, len(cmd.Commands))
-		for _, sub := range cmd.Commands {
-			// Skip auto-registered help and any explicitly hidden subcommands
-			// so users see only the real, invokable commands.
-			if sub.Hidden || sub.Name == "help" {
-				continue
-			}
-			names = append(names, sub.Name)
-		}
-		list := strings.Join(names, ", ")
+		list := strings.Join(visibleSubcommandNames(cmd), ", ")
 
 		if arg := cmd.Args().First(); arg != "" {
 			return apperr.NewValidationError(
@@ -103,6 +94,44 @@ func requireSubcommand() cli.ActionFunc {
 			nil,
 		)
 	}
+}
+
+// suggestSubcommands handles usage errors that happen before Action runs. This
+// is most useful for parent commands whose subcommands own distinct flags: an
+// unknown flag on the parent usually means the user skipped the subcommand.
+func suggestSubcommands(_ context.Context, cmd *cli.Command, err error, _ bool) error {
+	if !strings.Contains(err.Error(), "flag provided but not defined") {
+		return err
+	}
+
+	names := visibleSubcommandNames(cmd)
+	if len(names) == 0 {
+		return err
+	}
+
+	return apperr.NewValidationError(
+		fmt.Sprintf(
+			"%q requires a subcommand: %s (%s)",
+			cmd.FullName(),
+			strings.Join(names, ", "),
+			err.Error(),
+		),
+		err,
+	)
+}
+
+// visibleSubcommandNames returns only invokable subcommands for user-facing
+// errors, omitting hidden commands and urfave/cli's built-in help command.
+func visibleSubcommandNames(cmd *cli.Command) []string {
+	names := make([]string, 0, len(cmd.Commands))
+	for _, sub := range cmd.Commands {
+		if sub.Hidden || sub.Name == "help" {
+			continue
+		}
+		names = append(names, sub.Name)
+	}
+
+	return names
 }
 
 // newValidationError creates a consistent validation error for command parsing.

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -233,6 +233,12 @@ func orderPlaceCommand(c *client.Ref, configPath string, w io.Writer) *cli.Comma
 		Usage: "Place an order",
 		UsageText: `schwab-agent order place --spec @order.json --confirm
 schwab-agent order place --spec - --confirm`,
+		// OnUsageError fires when urfave/cli encounters an unknown flag during
+		// parsing. For `order place`, this typically means the user forgot to
+		// specify a subcommand (equity, option, bracket, oco) and used flags
+		// that belong to one of those subcommands. Overriding the confusing
+		// default "flag provided but not defined" with a subcommand hint.
+		OnUsageError: suggestSubcommands,
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "spec", Usage: "Inline JSON, @file, or - for stdin"},
 			&cli.BoolFlag{Name: "confirm", Usage: "Confirm order placement"},

--- a/internal/commands/order_build.go
+++ b/internal/commands/order_build.go
@@ -26,7 +26,7 @@ func makeBuildOrderCommand[P any](
 		Name:      name,
 		Usage:     usage,
 		UsageText: usageText,
-		Flags: flags,
+		Flags:     flags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			_ = ctx
 
@@ -52,9 +52,10 @@ func makeBuildOrderCommand[P any](
 // orderBuildCommand returns the parent build command for offline order construction.
 func orderBuildCommand(w io.Writer) *cli.Command {
 	return &cli.Command{
-		Name:   "build",
-		Usage:  "Build order request JSON without calling the API",
-		Action: requireSubcommand(),
+		Name:         "build",
+		Usage:        "Build order request JSON without calling the API",
+		OnUsageError: suggestSubcommands,
+		Action:       requireSubcommand(),
 		Commands: []*cli.Command{
 			makeBuildOrderCommand(w, "equity", "Build an equity order request",
 				"schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 150.00 --duration DAY",

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -355,6 +355,45 @@ func TestOrderPlaceSpecFromFile(t *testing.T) {
 	assert.Equal(t, float64(24680), data["orderId"])
 }
 
+func TestOrderPlaceUnknownFlagSuggestsSubcommand(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	configPath := writeTestConfigMutable(t, "test-account-hash")
+
+	// Act
+	stdout, err := runOrderCommand(t, nil, configPath, "", "order", "place", "--symbol", "AAPL")
+
+	// Assert
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+
+	var valErr *apperr.ValidationError
+	require.ErrorAs(t, err, &valErr)
+	assert.Contains(t, valErr.Error(), "order place")
+	assert.Contains(t, valErr.Error(), "requires a subcommand")
+	assert.Contains(t, valErr.Error(), "equity")
+	assert.Contains(t, valErr.Error(), "option")
+	assert.Contains(t, valErr.Error(), "bracket")
+	assert.Contains(t, valErr.Error(), "oco")
+	assert.Contains(t, valErr.Error(), "flag provided but not defined: -symbol")
+}
+
+func TestOrderPlaceSpecMissingValueKeepsOriginalUsageError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	configPath := writeTestConfigMutable(t, "test-account-hash")
+
+	// Act
+	stdout, err := runOrderCommand(t, nil, configPath, "", "order", "place", "--spec")
+
+	// Assert
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.NotContains(t, err.Error(), "requires a subcommand")
+}
+
 func TestOrderMutableGuard(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Return a validation error that points `order place --symbol ...` users to the supported subcommands.
- Reuse the same unknown-flag hint for `order build` and keep other usage errors unchanged.
- Add regression coverage for the missing subcommand case and parent `--spec` flag parsing.

Closes #52