### PR TITLE
feat: support multi-period moving averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ schwab-agent account list
 # Get option chains
 schwab-agent chain get AAPL
 
+# Get multiple moving averages in one technical-analysis run
+schwab-agent ta sma AAPL --period 21,50,200 --points 1
+
 # Place a limit order (requires safety config + --confirm)
 schwab-agent order place equity \
   --symbol AAPL \

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -126,6 +126,18 @@ type taOutput struct {
 	Values    []map[string]any `json:"values"`
 }
 
+// multiTAOutput is used when SMA/EMA/RSI are requested for more than one
+// period in a single command. The values are keyed as indicator_period (for
+// example, sma_21) so agents can compare crossovers without making multiple
+// CLI calls and then hand-merging separate JSON envelopes.
+type multiTAOutput struct {
+	Indicator string           `json:"indicator"`
+	Symbol    string           `json:"symbol"`
+	Interval  string           `json:"interval"`
+	Periods   []int            `json:"periods"`
+	Values    []map[string]any `json:"values"`
+}
+
 // simpleTAConfig defines a closes-only technical indicator command.
 // SMA, EMA, and RSI share the same pipeline: fetch candles, extract closes,
 // compute indicator, write output. Only the parameters differ.
@@ -142,14 +154,62 @@ type simpleTAConfig struct {
 	compute func(closes []float64, period int) ([]float64, error)
 }
 
-// taIndicatorFlags returns the shared flags for all TA indicator subcommands.
-// RSI defaults to period 14; SMA/EMA default to 20.
+// simpleTAIndicatorFlags returns the shared flags for closes-only indicators.
+// SMA, EMA, and RSI accept multiple periods in a single run.
+func simpleTAIndicatorFlags(defaultPeriod int) []cli.Flag {
+	return []cli.Flag{
+		&cli.IntSliceFlag{Name: "period", Usage: "Indicator period (repeatable or comma-separated)", Value: []int{defaultPeriod}},
+		&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
+		&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
+	}
+}
+
+// taIndicatorFlags returns the shared single-period flags for indicators that
+// are not wired for combined multi-period output.
 func taIndicatorFlags(defaultPeriod int) []cli.Flag {
 	return []cli.Flag{
 		&cli.IntFlag{Name: "period", Usage: "Indicator period", Value: defaultPeriod},
 		&cli.StringFlag{Name: "interval", Usage: "Data interval (daily, weekly, 1min, 5min, 15min, 30min)", Value: "daily"},
 		&cli.IntFlag{Name: "points", Usage: "Number of output points (0 = all)", Value: 1},
 	}
+}
+
+// parseTAPeriods returns the requested indicator windows. urfave/cli's slice
+// flag accepts both repeated flags and comma-separated values, which lets a
+// user ask for "21, 50, and 200 day moving averages" in a single command while
+// keeping the old single --period form working unchanged.
+func parseTAPeriods(cmd *cli.Command) ([]int, error) {
+	periods := cmd.IntSlice("period")
+	if len(periods) == 0 {
+		return nil, newValidationError("at least one period is required")
+	}
+
+	seen := make(map[int]struct{}, len(periods))
+	for _, period := range periods {
+		if period <= 0 {
+			return nil, newValidationError("period must be greater than 0")
+		}
+
+		if _, ok := seen[period]; ok {
+			return nil, newValidationError(fmt.Sprintf("duplicate period: %d", period))
+		}
+		seen[period] = struct{}{}
+	}
+
+	return periods, nil
+}
+
+// maxPeriod returns the largest requested period, used to fetch enough candle
+// history once before calculating each moving-average window locally.
+func maxPeriod(periods []int) int {
+	largest := periods[0]
+	for _, period := range periods[1:] {
+		if period > largest {
+			largest = period
+		}
+	}
+
+	return largest
 }
 
 // makeSimpleTACommand builds a CLI command for a closes-only indicator.
@@ -160,14 +220,18 @@ func makeSimpleTACommand(cfg simpleTAConfig, c *client.Ref, w io.Writer) *cli.Co
 		Name:      cfg.name,
 		Usage:     cfg.usage,
 		UsageText: cfg.usageText,
-		Flags:     taIndicatorFlags(cfg.defaultPeriod),
+		Flags:     simpleTAIndicatorFlags(cfg.defaultPeriod),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			symbol := cmd.Args().First()
 			if err := requireArg(symbol, "symbol"); err != nil {
 				return err
 			}
 
-			period := cmd.Int("period")
+			periods, err := parseTAPeriods(cmd)
+			if err != nil {
+				return err
+			}
+			period := maxPeriod(periods)
 			interval := cmd.String("interval")
 			points := cmd.Int("points")
 
@@ -181,12 +245,20 @@ func makeSimpleTACommand(cfg simpleTAConfig, c *client.Ref, w io.Writer) *cli.Co
 				return err
 			}
 
-			values, err := cfg.compute(closes, period)
-			if err != nil {
-				return err
+			valuesByPeriod := make(map[int][]float64, len(periods))
+			for _, p := range periods {
+				values, err := cfg.compute(closes, p)
+				if err != nil {
+					return err
+				}
+				valuesByPeriod[p] = values
 			}
 
-			return writeTAOutput(w, cfg.name, symbol, interval, period, points, timestamps, values)
+			if len(periods) == 1 {
+				return writeTAOutput(w, cfg.name, symbol, interval, periods[0], points, timestamps, valuesByPeriod[periods[0]])
+			}
+
+			return writeMultiTAOutput(w, cfg.name, symbol, interval, periods, points, timestamps, valuesByPeriod)
 		},
 	}
 }
@@ -198,33 +270,35 @@ func TACommand(c *client.Ref, w io.Writer) *cli.Command {
 		Usage:  "Technical analysis indicators",
 		Action: requireSubcommand(),
 		Commands: []*cli.Command{
-		makeSimpleTACommand(simpleTAConfig{
-			name:  "sma",
-			usage: "Simple Moving Average",
-			usageText: `schwab-agent ta sma AAPL
-schwab-agent ta sma AAPL --period 50 --interval daily --points 10`,
-			defaultPeriod: 20,
-			multiplier:    1,
-			compute:       ta.SMA,
-		}, c, w),
-		makeSimpleTACommand(simpleTAConfig{
-			name:  "ema",
-			usage: "Exponential Moving Average",
-			usageText: `schwab-agent ta ema AAPL
-schwab-agent ta ema AAPL --period 50 --interval daily --points 10`,
-			defaultPeriod: 20,
-			multiplier:    3,
-			compute:       ta.EMA,
-		}, c, w),
-		makeSimpleTACommand(simpleTAConfig{
-			name:  "rsi",
-			usage: "Relative Strength Index",
-			usageText: `schwab-agent ta rsi AAPL
-schwab-agent ta rsi AAPL --period 14 --interval daily --points 10`,
-			defaultPeriod: 14,
-			multiplier:    3,
-			compute:       ta.RSI,
-		}, c, w),
+			makeSimpleTACommand(simpleTAConfig{
+				name:  "sma",
+				usage: "Simple Moving Average",
+				usageText: `schwab-agent ta sma AAPL
+	schwab-agent ta sma AAPL --period 50 --interval daily --points 10
+	schwab-agent ta sma AAPL --period 21,50,200 --points 1`,
+				defaultPeriod: 20,
+				multiplier:    1,
+				compute:       ta.SMA,
+			}, c, w),
+			makeSimpleTACommand(simpleTAConfig{
+				name:  "ema",
+				usage: "Exponential Moving Average",
+				usageText: `schwab-agent ta ema AAPL
+	schwab-agent ta ema AAPL --period 50 --interval daily --points 10
+	schwab-agent ta ema AAPL --period 12 --period 26 --points 5`,
+				defaultPeriod: 20,
+				multiplier:    3,
+				compute:       ta.EMA,
+			}, c, w),
+			makeSimpleTACommand(simpleTAConfig{
+				name:  "rsi",
+				usage: "Relative Strength Index",
+				usageText: `schwab-agent ta rsi AAPL
+	schwab-agent ta rsi AAPL --period 14 --interval daily --points 10`,
+				defaultPeriod: 14,
+				multiplier:    3,
+				compute:       ta.RSI,
+			}, c, w),
 			taMACDCommand(c, w),
 			taATRCommand(c, w),
 			taBBandsCommand(c, w),
@@ -916,5 +990,54 @@ func writeTAOutput(
 		Period:    period,
 		Values:    out,
 	}
-	return output.WriteSuccess(w, data, output.NewMetadata())
+	return output.WriteSuccess(w, data, output.TimestampMeta())
+}
+
+// writeMultiTAOutput builds a combined time series for multiple requested
+// periods. Each row represents a candle timestamp and contains one value per
+// period using stable keys such as sma_21, sma_50, and sma_200.
+func writeMultiTAOutput(
+	w io.Writer,
+	indicator, symbol, interval string,
+	periods []int,
+	points int,
+	timestamps []string,
+	valuesByPeriod map[int][]float64,
+) error {
+	maxValues := 0
+	for _, period := range periods {
+		if len(valuesByPeriod[period]) > maxValues {
+			maxValues = len(valuesByPeriod[period])
+		}
+	}
+
+	start := len(timestamps) - maxValues
+	out := make([]map[string]any, maxValues)
+	for i := range maxValues {
+		out[i] = map[string]any{"datetime": timestamps[start+i]}
+	}
+
+	for _, period := range periods {
+		values := valuesByPeriod[period]
+		valueStart := maxValues - len(values)
+		key := fmt.Sprintf("%s_%d", indicator, period)
+		for i, value := range values {
+			out[valueStart+i][key] = value
+		}
+	}
+
+	// Apply --points after merging so the latest timestamp can include every
+	// requested period in one object, which is the common crossover use case.
+	if points > 0 && points < len(out) {
+		out = out[len(out)-points:]
+	}
+
+	data := multiTAOutput{
+		Indicator: indicator,
+		Symbol:    symbol,
+		Interval:  interval,
+		Periods:   periods,
+		Values:    out,
+	}
+	return output.WriteSuccess(w, data, output.TimestampMeta())
 }

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -294,6 +294,44 @@ func TestTASMA_LargePeriodScalesHistory(t *testing.T) {
 	assert.Len(t, values, 1, "--points 1 should limit output to 1 entry")
 }
 
+func TestTASMA_MultipleCommaSeparatedPeriods(t *testing.T) {
+	// Arrange: only one price-history request should be needed because the
+	// command fetches enough candles for the largest requested SMA period.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
+		assert.Equal(t, "1", r.URL.Query().Get("period"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockCandleListJSON("AAPL", 252)))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	require.NoError(t, runTestCommand(t, cmd, "ta", "sma", "--period", "21,50,200", "--points", "1", "AAPL"))
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	assert.Equal(t, "sma", data["indicator"])
+	assert.Equal(t, "AAPL", data["symbol"])
+	assert.NotContains(t, data, "period", "multi-period output should use periods")
+
+	periods, ok := data["periods"].([]any)
+	require.True(t, ok, "periods should be an array")
+	assert.Equal(t, []any{float64(21), float64(50), float64(200)}, periods)
+
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 1, "--points 1 should return one merged row")
+
+	latest := values[0].(map[string]any)
+	assert.Contains(t, latest, "datetime")
+	assert.Contains(t, latest, "sma_21")
+	assert.Contains(t, latest, "sma_50")
+	assert.Contains(t, latest, "sma_200")
+}
+
 func TestTAEMA_ValidEnvelope(t *testing.T) {
 	// Arrange
 	srv := httptest.NewServer(priceHistoryHandler(t, "MSFT", 80))
@@ -320,6 +358,67 @@ func TestTAEMA_ValidEnvelope(t *testing.T) {
 	first := values[0].(map[string]any)
 	assert.Contains(t, first, "datetime")
 	assert.Contains(t, first, "ema")
+}
+
+func TestTAEMA_MultipleRepeatedPeriods(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(priceHistoryHandler(t, "MSFT", 120))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	require.NoError(t, runTestCommand(t, cmd, "ta", "ema", "--period", "12", "--period", "26", "--points", "2", "MSFT"))
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	assert.Equal(t, "ema", data["indicator"])
+
+	periods, ok := data["periods"].([]any)
+	require.True(t, ok, "periods should be an array")
+	assert.Equal(t, []any{float64(12), float64(26)}, periods)
+
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 2)
+
+	latest := values[1].(map[string]any)
+	assert.Contains(t, latest, "ema_12")
+	assert.Contains(t, latest, "ema_26")
+}
+
+func TestTASimplePeriodValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "zero period",
+			args: []string{"ta", "sma", "--period", "0", "AAPL"},
+		},
+		{
+			name: "duplicate period",
+			args: []string{"ta", "sma", "--period", "21,21", "AAPL"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			server := jsonServer(`{}`)
+			defer server.Close()
+
+			// Act
+			var buf bytes.Buffer
+			cmd := TACommand(testClient(t, server), &buf)
+			err := runTestCommand(t, cmd, tt.args...)
+
+			// Assert
+			require.Error(t, err)
+			var valErr *apperr.ValidationError
+			assert.ErrorAs(t, err, &valErr)
+		})
+	}
 }
 
 func TestTARSI_ValidEnvelope(t *testing.T) {
@@ -354,6 +453,37 @@ func TestTARSI_ValidEnvelope(t *testing.T) {
 		assert.GreaterOrEqual(t, rsiVal, 0.0, "RSI[%d] should be >= 0", i)
 		assert.LessOrEqual(t, rsiVal, 100.0, "RSI[%d] should be <= 100", i)
 	}
+}
+
+func TestTARSI_MultipleCommaSeparatedPeriods(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(priceHistoryHandler(t, "TSLA", 120))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := TACommand(testClient(t, srv), &buf)
+	require.NoError(t, runTestCommand(t, cmd, "ta", "rsi", "--period", "14,21,28", "--points", "2", "TSLA"))
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	assert.Equal(t, "rsi", data["indicator"])
+	assert.Equal(t, "TSLA", data["symbol"])
+	assert.NotContains(t, data, "period", "multi-period output should use periods")
+
+	periods, ok := data["periods"].([]any)
+	require.True(t, ok, "periods should be an array")
+	assert.Equal(t, []any{float64(14), float64(21), float64(28)}, periods)
+
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 2)
+
+	latest := values[1].(map[string]any)
+	assert.Contains(t, latest, "datetime")
+	assert.Contains(t, latest, "rsi_14")
+	assert.Contains(t, latest, "rsi_21")
+	assert.Contains(t, latest, "rsi_28")
 }
 
 func TestTARSI_MissingSymbol(t *testing.T) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -26,6 +26,13 @@ func NewMetadata() Metadata {
 	}
 }
 
+// TimestampMeta returns metadata with the standard UTC timestamp field set.
+// It exists as the success-envelope helper used by command packages; NewMetadata
+// remains the lower-level constructor for callers that add more metadata fields.
+func TimestampMeta() Metadata {
+	return NewMetadata()
+}
+
 // Envelope is the standard JSON response wrapper for successful operations.
 type Envelope struct {
 	Data     any      `json:"data"`

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -316,6 +316,14 @@ func TestNewMetadataIsUTC(t *testing.T) {
 	assert.Contains(t, meta.Timestamp, "Z")
 }
 
+func TestTimestampMeta(t *testing.T) {
+	meta := TimestampMeta()
+
+	assert.NotEmpty(t, meta.Timestamp)
+	_, err := time.Parse(time.RFC3339, meta.Timestamp)
+	assert.NoError(t, err)
+}
+
 func TestEnvelopeJSONStructure(t *testing.T) {
 	buf := &bytes.Buffer{}
 	data := map[string]any{"key": "value"}

--- a/skills/schwab-agent/schwab-ta.md
+++ b/skills/schwab-agent/schwab-ta.md
@@ -9,11 +9,11 @@ Eleven indicators computed locally from Schwab price history. Pattern: `schwab-a
 | `--interval` | daily | daily, weekly, 1min, 5min, 15min, 30min |
 | `--points` | 1 | Limit output to N most recent values (0 = all) |
 
-Most indicators also accept `--period` (lookback window). Exceptions noted below.
+Most indicators also accept `--period` (lookback window). For SMA, EMA, and RSI, `--period` may be repeated or comma-separated to calculate multiple lookbacks in one command, for example `--period 21,50,200`.
 
 ## Standard Indicators
 
-All use `--period` for lookback window. Output is a time series with `datetime` plus indicator-specific keys.
+All use `--period` for lookback window. Output is a time series with `datetime` plus indicator-specific keys. SMA, EMA, and RSI support multiple periods in one run.
 
 | Indicator | Command | Period Default | Output Keys | Interpretation |
 |-----------|---------|---------------|-------------|----------------|
@@ -23,7 +23,13 @@ All use `--period` for lookback window. Output is a time series with `datetime` 
 | ATR | `ta atr` | 14 | `atr` | Volatility in price units. Higher = wider swings |
 | ADX | `ta adx` | 14 | `adx`, `plus_di`, `minus_di` | >25 trending, <20 ranging. plus/minus_di show directional bias |
 
-Example: `schwab-agent ta rsi AAPL --period 9 --interval 5min --points 20`
+Examples:
+
+```bash
+schwab-agent ta rsi AAPL --period 9 --interval 5min --points 20
+schwab-agent ta sma AAPL --period 21,50,200 --points 1
+schwab-agent ta ema AAPL --period 12 --period 26 --points 5
+```
 
 ## MACD - Moving Average Convergence/Divergence
 
@@ -110,6 +116,21 @@ Time series indicators return:
 }
 ```
 
+SMA, EMA, and RSI with multiple periods return `periods` and key each available value by period. Early rows may omit longer-period keys until enough history exists; the latest rows include all requested periods when Schwab returns enough candles:
+
+```json
+{
+  "data": {
+    "indicator": "sma",
+    "symbol": "AAPL",
+    "interval": "daily",
+    "periods": [21, 50, 200],
+    "values": [{"datetime": "2026-04-18", "sma_21": 203.14, "sma_50": 198.42, "sma_200": 184.77}]
+  },
+  "metadata": {"timestamp": "2026-04-22T10:00:00Z"}
+}
+```
+
 Scalar indicators (HV, Expected Move) return fields directly in `data` instead of a `values` array.
 
 ## Recipes
@@ -118,13 +139,14 @@ Scalar indicators (HV, Expected Move) return fields directly in `data` instead o
 |--------|---------|
 | "Is AAPL overbought?" | `ta rsi AAPL` |
 | "20-day moving average" | `ta sma AAPL` |
-| "50/200-day SMA crossover" | `ta sma AAPL --period 50 --points 5` then `--period 200 --points 5` |
+| "21/50/200-day SMA" | `ta sma AAPL --period 21,50,200 --points 1` |
+| "50/200-day SMA crossover" | `ta sma AAPL --period 50,200 --points 5` |
 | "MACD signal" | `ta macd AAPL --points 5` |
 | "How volatile is AAPL?" | `ta atr AAPL` |
 | "Near Bollinger Band?" | `ta bbands AAPL` |
 | "Stochastic reading" | `ta stoch AAPL` |
 | "Trending or ranging?" | `ta adx AAPL` |
-| "EMA crossover (12/26)" | `ta ema AAPL --period 12 --points 5` then `--period 26 --points 5` |
+| "EMA crossover (12/26)" | `ta ema AAPL --period 12,26 --points 5` |
 | "Intraday RSI (5min)" | `ta rsi AAPL --interval 5min --points 20` |
 | "Weekly MACD" | `ta macd NVDA --interval weekly --points 10` |
 | "Tight Bollinger Bands" | `ta bbands AAPL --std-dev 1.5 --points 10` |


### PR DESCRIPTION
## Summary
- Support repeatable and comma-separated `--period` values for SMA, EMA, and RSI so agents can fetch multiple moving averages in one command.
- Preserve the existing single-period JSON shape while adding multi-period output keys like `sma_21`, `sma_50`, and `sma_200`.
- Update TA tests, README examples, and skill docs for the new workflow.

## Verification
- `make test`
- `make lint`
- `make build`
- 5-agent review passed: goal fit, QA execution, code quality, security, and context mining