### PR TITLE
fix: default --points to 1 instead of 0 for TA indicators

### DIFF
--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -148,7 +148,7 @@ func taIndicatorFlags(defaultPeriod int) []cli.Flag {
 	return []cli.Flag{
 		&cli.IntFlag{Name: "period", Usage: "Indicator period", Value: defaultPeriod},
 		&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
-		&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 0},
+		&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
 	}
 }
 
@@ -248,7 +248,7 @@ schwab-agent ta macd AAPL --fast 12 --slow 26 --signal 9 --interval daily --poin
 			&cli.IntFlag{Name: "slow", Usage: "Slow EMA period", Value: 26},
 			&cli.IntFlag{Name: "signal", Usage: "Signal EMA period", Value: 9},
 			&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
-			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 0},
+			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			symbol := cmd.Args().First()
@@ -365,7 +365,7 @@ schwab-agent ta bbands AAPL --period 20 --std-dev 2.0 --interval daily --points 
 			&cli.IntFlag{Name: "period", Usage: "BBands period", Value: 20},
 			&cli.Float64Flag{Name: "std-dev", Usage: "Standard deviations", Value: 2.0},
 			&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
-			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 0},
+			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			symbol := cmd.Args().First()
@@ -434,7 +434,7 @@ schwab-agent ta stoch AAPL --k-period 14 --smooth-k 3 --d-period 3 --interval da
 			&cli.IntFlag{Name: "smooth-k", Usage: "Slow %K smoothing period", Value: 3},
 			&cli.IntFlag{Name: "d-period", Usage: "Slow %D period", Value: 3},
 			&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
-			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 0},
+			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			symbol := cmd.Args().First()
@@ -582,7 +582,7 @@ schwab-agent ta vwap AAPL --interval 5min --points 10`,
 		// VWAP is cumulative - no --period flag. Only --interval and --points.
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
-			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 0},
+			&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			symbol := cmd.Args().First()

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -211,7 +211,7 @@ func TestTASMA_PeriodFlag(t *testing.T) {
 	// Act
 	var buf bytes.Buffer
 	cmd := TACommand(testClient(t, srv), &buf)
-	require.NoError(t, runTestCommand(t, cmd, "ta", "sma", "--period", "10", "AAPL"))
+	require.NoError(t, runTestCommand(t, cmd, "ta", "sma", "--period", "10", "--points", "0", "AAPL"))
 
 	// Assert
 	_, data := decodeTAEnvelope(t, &buf)
@@ -220,7 +220,7 @@ func TestTASMA_PeriodFlag(t *testing.T) {
 
 	values, ok := data["values"].([]any)
 	require.True(t, ok)
-	// SMA(10) on 50 candles: 50 - 10 + 1 = 41 values
+	// SMA(10) on 50 candles: 50 - 10 + 1 = 41 values (--points 0 returns all)
 	assert.Len(t, values, 41)
 }
 

--- a/skills/schwab-ta.md
+++ b/skills/schwab-ta.md
@@ -7,7 +7,7 @@ Eleven indicators computed locally from Schwab price history. Pattern: `schwab-a
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--interval` | daily | daily, weekly, 1min, 5min, 15min, 30min |
-| `--points` | 0 (all) | Limit output to N most recent values |
+| `--points` | 1 | Limit output to N most recent values (0 = all) |
 
 Most indicators also accept `--period` (lookback window). Exceptions noted below.
 
@@ -116,14 +116,14 @@ Scalar indicators (HV, Expected Move) return fields directly in `data` instead o
 
 | Intent | Command |
 |--------|---------|
-| "Is AAPL overbought?" | `ta rsi AAPL --points 1` |
-| "20-day moving average" | `ta sma AAPL --period 20 --points 1` |
+| "Is AAPL overbought?" | `ta rsi AAPL` |
+| "20-day moving average" | `ta sma AAPL` |
 | "50/200-day SMA crossover" | `ta sma AAPL --period 50 --points 5` then `--period 200 --points 5` |
 | "MACD signal" | `ta macd AAPL --points 5` |
-| "How volatile is AAPL?" | `ta atr AAPL --points 1` |
-| "Near Bollinger Band?" | `ta bbands AAPL --points 1` |
-| "Stochastic reading" | `ta stoch AAPL --points 1` |
-| "Trending or ranging?" | `ta adx AAPL --points 1` |
+| "How volatile is AAPL?" | `ta atr AAPL` |
+| "Near Bollinger Band?" | `ta bbands AAPL` |
+| "Stochastic reading" | `ta stoch AAPL` |
+| "Trending or ranging?" | `ta adx AAPL` |
 | "EMA crossover (12/26)" | `ta ema AAPL --period 12 --points 5` then `--period 26 --points 5` |
 | "Intraday RSI (5min)" | `ta rsi AAPL --interval 5min --points 20` |
 | "Weekly MACD" | `ta macd NVDA --interval weekly --points 10` |


### PR DESCRIPTION
## Summary

- Default `--points` from 0 (all) to 1 for all TA indicator commands (SMA, EMA, RSI, ATR, ADX, HV, MACD, BBands, Stochastic, VWAP)
- Agents almost always need the latest value, not the full time series. `--points 0` still returns everything.
- Skill doc updated: new default reflected in shared flags table, redundant `--points 1` removed from single-value recipes

Closes #56