### PR TITLE
feat: add jira-agent skill files

### DIFF
--- a/skills/jira-agent/AGENTS.md
+++ b/skills/jira-agent/AGENTS.md
@@ -1,0 +1,65 @@
+# skills/jira-agent agent guide
+
+Generated: Tue Apr 28 2026. Applies to the embedded `jira-agent` LLM skill documentation.
+
+## Purpose
+
+This directory is the AI-facing manual for the `jira-agent` CLI. It helps tool-calling LLMs pick the right Jira command, request bounded output, avoid unsafe writes, and recover from structured errors. Keep it concise, accurate, and source-backed by the live `jira-agent schema` command.
+
+Keep this file, the root `AGENTS.md`, and the skill docs current anytime code changes. Code changes that affect agent-visible behavior must update the relevant `skills/jira-agent` files in the same change.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `SKILL.md` | Entry point with YAML front matter, auth, global flags, schema discovery, output contracts, exit codes, gotchas. |
+| `issues.md` | Issue CRUD, search, bulk operations, metadata discovery. |
+| `issue-workflows.md` | Transitions, assignments, comments, worklogs, watchers, votes, attachments, links, changelog, ranking, notifications. |
+| `agile.md` | Boards, sprints, epics, backlog, Jira Software Agile API workflows. |
+| `project-management.md` | Projects, components, versions. |
+| `admin-reference.md` | Fields, users, groups, filters, permissions, dashboards, workflows, statuses, priorities, resolutions, issue types, labels, JQL helpers, server info. |
+
+## Maintenance trigger
+
+Update these docs in the same change when any code change affects these areas:
+
+- Command names, paths, aliases, or default commands.
+- Agent-relevant flags, args, required flags, or examples.
+- Auth behavior, write-enable behavior, or error remediation.
+- Output envelope, error envelope, CSV/TSV behavior, pagination, or exit codes.
+- Recommended LLM workflows such as schema discovery, field discovery, and bulk patterns.
+
+## Source of truth
+
+- The live `jira-agent schema` command is authoritative. Do not hand-invent flags or command paths.
+- Preferred discovery commands for checking examples:
+  - `jira-agent schema --compact`
+  - `jira-agent schema --compact --depth 1`
+  - `jira-agent schema --category issue --required-only --depth 1`
+  - `jira-agent schema --command "issue create" --required-only`
+- Examples should prefer canonical paths over aliases. Use `issue bulk <action>` and `issue remote-link`.
+- `--pretty` is for humans only. It must never appear in skill files or LLM-facing examples.
+
+## Writing style
+
+- Preserve YAML front matter in `SKILL.md`; external skill loaders consume it.
+- Keep docs token-efficient. Use one accurate default example plus only non-obvious flags.
+- Prefer workflows over exhaustive flag catalogs because schema provides the catalog.
+- Use terse bullets and command examples that an LLM can copy after filling placeholders.
+- Explain Jira gotchas that cause failed tool calls: account IDs, transition IDs, ADF JSON, custom field JSON, visibility pairs, write protection, pagination differences.
+
+## Output contract to document
+
+- Default output is JSON. CSV/TSV are for flat tables.
+- Success JSON has `data`, optional `errors`, and `metadata`; do not mention a `status` field unless the code adds one.
+- Error output is always JSON with `error.code`, `error.message`, and optional `error.details`.
+- `schema` emits raw JSON, not the success envelope.
+- Exit codes: 0 success, 2 not found, 3 auth, 4 API, 5 validation, 1 unknown.
+- Pagination differs by endpoint. `issue search` can use cursor-style `--next-page-token`; most list commands use `--start-at` and `--max-results`.
+
+## Safety guidance
+
+- Writes are blocked unless `JIRA_ALLOW_WRITES=true` or config has `"i-too-like-to-live-dangerously": true`.
+- LLM-facing docs must not encourage retries of blocked writes. Tell the user what enablement is missing.
+- Read examples should request minimal fields when possible, for example `--fields key,summary,status`.
+- Mutation examples should show discovery first when Jira configuration affects required fields, especially `issue meta` before issue create/edit.

--- a/skills/jira-agent/SKILL.md
+++ b/skills/jira-agent/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: jira-agent
+description: "Jira Cloud CLI for AI agents. Structured JSON/CSV/TSV output, semantic exit codes. Covers: issue CRUD, search, bulk ops (create/fetch/delete/edit/move/transition), transitions, assignments, comments, worklogs, watchers, votes, attachments, issue links, remote links, changelog, ranking, notifications; agile boards, sprints, epics, backlogs; projects, components, versions; fields (contexts/options), users, groups, filters, permissions, dashboards, workflows, statuses, priorities, resolutions, issue types, labels, JQL helpers, and server info. Triggers: 'jira', 'jira issue', 'jira search', 'jql', 'jira create', 'jira bulk', 'jira transition', 'jira assign', 'jira comment', 'jira worklog', 'jira sprint', 'jira epic', 'jira board', 'jira backlog', 'jira component', 'jira version', 'jira project', 'jira field', 'jira user', 'jira group', 'jira filter', 'jira permission', 'jira dashboard', 'jira workflow', 'jira status', 'jira-agent'."
+metadata:
+  author: "Major Hayden"
+  version: "2.0.0"
+---
+
+# jira-agent CLI
+
+Go CLI for Jira Cloud REST API v3. All output is structured, errors always JSON, exit codes are semantic.
+
+## Feedback
+
+If you hit bugs, confusing usability, missing guidance, or token-inefficient workflows while using `jira-agent`, encourage the user to open a GitHub issue at `github.com/major/jira-agent`. Offer to open the issue for them with GitHub's `gh` CLI if it is installed and the user wants you to file it.
+
+## Companion Files
+
+This is the entry point. Command details are split by theme:
+
+| File | Scope |
+|------|-------|
+| [issues.md](issues.md) | Issue CRUD, search, bulk ops, meta, count |
+| [issue-workflows.md](issue-workflows.md) | Transition, assign, comment, worklog, watcher, vote, attachment, link, remote-link, changelog, rank, notify |
+| [agile.md](agile.md) | Board, sprint, epic, backlog |
+| [project-management.md](project-management.md) | Project, component, version |
+| [admin-reference.md](admin-reference.md) | Field, user, group, filter, permission, dashboard, workflow, status, priority, resolution, issuetype, label, JQL, server-info |
+
+## Auth
+
+Env vars (override config file):
+
+```bash
+export JIRA_INSTANCE="your-domain.atlassian.net"
+export JIRA_EMAIL="you@example.com"
+export JIRA_API_KEY="your-api-token"
+export JIRA_ALLOW_WRITES=true  # optional: enable write operations
+```
+
+Config file fallback: `~/.config/jira-agent/config.json` (XDG_CONFIG_HOME aware). Verify with `jira-agent whoami`.
+
+### Write Protection
+
+Writes (create, edit, delete, transition, assign) are disabled by default. Enable:
+
+- Config: `"i-too-like-to-live-dangerously": true`
+- Env: `JIRA_ALLOW_WRITES=true`
+
+Blocked writes return exit 5 with remediation. Read-only commands always work. `issue transition --list` is read-only.
+
+## Global Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--project` | `-p` | | Default Jira project key (also `JIRA_PROJECT` env) |
+| `--output` | `-o` | `json` | `json`, `csv`, or `tsv` |
+| `--verbose` | `-v` | off | Verbose logging to stderr |
+| `--config` | | | Config file path override |
+
+## Schema Discovery
+
+Use schema before guessing flags. Start compact, drill into what you need:
+
+```bash
+jira-agent schema --compact                          # command index for routing
+jira-agent schema --category issue --required-only   # one command family
+jira-agent schema --command "issue create"            # full details for one command
+jira-agent schema --command "issue link"              # subtree: returns link + all leaves
+```
+
+Parent command filters return descendant commands, so `--command "issue link"` covers `list`, `add`, `delete`, `types`.
+
+For reads/searches, request only needed fields: `--fields key,summary,status`. Use CSV/TSV for simple tables, JSON for updates or nested data.
+
+## Output
+
+### Success envelope (JSON)
+
+```json
+{
+  "data": { ... },
+  "errors": [],
+  "metadata": { "timestamp": "...", "total": 42, "returned": 10, "start_at": 0, "max_results": 50 }
+}
+```
+
+Access results via `.data`. Check `.metadata` for pagination.
+
+### Error response (always JSON, regardless of --output)
+
+```json
+{
+  "error": { "code": "NOT_FOUND", "message": "Issue KEY-999 not found", "details": "..." }
+}
+```
+
+| Code | Exit | Meaning |
+|------|------|---------|
+| `AUTH_FAILED` | 3 | Missing or invalid credentials |
+| `NOT_FOUND` | 2 | Resource does not exist |
+| `API_ERROR` | 4 | Jira API error |
+| `VALIDATION_ERROR` | 5 | Invalid input or blocked write |
+| `UNKNOWN` | 1 | Unexpected error |
+
+### CSV/TSV
+
+Flat rows with header, no envelope. Nested values become inline JSON in cells.
+
+## Gotchas
+
+- **Description**: Plain text auto-converts to ADF. Pass valid ADF JSON for structured content.
+- **Custom fields**: `--field key=value` parses value as JSON if valid, else raw string. Quote carefully in shell.
+- **Project flag**: Command-level `--project` overrides root `-p`.
+- **Type resolution**: Issue type matching is case-insensitive.
+- **Transition resolution**: Matches status/transition name (case-insensitive), not numeric ID.
+- **Schema output**: Raw JSON, not wrapped in success envelope.
+- **Pagination**: `issue search` uses `--next-page-token` (cursor). Most other list commands use `--start-at` (offset).
+- **Assignment**: `issue assign` accepts account ID, not email. `--unassign` clears, `--default` uses project default.
+- **Visibility**: Both `--visibility-type` and `--visibility-value` must be set together.
+- **Write protection**: All writes blocked unless `JIRA_ALLOW_WRITES=true` or config set. Exit 5 with remediation.

--- a/skills/jira-agent/admin-reference.md
+++ b/skills/jira-agent/admin-reference.md
@@ -1,0 +1,329 @@
+# Admin Reference
+
+Field management, users, groups, filters, permissions, dashboards, workflows, statuses, priorities, resolutions, issue types, labels, JQL helpers, and server info.
+
+## Fields
+
+### field list / search
+
+```bash
+jira-agent field list
+jira-agent field search -q "story points" --type custom
+jira-agent field search -q "priority" --type system --max-results 10
+```
+
+| Flag | Notes |
+|------|-------|
+| `-q` / `--query` | Search term |
+| `--type` | `custom` or `system` |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### field context list / create / update / delete
+
+```bash
+jira-agent field context list customfield_10001
+jira-agent field context create customfield_10001 --name "Project X Context" \
+  --projects PROJ1,PROJ2 --issue-types Story,Bug
+jira-agent field context update customfield_10001 10500 --name "Renamed"
+jira-agent field context delete customfield_10001 10500
+```
+
+| Flag | Notes |
+|------|-------|
+| `--name` | Required for create |
+| `--description` | Context description |
+| `--projects` | Comma-separated project IDs (create only) |
+| `--issue-types` | Comma-separated issue type IDs (create only) |
+| `--max-results` | Page size (list, default 50) |
+| `--start-at` | Offset (list) |
+
+### field option list / create / update / delete / reorder
+
+```bash
+jira-agent field option list customfield_10001 10500
+jira-agent field option create customfield_10001 10500 --values "Option A,Option B"
+jira-agent field option update customfield_10001 10500 --option-id 10600 --value "Renamed" --disabled
+jira-agent field option delete customfield_10001 10500 10600
+jira-agent field option reorder customfield_10001 10500 --option-ids 10600,10601 \
+  --position After --anchor 10602
+```
+
+| Flag | Notes |
+|------|-------|
+| `--values` | Comma-separated (create only) |
+| `--option-id` | Option to update (update only) |
+| `--value` | New value (update only) |
+| `--disabled` | Disable option (update only) |
+| `--option-ids` | IDs to move (reorder only) |
+| `--position` | `First`, `Last`, `Before`, `After` (case-sensitive, reorder only) |
+| `--anchor` | Required for Before/After positions (reorder only) |
+
+## Users
+
+### user get / search / groups
+
+```bash
+jira-agent user get --account-id 5b10ac8d82e05b22cc7d4ef5
+jira-agent user get --account-id 5b10ac8d --expand groups,applicationRoles
+jira-agent user search --query "john"
+jira-agent user search --query "john" --max-results 10
+jira-agent user groups --account-id 5b10ac8d82e05b22cc7d4ef5
+```
+
+| Flag | Notes |
+|------|-------|
+| `--account-id` | Required for get/groups |
+| `--query` | Search by name/email (search only) |
+| `--expand` | e.g., `groups,applicationRoles` |
+| `--max-results` | Default 50 (search only) |
+| `--start-at` | Offset (search only) |
+
+## Groups
+
+### group list / get
+
+```bash
+jira-agent group list
+jira-agent group list --query "dev" --case-insensitive
+jira-agent group get --groupname "jira-software-users" --expand users
+jira-agent group get --group-id abc123-def456
+```
+
+### group create / delete
+
+```bash
+jira-agent group create "new-team"
+jira-agent group delete --groupname "old-team"
+jira-agent group delete --group-id abc123 --swap-group "replacement-team"
+```
+
+`--swap-group`/`--swap-group-id` reassigns permissions before deletion.
+
+### group members
+
+```bash
+jira-agent group members --groupname "developers" --max-results 50
+jira-agent group members --group-id abc123 --include-inactive
+```
+
+### group add-member / remove-member
+
+```bash
+jira-agent group add-member --account-id 5b10ac8d --groupname "developers"
+jira-agent group remove-member --account-id 5b10ac8d --group-id abc123
+```
+
+`--account-id` required. Identify group by `--groupname` or `--group-id`.
+
+### group member-picker
+
+```bash
+jira-agent group member-picker --query "john"
+jira-agent group member-picker --query "j" --issue-key PROJ-100 --project-id 10000
+```
+
+Autocomplete for group member assignment. Filters by `--query`, scoped by `--issue-key`/`--project-id`.
+
+## Filters
+
+### filter list / get / favorites
+
+```bash
+jira-agent filter list --name "Sprint" --expand jql
+jira-agent filter list --account-id 5b10ac8d --project-id 10000
+jira-agent filter get 10500 --expand jql,subscriptions
+jira-agent filter favorites
+```
+
+### filter create / update / delete
+
+```bash
+jira-agent filter create --name "My Bugs" --jql "assignee = currentUser() AND type = Bug"
+jira-agent filter create --name "Sprint Board" --jql "sprint in openSprints()" \
+  --description "Active sprint filter"
+jira-agent filter update 10500 --name "Renamed" --jql "updated query"
+jira-agent filter delete 10500
+```
+
+| Flag | Notes |
+|------|-------|
+| `--name` | Filter name |
+| `--jql` | JQL query |
+| `--description` | Filter description |
+| `--body-json` | Full JSON body (advanced) |
+| `--expand` | e.g., `jql,subscriptions` |
+| `--override-share-permissions` | Boolean |
+
+### filter permissions / share / unshare / default-share-scope
+
+```bash
+jira-agent filter permissions 10500
+jira-agent filter share 10500 --with user:5b10ac8d82e05b22cc7d4ef5
+jira-agent filter unshare 10500 --permission-id 10200
+jira-agent filter default-share-scope get
+jira-agent filter default-share-scope set --scope PRIVATE
+```
+
+## Permissions
+
+### permission check / list
+
+```bash
+jira-agent permission check --permissions BROWSE_PROJECTS,CREATE_ISSUES --project-key PROJ
+jira-agent permission check --permissions EDIT_ISSUES --issue-key PROJ-100
+jira-agent permission list
+```
+
+| Flag | Notes |
+|------|-------|
+| `--permissions` | Required, comma-separated permission keys |
+| `--project-key` | Scope to project |
+| `--project-id` | Alternative to project-key |
+| `--issue-key` | Scope to issue |
+| `--issue-id` | Alternative to issue-key |
+| `--comment-id` | Scope to comment |
+
+### permission schemes list / get / project
+
+```bash
+jira-agent permission schemes list
+jira-agent permission schemes get 10000
+jira-agent permission schemes project PROJ
+```
+
+## Dashboards
+
+### dashboard list / get / gadgets
+
+```bash
+jira-agent dashboard list
+jira-agent dashboard list --filter my --max-results 10
+jira-agent dashboard get 10100
+jira-agent dashboard gadgets 10100
+jira-agent dashboard gadgets 10100 --module-key "com.atlassian.jira.gadgets:filter-results-gadget"
+```
+
+| Flag | Notes |
+|------|-------|
+| `--filter` | `my` or `favorite` (list only) |
+| `--gadget-id` | Filter gadgets (gadgets only) |
+| `--module-key` | Filter by module (gadgets only) |
+| `--uri` | Filter by URI (gadgets only) |
+
+### dashboard create / copy / update / delete
+
+```bash
+jira-agent dashboard create --name "Team dashboard"
+jira-agent dashboard copy 10100 --name "Team dashboard copy"
+jira-agent dashboard update 10100 --name "Renamed"
+jira-agent dashboard delete 10100
+```
+
+## Workflows
+
+### workflow list / get
+
+```bash
+jira-agent workflow list
+jira-agent workflow list --query "software" --is-active --scope global
+jira-agent workflow get abc123-workflow-id
+jira-agent workflow get abc123 --name "Software Simplified Workflow"
+```
+
+| Flag | Notes |
+|------|-------|
+| `--query` | Search term (list) |
+| `--scope` | Filter scope (list) |
+| `--is-active` | Active only (list) |
+| `--order-by` | Sort (list) |
+| `--expand` | Expansions |
+| `--name` | Workflow name (get, alternative to ID) |
+
+### workflow statuses
+
+```bash
+jira-agent workflow statuses
+```
+
+Lists all statuses across workflows.
+
+### workflow scheme list / get / project
+
+```bash
+jira-agent workflow scheme list
+jira-agent workflow scheme get 10000
+jira-agent workflow scheme project PROJ
+```
+
+### workflow transition-rules
+
+```bash
+jira-agent workflow transition-rules --workflow-id abc123
+jira-agent workflow transition-rules --project-id 10000 --issue-type-id 10001
+```
+
+## Statuses
+
+```bash
+jira-agent status list
+jira-agent status get "In Progress"
+jira-agent status get 10001
+jira-agent status categories
+```
+
+`get` accepts status name or ID. `categories` lists status categories (To Do, In Progress, Done).
+
+## Priorities / Resolutions / Labels
+
+```bash
+jira-agent priority list
+jira-agent resolution list
+jira-agent label list
+```
+
+Read-only lists, no flags.
+
+## Issue Types
+
+```bash
+jira-agent issuetype list
+jira-agent issuetype get 10001
+jira-agent issuetype project 10000
+```
+
+Alias: `issue-type`. `project` lists types available in a specific project.
+
+## JQL Helpers
+
+### jql fields / suggest / validate
+
+```bash
+jira-agent jql fields
+jira-agent jql suggest --field-name status --field-value "In"
+jira-agent jql suggest --field-name assignee --predicate-name "was"
+jira-agent jql validate --query "project = PROJ AND status = 'Done'"
+jira-agent jql validate --query "bad query" --validation warn
+```
+
+| Command | Key Flags |
+|---------|-----------|
+| `fields` | None. Lists JQL-searchable fields |
+| `suggest` | `--field-name` (required), `--field-value`, `--predicate-name`, `--predicate-value` |
+| `validate` | `--query` (required, repeatable), `--validation` (`strict`/`warn`/`none`, default `strict`) |
+
+## Server Info
+
+```bash
+jira-agent server-info
+```
+
+Returns Jira instance details (version, deployment type, URLs). No flags.
+
+## whoami
+
+```bash
+jira-agent whoami
+```
+
+Verify auth. Returns current user info. No flags.

--- a/skills/jira-agent/agile.md
+++ b/skills/jira-agent/agile.md
@@ -1,0 +1,295 @@
+# Agile
+
+Board, sprint, epic, and backlog management. Uses Jira Software Agile API (`/rest/agile/1.0`). Requires Jira Software access.
+
+## Boards
+
+### board list / get
+
+```bash
+jira-agent board list
+jira-agent board list --project PROJ --type scrum --name "Platform" --max-results 25
+jira-agent board get 84
+```
+
+| Flag | Notes |
+|------|-------|
+| `--type` | `scrum` or `kanban` (list only) |
+| `--name` | Filter by name (list only) |
+| `--project` | Project key or ID referenced by board filter (list only) |
+| `--max-results` | Default 50 (list only) |
+| `--start-at` | Offset (list only) |
+
+### board config
+
+```bash
+jira-agent board config 84
+```
+
+Returns board configuration (columns, estimation, ranking). Args: `<board-id>`.
+
+### board epics
+
+```bash
+jira-agent board epics 84
+jira-agent board epics 84 --done --max-results 10
+```
+
+| Flag | Notes |
+|------|-------|
+| `--done` | Include completed epics |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### board issues
+
+```bash
+jira-agent board issues 84 --fields key,summary,status
+jira-agent board issues 84 --jql "assignee = currentUser()" --expand changelog
+```
+
+| Flag | Notes |
+|------|-------|
+| `--fields` | Comma-separated |
+| `--jql` | Filter issues |
+| `--expand` | Expansions |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### board projects / versions
+
+```bash
+jira-agent board projects 84
+jira-agent board versions 84 --max-results 20
+```
+
+Pagination: `--max-results`, `--start-at`. Args: `<board-id>`.
+
+### board create / filter / delete / property
+
+```bash
+jira-agent board create --name "Team board" --type scrum --filter 10000
+jira-agent board create --name "Team board" --type kanban --filter 10000 --location-project PROJ
+jira-agent board filter 10000 --max-results 25
+jira-agent board delete 84
+jira-agent board property list 84
+jira-agent board property set 84 com.example.flag --value-json '{"enabled":true}'
+```
+
+`property` also supports `get` and `delete` with args `<board-id> <property-key>`.
+
+## Sprints
+
+### sprint list
+
+```bash
+jira-agent sprint list --board-id 84
+jira-agent sprint list --board-id 84 --state active
+jira-agent sprint list --board-id 84 --state future,active --max-results 5
+```
+
+| Flag | Notes |
+|------|-------|
+| `--board-id` | Required |
+| `--state` | `future`, `active`, `closed` (comma-sep for multiple) |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### sprint get
+
+```bash
+jira-agent sprint get 42
+```
+
+### sprint create
+
+```bash
+jira-agent sprint create --board-id 84 --name "Sprint 12"
+jira-agent sprint create --board-id 84 --name "Sprint 12" \
+  --start-date 2026-05-01T00:00:00.000Z --end-date 2026-05-14T00:00:00.000Z \
+  --goal "Complete auth module"
+```
+
+| Flag | Notes |
+|------|-------|
+| `--board-id` | Required |
+| `--name` | Required |
+| `--start-date` | ISO 8601 |
+| `--end-date` | ISO 8601 |
+| `--goal` | Sprint goal text |
+
+### sprint update
+
+```bash
+jira-agent sprint update 42 --name "Sprint 12 (Extended)"
+jira-agent sprint update 42 --state closed
+jira-agent sprint update 42 --goal "Revised goal" --end-date 2026-05-21T00:00:00.000Z
+```
+
+Same optional flags as create plus `--state`. Args: `<sprint-id>`.
+
+### sprint delete
+
+```bash
+jira-agent sprint delete 42
+```
+
+### sprint issues
+
+```bash
+jira-agent sprint issues 42 --fields key,summary,status,assignee
+jira-agent sprint issues 42 --jql "status != Done" --max-results 100
+```
+
+| Flag | Notes |
+|------|-------|
+| `--fields` | Comma-separated |
+| `--jql` | Filter within sprint |
+| `--expand` | Expansions |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### sprint move-issues
+
+```bash
+jira-agent sprint move-issues 42 --issues KEY-1,KEY-2,KEY-3
+jira-agent sprint move-issues 42 --issues KEY-1 --rank-before KEY-5
+jira-agent sprint move-issues 42 --issues KEY-1 --rank-after KEY-10
+```
+
+| Flag | Notes |
+|------|-------|
+| `--issues` | Required, comma-separated |
+| `--rank-before` | Position before this issue |
+| `--rank-after` | Position after this issue |
+
+### sprint swap / property
+
+```bash
+jira-agent sprint swap 100 101
+jira-agent sprint property list 42
+jira-agent sprint property get 42 com.example.flag
+jira-agent sprint property set 42 com.example.flag --value-json '{"enabled":true}'
+jira-agent sprint property delete 42 com.example.flag
+```
+
+## Epics
+
+### epic get
+
+```bash
+jira-agent epic get PROJ-100
+jira-agent epic get 10042
+```
+
+Args: `<epic-id-or-key>`.
+
+### epic issues
+
+```bash
+jira-agent epic issues PROJ-100 --fields key,summary,status
+jira-agent epic issues PROJ-100 --jql "status = 'In Progress'" --max-results 20
+```
+
+| Flag | Notes |
+|------|-------|
+| `--fields` | Comma-separated |
+| `--jql` | Filter within epic |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### epic move-issues
+
+```bash
+jira-agent epic move-issues PROJ-100 --issues KEY-1,KEY-2
+```
+
+`--issues` required. Moves issues into the epic.
+
+### epic orphans
+
+```bash
+jira-agent epic orphans --fields key,summary
+jira-agent epic orphans --jql "project = PROJ" --fields key,summary,status
+```
+
+Lists issues with no epic. Use `--jql` to scope by project or other criteria. Same pagination flags as `epic issues`.
+
+### epic remove-issues
+
+```bash
+jira-agent epic remove-issues --issues KEY-1,KEY-2
+```
+
+`--issues` required. Removes issues from their epic (issues become orphans).
+
+### epic rank
+
+```bash
+jira-agent epic rank PROJ-100 --rank-before PROJ-200
+jira-agent epic rank PROJ-100 --rank-after PROJ-50
+```
+
+| Flag | Notes |
+|------|-------|
+| `--rank-before` | Rank before this epic |
+| `--rank-after` | Rank after this epic |
+
+## Backlog
+
+### backlog list
+
+```bash
+jira-agent backlog list --board-id 84
+jira-agent backlog list --board-id 84 --fields key,summary,status --jql "type = Bug"
+```
+
+| Flag | Notes |
+|------|-------|
+| `--board-id` | Required |
+| `--fields` | Comma-separated |
+| `--jql` | Filter backlog items |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### backlog move
+
+```bash
+jira-agent backlog move --issues KEY-1,KEY-2
+```
+
+`--issues` required. Moves issues to the backlog (removes from any sprint).
+
+## Workflows
+
+### Sprint planning
+
+```bash
+# Find the board
+jira-agent board list --project PROJ --type scrum
+
+# List sprints, find active
+jira-agent sprint list --board-id 84 --state active
+
+# Check sprint contents
+jira-agent sprint issues 42 --fields key,summary,status,assignee --output csv
+
+# Move items into sprint
+jira-agent sprint move-issues 42 --issues PROJ-10,PROJ-11
+
+# Move items to backlog
+jira-agent backlog move --issues PROJ-15
+```
+
+### Epic management
+
+```bash
+# Check epic progress
+jira-agent epic issues PROJ-100 --fields key,summary,status --output csv
+
+# Find issues without an epic
+jira-agent epic orphans --jql "project = PROJ" --fields key,summary
+
+# Move issues into epic
+jira-agent epic move-issues PROJ-100 --issues PROJ-50,PROJ-51
+```

--- a/skills/jira-agent/issue-workflows.md
+++ b/skills/jira-agent/issue-workflows.md
@@ -1,0 +1,261 @@
+# Issue Workflows
+
+Transition, assign, comment, worklog, watcher, vote, attachment, link, remote-link, changelog, rank, notify.
+
+## issue transition
+
+```bash
+jira-agent issue transition KEY-123 --to "In Progress"
+jira-agent issue transition KEY-123 --to Done --comment "Completed"
+jira-agent issue transition KEY-123 --to Done --field customfield_10001=value
+jira-agent issue transition KEY-123 --list
+```
+
+| Flag | Notes |
+|------|-------|
+| `--to` | Target status name (case-insensitive). Required unless `--list` |
+| `--comment` | Transition comment |
+| `--field` | Repeatable `key=value` for transition fields |
+| `--list` | List available transitions (read-only, bypasses write guard) |
+
+Matches against both transition names and target status names.
+
+## issue assign
+
+```bash
+jira-agent issue assign KEY-123 5b10ac8d82e05b22cc7d4ef5
+jira-agent issue assign KEY-123 --unassign
+jira-agent issue assign KEY-123 --default
+```
+
+Second positional arg is `accountId` (not email). `--unassign` clears, `--default` uses project default.
+
+## Comments
+
+### issue comment list
+
+```bash
+jira-agent issue comment list KEY-123
+jira-agent issue comment list KEY-123 --order-by -created --max-results 10
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--order-by` | | `created`, `-created`, `+created` |
+| `--expand` | | `renderedBody` |
+| `--max-results` | 50 | Page size |
+| `--start-at` | 0 | Offset |
+
+### issue comment add
+
+```bash
+jira-agent issue comment add KEY-123 --body "This is a comment"
+jira-agent issue comment add KEY-123 --body '{"type":"doc",...}' \
+  --visibility-type role --visibility-value Developers
+```
+
+| Flag | Notes |
+|------|-------|
+| `--body` / `-b` | Required. Plain text or ADF JSON |
+| `--visibility-type` | `group` or `role` |
+| `--visibility-value` | Name (required if type set) |
+| `--expand` | `renderedBody` |
+
+### issue comment edit
+
+```bash
+jira-agent issue comment edit KEY-123 10005 --body "Updated comment"
+```
+
+Same flags as add, plus `--notify` (default true). Args: `<issue-key> <comment-id>`.
+
+### issue comment delete
+
+```bash
+jira-agent issue comment delete KEY-123 10005
+```
+
+## Worklogs
+
+### issue worklog list
+
+```bash
+jira-agent issue worklog list KEY-123
+jira-agent issue worklog list KEY-123 --started-after 1700000000000 --max-results 20
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--start-at` | 0 | Offset |
+| `--max-results` | 20 | Page size |
+| `--started-after` | | Unix ms timestamp |
+| `--started-before` | | Unix ms timestamp |
+| `--expand` | | `properties` |
+
+### issue worklog add
+
+```bash
+jira-agent issue worklog add KEY-123 \
+  --started 2026-04-27T10:00:00.000-0500 --time-spent 1h --comment "Investigated"
+jira-agent issue worklog add KEY-123 \
+  --started 2026-04-27T10:00:00.000-0500 --time-spent-seconds 1800 \
+  --adjust-estimate leave --notify=false
+```
+
+| Flag | Notes |
+|------|-------|
+| `--started` | Required timestamp, e.g., `2026-04-27T10:00:00.000-0500` |
+| `--time-spent` | Required unless `--time-spent-seconds`, e.g., `1h 30m` |
+| `--time-spent-seconds` | Required unless `--time-spent` |
+| `--comment` | Plain text or ADF JSON |
+| `--visibility-type` | `group` or `role` |
+| `--visibility-value` | Name (required if type set) |
+| `--properties-json` | JSON array of worklog properties |
+| `--notify` | Default true |
+| `--adjust-estimate` | `auto`, `leave`, `manual`, or `new` |
+| `--new-estimate` | For estimate adjustment |
+| `--override-editable-flag` | Override Jira's editable check |
+
+### issue worklog edit
+
+```bash
+jira-agent issue worklog edit KEY-123 10005 --time-spent 2h
+jira-agent issue worklog edit KEY-123 10005 --comment "Updated" --override-editable-flag
+```
+
+Same flags as add but all optional. At least one field required. Args: `<issue-key> <worklog-id>`.
+
+### issue worklog delete
+
+```bash
+jira-agent issue worklog delete KEY-123 10005
+jira-agent issue worklog delete KEY-123 10005 --adjust-estimate manual --increase-by 1h
+```
+
+| Flag | Notes |
+|------|-------|
+| `--notify` | Default true |
+| `--adjust-estimate` | `auto`, `leave`, `manual`, or `new` |
+| `--new-estimate` | New remaining estimate |
+| `--increase-by` | For manual adjustment |
+| `--override-editable-flag` | Override editable check |
+
+## Watchers
+
+### issue watcher list / add / remove
+
+```bash
+jira-agent issue watcher list KEY-123
+jira-agent issue watcher add KEY-123 --account-id 5b10ac8d82e05b22cc7d4ef5
+jira-agent issue watcher remove KEY-123 --account-id 5b10ac8d82e05b22cc7d4ef5
+```
+
+`--account-id` is required for add/remove.
+
+## Votes
+
+### issue vote get / add / remove
+
+```bash
+jira-agent issue vote get KEY-123
+jira-agent issue vote add KEY-123
+jira-agent issue vote remove KEY-123
+```
+
+No flags. Operates on the authenticated user's vote.
+
+## Attachments
+
+### issue attachment list / add / get / delete
+
+```bash
+jira-agent issue attachment list KEY-123
+jira-agent issue attachment add KEY-123 --file /path/to/document.pdf
+jira-agent issue attachment add KEY-123 --file doc.pdf --file image.png
+jira-agent issue attachment get 10500
+jira-agent issue attachment delete 10500
+```
+
+`list` and `add` take issue key. `--file` is repeatable. `get` and `delete` take attachment ID.
+
+## Issue Links
+
+### issue link list / add / delete / types
+
+```bash
+jira-agent issue link list KEY-123
+jira-agent issue link add --inward KEY-123 --outward KEY-456 --type "Blocks"
+jira-agent issue link add --inward KEY-123 --outward KEY-456 --type-id 10000
+jira-agent issue link delete 10500
+jira-agent issue link types
+```
+
+| Flag | Notes |
+|------|-------|
+| `--inward` | Required for add. Inward issue key |
+| `--outward` | Required for add. Outward issue key |
+| `--type` | Link type name (e.g., "Blocks", "Cloners") |
+| `--type-id` | Link type ID (alternative to `--type`) |
+
+`delete` takes link ID. `types` lists all available link types.
+
+## Remote Links
+
+### issue remote-link list / add / edit / delete
+
+```bash
+jira-agent issue remote-link list KEY-123
+jira-agent issue remote-link add KEY-123 --title "Design Doc" --url "https://..."
+jira-agent issue remote-link add KEY-123 --title "CI Build" --url "https://..." \
+  --global-id "ci-build-42" --relationship "is built by"
+jira-agent issue remote-link edit KEY-123 10500 --title "Updated" --url "https://new-url"
+jira-agent issue remote-link delete KEY-123 10500
+```
+
+| Flag | Notes |
+|------|-------|
+| `--title` | Required for add/edit |
+| `--url` | Required for add/edit |
+| `--global-id` | Optional unique ID |
+| `--relationship` | Optional relationship description |
+
+## Changelog
+
+```bash
+jira-agent issue changelog KEY-123
+jira-agent issue changelog KEY-123 --max-results 10 --start-at 0
+```
+
+Returns field change history. Offset pagination.
+
+## Ranking
+
+```bash
+jira-agent issue rank --issues KEY-1,KEY-2 --before KEY-5
+jira-agent issue rank --issues KEY-3 --after KEY-10
+```
+
+| Flag | Notes |
+|------|-------|
+| `--issues` | Required, comma-separated keys to rank |
+| `--before` | Rank before this issue (mutually exclusive with `--after`) |
+| `--after` | Rank after this issue |
+
+## Notifications
+
+```bash
+jira-agent issue notify KEY-123 --subject "Urgent update" --text-body "Please review"
+jira-agent issue notify KEY-123 --subject "Status change" --html-body "<b>Done</b>" \
+  --to-assignee --to-watchers --to-users 5b10ac8d82e05b22cc7d4ef5 --to-users 5b10ac8d82e05b22cc7d4ef6
+```
+
+| Flag | Notes |
+|------|-------|
+| `--subject` | Required |
+| `--text-body` | Plain text body |
+| `--html-body` | HTML body |
+| `--to-assignee` | Notify assignee |
+| `--to-reporter` | Notify reporter |
+| `--to-users` | Repeatable account IDs (not emails) |
+| `--to-voters` | Notify voters |
+| `--to-watchers` | Notify watchers |

--- a/skills/jira-agent/issues.md
+++ b/skills/jira-agent/issues.md
@@ -1,0 +1,220 @@
+# Issues
+
+Issue CRUD, search, bulk operations, metadata, and count.
+
+## issue get
+
+```bash
+jira-agent issue get KEY-123
+jira-agent issue get KEY-123 --fields summary,status,assignee --expand changelog
+```
+
+## issue search
+
+```bash
+jira-agent issue search --jql "project = PROJ AND status = 'In Progress'"
+jira-agent issue search --jql "assignee = currentUser()" --fields key,summary,status --max-results 20
+jira-agent issue search --jql "..." --next-page-token TOKEN
+```
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--jql` | (required) | JQL query string |
+| `--fields` | summary,status,assignee,priority | Comma-separated |
+| `--max-results` | 50 | Page size |
+| `--next-page-token` | | Cursor from previous `.metadata` |
+| `--expand` | | e.g., `changelog,renderedFields` |
+| `--order-by` | | Sort field |
+| `--order` | | `asc` or `desc` |
+
+## issue create
+
+```bash
+jira-agent issue create --project PROJ --type Task --summary "Fix the bug"
+jira-agent issue create --project PROJ --type Story --summary "New feature" \
+  --description "Details" --priority High --labels bug,urgent \
+  --assignee 5b10ac8d82e05b22cc7d4ef5 --field customfield_10016=5
+```
+
+| Flag | Notes |
+|------|-------|
+| `--project` | Required (also reads `JIRA_PROJECT` env) |
+| `--type` | Required, case-insensitive |
+| `--summary` | Required |
+| `--description` | Plain text auto-converts to ADF; valid ADF JSON passes through |
+| `--assignee` | Account ID only (not email) |
+| `--priority` | Name: High, Medium, Low |
+| `--labels` | Comma-separated |
+| `--components` | Comma-separated |
+| `--parent` | Parent key (subtasks) |
+| `--field` | Repeatable `key=value` (JSON-parsed if valid) |
+| `--fields-json` | JSON object merged into fields, overrides individual flags |
+
+## issue edit
+
+```bash
+jira-agent issue edit KEY-123 --summary "Updated title"
+jira-agent issue edit KEY-123 --field customfield_10001='{"complex":"value"}'
+jira-agent issue edit KEY-123 --fields-json '{"summary":"New","priority":{"name":"High"}}'
+```
+
+Same optional field flags as create, except `--project` and `--type`, plus `--notify` (default true). At least one field change required.
+
+## issue delete
+
+```bash
+jira-agent issue delete KEY-123
+jira-agent issue delete KEY-123 --delete-subtasks
+```
+
+## issue meta
+
+```bash
+jira-agent issue meta --project PROJ
+jira-agent issue meta --project PROJ --type Bug
+jira-agent issue meta --operation edit --issue KEY-123
+```
+
+Discover required/available fields before creating or editing.
+
+| Flag | Notes |
+|------|-------|
+| `--project` | Project key |
+| `--type` | Filter to issue type |
+| `--operation` | `create` (default) or `edit` |
+| `--issue` | Required for `--operation edit` |
+
+## issue count
+
+```bash
+jira-agent issue count --jql "project = PROJ AND status = 'To Do'"
+```
+
+Returns issue count without fetching full results. `--jql` is required.
+
+## Bulk Operations
+
+All bulk ops require write access. Issue limits noted per command.
+
+### issue bulk create
+
+```bash
+jira-agent issue bulk create --issues-json '[{"fields":{"project":{"key":"PROJ"},"issuetype":{"name":"Task"},"summary":"First"}}]'
+jira-agent issue bulk create --issues-json '{"issueUpdates":[{"fields":{"project":{"key":"PROJ"},"issuetype":{"name":"Bug"},"summary":"Second"}}]}'
+```
+
+Up to 50 issues. Accepts raw array or `{"issueUpdates": [...]}` wrapper. Use `issue meta` first for field schemas.
+
+### issue bulk fetch
+
+```bash
+jira-agent issue bulk fetch --issues PROJ-1,PROJ-2 --fields key,summary,status
+jira-agent issue bulk fetch --issues PROJ-1,10002 --expand changelog --fields-by-keys
+```
+
+Up to 100 issues by key or ID. Compare returned `issues` and `issueErrors` arrays for completeness.
+
+| Flag | Notes |
+|------|-------|
+| `--issues` | Required, comma-separated keys or IDs |
+| `--fields` | Comma-separated field names or IDs |
+| `--expand` | e.g., `changelog` |
+| `--properties` | Comma-separated, max 5 |
+| `--fields-by-keys` | Treat `--fields` as field keys |
+
+### issue bulk delete
+
+```bash
+jira-agent issue bulk delete --issues PROJ-1,PROJ-2,PROJ-3
+jira-agent issue bulk delete --issues PROJ-1,PROJ-2 --send-notification=false
+```
+
+Up to 1000 issues. `--send-notification` defaults true.
+
+### issue bulk edit
+
+```bash
+jira-agent issue bulk edit --payload-json '{
+  "selectedIssueIdsOrKeys": ["PROJ-1","PROJ-2"],
+  "selectedActions": ["priority"],
+  "editedFieldsInput": {"priority": {"name": "High"}}
+}'
+```
+
+Up to 1000 issues, 200 fields. Use `issue bulk edit-fields` to discover editable fields first.
+
+### issue bulk edit-fields
+
+```bash
+jira-agent issue bulk edit-fields --issues PROJ-1,PROJ-2
+jira-agent issue bulk edit-fields --issues PROJ-1 --search-text "priority"
+```
+
+Lists fields available for bulk editing. Cursor pagination via `--starting-after`/`--ending-before`.
+
+### issue bulk move
+
+```bash
+jira-agent issue bulk move --payload-json '{
+  "targetToSourcesMapping": {"DEST": {"issueIdsOrKeys": ["PROJ-1"], "targetIssueType": "Task"}},
+  "sendBulkNotification": false
+}'
+```
+
+Up to 1000 issues. Payload maps target projects to source issues.
+
+### issue bulk transition
+
+```bash
+jira-agent issue bulk transition --transitions-json '[
+  {"selectedIssueIdsOrKeys":["PROJ-1","PROJ-2"],"transitionId":"31"}
+]' --send-notification=false
+```
+
+Up to 1000 issues. Requires transition IDs (not names). Use `issue bulk transitions` to discover them.
+
+### issue bulk transitions
+
+```bash
+jira-agent issue bulk transitions --issues PROJ-1,PROJ-2
+```
+
+Lists available transitions for bulk transition. Cursor pagination via `--starting-after`/`--ending-before`.
+
+## Workflows
+
+### Search, inspect, update
+
+```bash
+jira-agent issue search --jql "project = PROJ AND status = 'To Do' AND assignee = currentUser()"
+jira-agent issue get PROJ-42 --expand changelog
+jira-agent issue edit PROJ-42 --priority Critical
+jira-agent issue transition PROJ-42 --to "In Progress"
+```
+
+### Create with custom fields
+
+```bash
+jira-agent issue meta --project PROJ --type Story
+jira-agent field search -q "story points"
+jira-agent issue create --project PROJ --type Story \
+  --summary "Implement caching" --priority High \
+  --field customfield_10016=5 --labels backend,performance
+```
+
+### Paginate search results
+
+```bash
+RESULT=$(jira-agent issue search --jql "project = PROJ" --max-results 50)
+# Extract next-page-token from .metadata, pass to subsequent calls
+jira-agent issue search --jql "project = PROJ" --max-results 50 \
+  --next-page-token "TOKEN_FROM_PREVIOUS_RESPONSE"
+```
+
+### Bulk status check
+
+```bash
+jira-agent issue search \
+  --jql "project = PROJ AND sprint in openSprints()" \
+  --fields key,summary,status,assignee --output csv
+```

--- a/skills/jira-agent/project-management.md
+++ b/skills/jira-agent/project-management.md
@@ -1,0 +1,214 @@
+# Project Management
+
+Projects, components, and versions.
+
+## Projects
+
+### project list / get
+
+```bash
+jira-agent project list
+jira-agent project list --query "backend" --type-key software --max-results 20 --output csv
+jira-agent project get PROJ
+jira-agent project get PROJ --expand description,issueTypes,lead
+```
+
+| Flag | Notes |
+|------|-------|
+| `--query` / `-q` | Filter by name/key (list only) |
+| `--type-key` | `business`, `service_desk`, `software` (list only) |
+| `--order-by` | `category`, `key`, `name`, `owner`; prefix `-` for desc (list only) |
+| `--expand` | list: `description,lead,issueTypes,url,insight`; get: `description,issueTypes,lead,projectKeys` |
+| `--max-results` | Max 100 (list only, default 50) |
+| `--start-at` | Offset (list only) |
+
+### project roles / categories
+
+```bash
+jira-agent project roles list PROJ
+jira-agent project roles get PROJ 10000 --exclude-inactive-users
+jira-agent project categories list
+jira-agent project categories get 10000
+```
+
+## Components
+
+### component list
+
+```bash
+jira-agent component list --project PROJ
+jira-agent component list --project PROJ --query "auth" --order-by name
+```
+
+| Flag | Notes |
+|------|-------|
+| `--project` | Required |
+| `--query` | Filter by name |
+| `--order-by` | Sort field |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### component get / issue-counts
+
+```bash
+jira-agent component get 10500
+jira-agent component issue-counts 10500
+```
+
+Args: `<component-id>`.
+
+### component create
+
+```bash
+jira-agent component create --project PROJ --name "Authentication"
+jira-agent component create --project PROJ --name "Auth" \
+  --description "Auth module" --lead-account-id 5b10ac8d --assignee-type PROJECT_LEAD
+```
+
+| Flag | Notes |
+|------|-------|
+| `--project` | Required |
+| `--name` | Required |
+| `--description` | Component description |
+| `--lead-account-id` | Component lead |
+| `--assignee-type` | `PROJECT_DEFAULT`, `COMPONENT_LEAD`, `PROJECT_LEAD`, `UNASSIGNED` |
+
+### component update
+
+```bash
+jira-agent component update 10500 --name "Renamed" --description "Updated desc"
+```
+
+Same optional flags as create. Args: `<component-id>`.
+
+### component delete
+
+```bash
+jira-agent component delete 10500
+jira-agent component delete 10500 --move-issues-to 10501
+```
+
+`--move-issues-to` reassigns issues to another component before deletion.
+
+## Versions
+
+### version list
+
+```bash
+jira-agent version list --project PROJ
+jira-agent version list --project PROJ --status released --query "v2" --order-by -releaseDate
+```
+
+| Flag | Notes |
+|------|-------|
+| `--project` | Required |
+| `--status` | Filter: `released`, `unreleased`, etc. |
+| `--query` | Filter by name |
+| `--order-by` | Sort field; prefix `-` for desc |
+| `--expand` | Expansions |
+| `--max-results` | Default 50 |
+| `--start-at` | Offset |
+
+### version get
+
+```bash
+jira-agent version get 10100
+jira-agent version get 10100 --expand issuesstatus
+```
+
+### version create
+
+```bash
+jira-agent version create --project PROJ --name "v2.1.0"
+jira-agent version create --project PROJ --name "v2.1.0" \
+  --description "Bug fixes" --start-date 2026-05-01 --release-date 2026-06-01
+```
+
+| Flag | Notes |
+|------|-------|
+| `--project` | Required |
+| `--name` | Required |
+| `--description` | Version description |
+| `--start-date` | YYYY-MM-DD |
+| `--release-date` | YYYY-MM-DD |
+| `--released` | Mark as released |
+| `--archived` | Mark as archived |
+
+### version update
+
+```bash
+jira-agent version update 10100 --name "v2.1.1" --released
+jira-agent version update 10100 --release-date 2026-06-15 --archived=false
+```
+
+Same optional flags as create. Args: `<version-id>`.
+
+### version delete
+
+```bash
+jira-agent version delete 10100
+jira-agent version delete 10100 --move-affected-issues-to 10101 --move-fix-issues-to 10101
+```
+
+| Flag | Notes |
+|------|-------|
+| `--move-affected-issues-to` | Version ID for affected issues |
+| `--move-fix-issues-to` | Version ID for fix issues |
+
+### version merge
+
+```bash
+jira-agent version merge 10100 10101
+```
+
+Merges source into target. Args: `<source-version-id> <target-version-id>`.
+
+### version move
+
+```bash
+jira-agent version move 10100 --position First
+jira-agent version move 10100 --after 10099
+```
+
+| Flag | Notes |
+|------|-------|
+| `--position` | `Earlier`, `Later`, `First`, `Last` |
+| `--after` | Position after this version ID |
+
+### version issue-counts / unresolved-count
+
+```bash
+jira-agent version issue-counts 10100
+jira-agent version unresolved-count 10100
+```
+
+Args: `<version-id>`.
+
+## Workflows
+
+### Release planning
+
+```bash
+# List versions
+jira-agent version list --project PROJ --status unreleased --output csv
+
+# Check what's left
+jira-agent version unresolved-count 10100
+
+# Release it
+jira-agent version update 10100 --released --release-date 2026-04-27
+
+# Merge abandoned version into current
+jira-agent version merge 10099 10100
+```
+
+### Component management
+
+```bash
+# Audit components
+jira-agent component list --project PROJ --output csv
+jira-agent component issue-counts 10500
+
+# Clean up: move issues and delete
+jira-agent component delete 10500 --move-issues-to 10501
+```


### PR DESCRIPTION
## Summary

- Add jira-agent CLI skill documentation to `skills/jira-agent/` matching the pattern used in other projects with skills
- 7 files: SKILL.md (entry point), AGENTS.md (maintenance guide), issues.md, issue-workflows.md, agile.md, project-management.md, admin-reference.md
- Gives agents working in this repo Jira reference alongside the existing schwab skill files