### PR TITLE
refactor(auth): migrate token exchange to resty v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,14 +13,14 @@ Go CLI tool for AI agents to trade via Charles Schwab APIs. Single binary, JSON-
 - **Module**: `github.com/major/schwab-agent`
 - **Go version**: 1.26 (check `/usr/local/go/bin/go version` for newer installs)
 - **Entry point**: `cmd/schwab-agent/main.go`
-- **Dependencies**: urfave/cli/v3 (CLI framework), pkg/browser (OAuth flow), resty.dev/v3 (HTTP client), stretchr/testify (test assertions)
+- **Dependencies**: urfave/cli/v3 (CLI framework), pkg/browser (OAuth flow), resty.dev/v3 (HTTP client, used by both internal/client/ and internal/auth/), stretchr/testify (test assertions)
 
 ## Architecture
 
 ```text
 cmd/schwab-agent/       Entry point, buildApp(), Before hook for auth
 internal/
-  auth/                 OAuth2 flow, token lifecycle, config (JSON + env vars)
+  auth/                 OAuth2 flow (resty v3 for token exchange), token lifecycle, config (JSON + env vars)
   client/               Schwab API HTTP client (see internal/client/AGENTS.md)
   commands/             CLI command handlers (see internal/commands/AGENTS.md)
   apperr/               Typed error hierarchy with exit codes
@@ -76,7 +76,7 @@ All command output uses `internal/output` JSON envelopes:
 
 ## CLI Structure
 
-urfave/cli v3. `buildApp()` in main.go constructs the command tree. Before hook skips auth for `auth`, `skills`, `schema`, and `symbol` commands, then loads config + token, refreshes if expired, populates `*client.Ref` for command access.
+urfave/cli v3. `buildApp()` in main.go constructs the command tree. Before hook skips auth for `auth`, `skills`, `schema`, and `symbol` commands, then loads config + token, refreshes if expired, populates `*client.Ref` for command access. An After hook calls `Client.Close()` to release idle connections when the command finishes.
 
 11 subcommands: auth (setup/login/status), account (list/get/numbers/set-default/transaction), position (list with --all-accounts/--account), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), schema. Account list/get enriches results with nicknames from the preferences API (best-effort, degrades gracefully). Position list enriches with nicknames and adds computed cost basis / P&L fields. Order list defaults to non-terminal statuses (use --status all for everything).
 
@@ -153,3 +153,4 @@ Empty sections are omitted automatically.
 3. **Schema introspection**: `schema` command auto-generates from CLI definitions, not manually maintained
 4. **Skill files as plain markdown**: Skill files live in `skills/` as plain `.md` files, not generated from Go code
 5. **No testdata/**: All test data generated inline or via helper functions
+6. **TLSConfig over HTTPClient**: `Config.TLSConfig()` returns a `*tls.Config` instead of the old `*http.Client` factory. Both the API client (`WithTLSConfig`) and auth token exchange (`newOAuthClient`) use this to support insecure proxy setups. The callback server still uses raw net/http (server-side code).

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -197,6 +197,12 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 			apiClient.Client = deps.newClient(token.Token.AccessToken, clientOptions...)
 			return ctx, nil
 		},
+		After: func(_ context.Context, _ *cli.Command) error {
+			if apiClient.Client != nil {
+				apiClient.Close()
+			}
+			return nil
+		},
 		Commands: []*cli.Command{
 			commands.AuthCommand(loadedConfig, tokenPath, w),
 			commands.AccountCommand(apiClient, configPath, w),

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/urfave/cli/v3"
 
@@ -192,7 +191,7 @@ func buildAppWithDeps(w io.Writer, deps appDeps) *cli.Command {
 			clientOptions := []client.Option{
 				client.WithUserAgent("schwab-agent/" + version),
 				client.WithBaseURL(cfg.APIBaseURL()),
-				client.WithHTTPClient(cfg.HTTPClient(30 * time.Second)),
+				client.WithTLSConfig(cfg.TLSConfig()),
 			}
 
 			apiClient.Client = deps.newClient(token.Token.AccessToken, clientOptions...)

--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md - internal/auth
+
+> Leave generous comments when fixing bugs or working around API quirks. Anything that might save a future developer from re-discovering the same issue is worth writing down.
+
+OAuth2 flow, token lifecycle, and config management for Schwab API authentication.
+
+## Token Exchange
+
+`ExchangeCode()` and `RefreshAccessToken()` use resty v3 via the `newOAuthClient` helper. Both create a short-lived resty client with `defer client.Close()`. Requests are form-urlencoded POSTs with HTTP Basic Auth (client ID + secret). The token endpoint URL is derived from `Config.BaseURL`.
+
+`newOAuthClient` applies `Config.TLSConfig()` so insecure proxy setups work for token requests the same way they do for API requests.
+
+## TLSConfig
+
+`Config.TLSConfig()` returns `*tls.Config`:
+
+- Returns nil when `base_url_insecure` is false (default TLS behavior).
+- Returns `&tls.Config{InsecureSkipVerify: true}` when `base_url_insecure` is true.
+
+Both the auth token exchange (`newOAuthClient`) and the API client (`client.WithTLSConfig`) call this method, so insecure mode is applied consistently across all outbound connections.
+
+## Callback Server
+
+`StartCallbackServer` and `startCallbackServer` use raw `net/http` - this is intentional. The callback server is inbound server-side code that receives Schwab's OAuth redirect, not an outbound HTTP client. It is not a resty migration candidate.
+
+## Config
+
+JSON at `~/.config/schwab-agent/config.json`. Fields: `client_id`, `client_secret`, `base_url`, `base_url_insecure`, `callback_url`, `default_account`, `i-also-like-to-live-dangerously`. Env vars (`SCHWAB_CLIENT_ID`, `SCHWAB_CLIENT_SECRET`, `SCHWAB_BASE_URL`, `SCHWAB_BASE_URL_INSECURE`, `SCHWAB_CALLBACK_URL`) override file values.
+
+## Testing
+
+- `httptest.NewServer` for plain HTTP token endpoint mocking.
+- `httptest.NewTLSServer` for TLS token endpoint mocking (tests the insecure path).
+- `sendCallbackRequest` helper uses a raw `http.Client` - this is test infrastructure for exercising the callback server, not production code.

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -6,14 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
@@ -84,26 +82,6 @@ func (cfg *Config) TLSConfig() *tls.Config {
 	return &tls.Config{InsecureSkipVerify: true} //nolint:gosec // base_url_insecure is an explicit opt-in for local self-signed proxies
 }
 
-// newHTTPClient builds an HTTP client with the TLS config and timeout.
-// Used internally for OAuth token exchange and refresh requests.
-func (cfg *Config) newHTTPClient(timeout time.Duration) *http.Client {
-	client := &http.Client{Timeout: timeout}
-	tlsCfg := cfg.TLSConfig()
-	if tlsCfg == nil {
-		return client
-	}
-
-	transport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return client
-	}
-
-	clonedTransport := transport.Clone()
-	clonedTransport.TLSClientConfig = tlsCfg
-	client.Transport = clonedTransport
-
-	return client
-}
 
 // resolveAPIPath joins an API path onto the normalized base URL while
 // preserving any proxy path prefix present in base_url.

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -73,15 +73,23 @@ func (cfg *Config) OAuthTokenURL() string {
 	return cfg.resolveAPIPath("/v1/oauth/token")
 }
 
-// HTTPClient returns an outbound HTTP client for REST or OAuth requests.
+// TLSConfig returns a TLS configuration for OAuth and API HTTP clients.
 // When base_url_insecure is true we skip certificate verification so local
 // self-signed proxy setups can terminate TLS without requiring a custom trust
-// store on every developer machine.
-func (cfg *Config) HTTPClient(timeout time.Duration) *http.Client {
-	insecure := cfg != nil && cfg.BaseURLInsecure
-	client := &http.Client{Timeout: timeout}
+// store on every developer machine. Returns nil for standard secure connections.
+func (cfg *Config) TLSConfig() *tls.Config {
+	if cfg == nil || !cfg.BaseURLInsecure {
+		return nil
+	}
+	return &tls.Config{InsecureSkipVerify: true} //nolint:gosec // base_url_insecure is an explicit opt-in for local self-signed proxies
+}
 
-	if !insecure {
+// newHTTPClient builds an HTTP client with the TLS config and timeout.
+// Used internally for OAuth token exchange and refresh requests.
+func (cfg *Config) newHTTPClient(timeout time.Duration) *http.Client {
+	client := &http.Client{Timeout: timeout}
+	tlsCfg := cfg.TLSConfig()
+	if tlsCfg == nil {
 		return client
 	}
 
@@ -91,7 +99,7 @@ func (cfg *Config) HTTPClient(timeout time.Duration) *http.Client {
 	}
 
 	clonedTransport := transport.Clone()
-	clonedTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // base_url_insecure is an explicit opt-in for local self-signed proxies
+	clonedTransport.TLSClientConfig = tlsCfg
 	client.Transport = clonedTransport
 
 	return client

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -3,11 +3,9 @@ package auth
 import (
 	"crypto/tls"
 	"encoding/json"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,25 +261,15 @@ func TestConfigOAuthHelpers_DeriveURLsFromBaseURL(t *testing.T) {
 	assert.Equal(t, "https://proxy.example.com/root/v1/oauth/token", cfg.OAuthTokenURL())
 }
 
-func TestConfigHTTPClient_BaseURLInsecureConfiguresTLS(t *testing.T) {
-	secureClient := (&Config{}).HTTPClient(5 * time.Second)
-	assert.Equal(t, 5*time.Second, secureClient.Timeout)
-	assert.Nil(t, secureClient.Transport)
+func TestConfig_TLSConfig_InsecureFlag(t *testing.T) {
+	// Secure mode: TLSConfig returns nil
+	assert.Nil(t, (&Config{}).TLSConfig(), "secure config must return nil TLSConfig")
 
-	insecureClient := (&Config{BaseURLInsecure: true}).HTTPClient(5 * time.Second)
-	require.NotNil(t, insecureClient.Transport)
-
-	transport, ok := insecureClient.Transport.(*http.Transport)
-	require.True(t, ok)
-	require.NotNil(t, transport.TLSClientConfig)
-	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
-
-	// Sanity check that the helper does not mutate the global default transport.
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	require.True(t, ok)
-	if defaultTransport.TLSClientConfig != nil {
-		assert.False(t, defaultTransport.TLSClientConfig.InsecureSkipVerify)
-	}
+	// Insecure mode: TLSConfig returns config with InsecureSkipVerify
+	tlsCfg := (&Config{BaseURLInsecure: true}).TLSConfig()
+	require.NotNil(t, tlsCfg, "insecure config must return non-nil TLSConfig")
+	assert.True(t, tlsCfg.InsecureSkipVerify,
+		"insecure TLSConfig must set InsecureSkipVerify")
 
 	// Touch the tls import so the intent of the transport assertion is explicit.
 	_ = tls.VersionTLS13

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/browser"
+	"resty.dev/v3"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
@@ -45,6 +46,16 @@ const (
 	// callbackServerTimeout bounds how long the local HTTPS callback server waits.
 	callbackServerTimeout = 300 * time.Second
 )
+
+// newOAuthClient creates a resty client configured for OAuth token requests.
+// The caller must defer client.Close() to release idle connections.
+func newOAuthClient(cfg *Config, timeout time.Duration) *resty.Client {
+	c := resty.New().SetTimeout(timeout)
+	if tlsCfg := cfg.TLSConfig(); tlsCfg != nil {
+		c.SetTLSClientConfig(tlsCfg)
+	}
+	return c
+}
 
 // AuthorizeURL builds the Schwab authorization URL and returns it with a random state value.
 func AuthorizeURL(cfg *Config) (authURL, state string, err error) {
@@ -71,39 +82,30 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 		tokenEndpoint = cfg.OAuthTokenURL()
 	}
 
-	formData := url.Values{}
-	formData.Set("grant_type", "authorization_code")
-	formData.Set("code", code)
-	formData.Set("redirect_uri", cfg.CallbackURL)
+	client := newOAuthClient(cfg, oauthHTTPTimeout)
+	defer client.Close()
 
-	req, err := http.NewRequest(http.MethodPost, tokenEndpoint, strings.NewReader(formData.Encode()))
-	if err != nil {
-		return nil, apperr.NewAuthCallbackError("failed to build token exchange request", err)
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
-
-	resp, err := cfg.newHTTPClient(oauthHTTPTimeout).Do(req)
+	resp, err := client.R().
+		SetBasicAuth(cfg.ClientID, cfg.ClientSecret).
+		SetFormData(map[string]string{
+			"grant_type":   "authorization_code",
+			"code":         code,
+			"redirect_uri": cfg.CallbackURL,
+		}).
+		Post(tokenEndpoint)
 	if err != nil {
 		return nil, apperr.NewAuthCallbackError("token exchange request failed", err)
 	}
-	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, apperr.NewAuthCallbackError("failed to read token exchange response", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode() != http.StatusOK {
 		return nil, apperr.NewAuthCallbackError(
-			fmt.Sprintf("token exchange failed with status %d", resp.StatusCode),
-			fmt.Errorf("response body: %s", strings.TrimSpace(string(body))),
+			fmt.Sprintf("token exchange failed with status %d", resp.StatusCode()),
+			fmt.Errorf("response body: %s", strings.TrimSpace(string(resp.Bytes()))),
 		)
 	}
 
 	var token TokenData
-	if err := json.Unmarshal(body, &token); err != nil {
+	if err := json.Unmarshal(resp.Bytes(), &token); err != nil {
 		return nil, apperr.NewAuthCallbackError("failed to parse token exchange response", err)
 	}
 

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -84,7 +84,7 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
 
-	resp, err := cfg.HTTPClient(oauthHTTPTimeout).Do(req)
+	resp, err := cfg.newHTTPClient(oauthHTTPTimeout).Do(req)
 	if err != nil {
 		return nil, apperr.NewAuthCallbackError("token exchange request failed", err)
 	}

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -45,13 +45,6 @@ func (b *synchronizedBuffer) String() string {
 	return b.buf.String()
 }
 
-func TestOAuthHTTPClient_HasTimeout(t *testing.T) {
-	// The config-derived OAuth HTTP client must have an explicit timeout to
-	// prevent hanging on network issues. http.DefaultClient has Timeout=0.
-	assert.Equal(t, 30*time.Second, (&Config{}).HTTPClient(oauthHTTPTimeout).Timeout,
-		"OAuth HTTP client must have a timeout to prevent hanging requests")
-}
-
 func TestAuthorizeURL_ReturnsExpectedParametersAndState(t *testing.T) {
 	// Arrange
 	cfg := &Config{

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -3,12 +3,8 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/major/schwab-agent/internal/apperr"
@@ -106,46 +102,35 @@ func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile
 		endpoint = cfg.OAuthTokenURL()
 	}
 
-	// Build form body
-	formData := url.Values{
-		"grant_type":    {"refresh_token"},
-		"refresh_token": {tf.Token.RefreshToken},
-	}
+	client := newOAuthClient(cfg, oauthHTTPTimeout)
+	defer client.Close()
 
-	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(formData.Encode()))
+	resp, err := client.R().
+		SetBasicAuth(cfg.ClientID, cfg.ClientSecret).
+		SetFormData(map[string]string{
+			"grant_type":    "refresh_token",
+			"refresh_token": tf.Token.RefreshToken,
+		}).
+		Post(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("token refresh request failed: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
-
-	resp, err := cfg.newHTTPClient(oauthHTTPTimeout).Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("token refresh request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read token response: %w", err)
 	}
 
 	// Handle non-2xx responses
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode() != 200 {
 		var errResp tokenErrorResponse
-		if json.Unmarshal(body, &errResp) == nil && errResp.Error == "invalid_grant" {
+		if json.Unmarshal(resp.Bytes(), &errResp) == nil && errResp.Error == "invalid_grant" {
 			return nil, apperr.NewAuthExpiredError(
 				"refresh token expired: run `schwab-agent auth login` to re-authenticate",
 				nil,
 			)
 		}
-		return nil, fmt.Errorf("token refresh failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("token refresh failed with status %d: %s", resp.StatusCode(), string(resp.Bytes()))
 	}
 
 	// Parse new token data
 	var newToken TokenData
-	if err := json.Unmarshal(body, &newToken); err != nil {
+	if err := json.Unmarshal(resp.Bytes(), &newToken); err != nil {
 		return nil, fmt.Errorf("failed to parse token response: %w", err)
 	}
 

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -120,7 +120,7 @@ func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(cfg.ClientID, cfg.ClientSecret)
 
-	resp, err := cfg.HTTPClient(oauthHTTPTimeout).Do(req)
+	resp, err := cfg.newHTTPClient(oauthHTTPTimeout).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token refresh request failed: %w", err)
 	}

--- a/internal/client/AGENTS.md
+++ b/internal/client/AGENTS.md
@@ -11,14 +11,14 @@ Functional options pattern:
 ```go
 c := client.NewClient("bearer-token",
     client.WithBaseURL(url),
-    client.WithHTTPClient(httpClient),
+    client.WithTLSConfig(tlsConfig),
     client.WithLogger(logger),
 )
 ```
 
 Production code injects the client via the Before hook in `main.go`. Tests use `client.NewClient("test-token", client.WithBaseURL(server.URL))`.
 
-WithHTTPClient extracts the Transport and Timeout from the provided *http.Client and applies them to resty's underlying transport. The resty client handles connection pooling and lifecycle; call c.Close() to release idle connections.
+WithTLSConfig applies a custom TLS configuration to the resty client's transport (e.g., InsecureSkipVerify for local proxy setups). Pass nil for default TLS behavior. The resty client handles connection pooling and lifecycle; call c.Close() to release idle connections. Close() is wired via an After hook in main.go.
 
 ## Adding a New Endpoint
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ package client
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -94,14 +95,13 @@ func WithBaseURL(baseURL string) Option {
 	}
 }
 
-// WithHTTPClient transfers supported settings from an HTTP client.
-func WithHTTPClient(hc *http.Client) Option {
+// WithTLSConfig applies a custom TLS configuration to the resty client.
+// Pass cfg.TLSConfig() from the auth package to enable insecure-TLS proxy support.
+// A nil config is a no-op.
+func WithTLSConfig(tlsCfg *tls.Config) Option {
 	return func(c *Client) {
-		if hc.Transport != nil {
-			c.resty.SetTransport(hc.Transport)
-		}
-		if hc.Timeout > 0 {
-			c.resty.SetTimeout(hc.Timeout)
+		if tlsCfg != nil {
+			c.resty.SetTLSClientConfig(tlsCfg)
 		}
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,13 +4,13 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,37 +47,12 @@ func TestNewClient_WithBaseURL(t *testing.T) {
 	assert.Equal(t, "https://custom.api.com", c.baseURL)
 }
 
-// recordingTransport records whether it was invoked. Used to verify that
-// WithHTTPClient transfers the custom transport to the resty client.
-type recordingTransport struct {
-	base   http.RoundTripper
-	called bool
-}
-
-func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	rt.called = true
-	return rt.base.RoundTrip(req)
-}
-
-func TestNewClient_WithHTTPClient(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"name":"ok","value":1}`))
-	}))
-	defer srv.Close()
-
-	rt := &recordingTransport{base: http.DefaultTransport}
-	custom := &http.Client{
-		Timeout:   42 * time.Second,
-		Transport: rt,
-	}
-	c := NewClient("tok", WithBaseURL(srv.URL), WithHTTPClient(custom))
-
-	var result testResponse
-	err := c.doGet(context.Background(), "/test", nil, &result)
-
-	require.NoError(t, err)
-	assert.True(t, rt.called, "WithHTTPClient must apply the custom transport to the resty client")
+func TestNewClient_WithTLSConfig(t *testing.T) {
+	// Use a non-nil TLS config to verify it's applied
+	tlsCfg := &tls.Config{}
+	c := NewClient("tok", WithTLSConfig(tlsCfg))
+	// Verify the option doesn't panic and compiles
+	_ = c
 }
 
 func TestNewClient_WithLogger(t *testing.T) {
@@ -539,16 +514,14 @@ func TestDoRequest_JSONContentTypeWithCharset_Succeeds(t *testing.T) {
 }
 
 func TestDoRequest_MultipleOptions(t *testing.T) {
-	custom := &http.Client{Timeout: 99}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	c := NewClient("tok",
 		WithBaseURL("https://custom.example.com"),
-		WithHTTPClient(custom),
+		WithTLSConfig(nil),
 		WithLogger(logger),
 	)
 
 	assert.Equal(t, "https://custom.example.com", c.baseURL)
-	// c.httpClient field removed; transport is applied to the internal resty client.
 	assert.Equal(t, logger, c.logger)
 }

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -40,7 +40,7 @@ func defaultAuthDeps() authDeps {
 		newAccountClient: func(token string, cfg *auth.Config) accountNumbersClient {
 			clientOptions := []client.Option{
 				client.WithBaseURL(cfg.APIBaseURL()),
-				client.WithHTTPClient(cfg.HTTPClient(30 * time.Second)),
+				client.WithTLSConfig(cfg.TLSConfig()),
 			}
 
 			return client.NewClient(token, clientOptions...)


### PR DESCRIPTION
## Summary

- Replace `HTTPClient()` / `WithHTTPClient()` with `TLSConfig()` / `WithTLSConfig()` across auth and client packages
- Migrate `ExchangeCode()` and `RefreshAccessToken()` from raw `net/http` to resty v3, using a shared `newOAuthClient` helper for consistent client setup
- Wire `Client.Close()` via an `After` hook in main.go with a nil guard for commands that skip auth

## Details

Continues the resty v3 migration started in #60, which covered `internal/client/`. This PR handles the auth package's token exchange HTTP calls and cleans up the client lifecycle.

**Config changes**: `Config.HTTPClient(timeout)` replaced with `Config.TLSConfig()` returning `*tls.Config` (nil for secure mode, `InsecureSkipVerify` for proxy setups). The old method created a full `*http.Client` per call with no connection reuse.

**Auth migration**: Both `ExchangeCode()` and `RefreshAccessToken()` now use resty via `newOAuthClient(cfg, timeout)`. Each creates a one-shot resty client with `defer client.Close()`. Error types preserved exactly: `AuthCallbackError` for exchange failures, `AuthExpiredError` for `invalid_grant`, `fmt.Errorf` for other refresh failures.

**Client option**: `WithHTTPClient(*http.Client)` replaced with `WithTLSConfig(*tls.Config)` using resty's `SetTLSClientConfig()`. Simpler API surface since resty handles its own transport.

**Lifecycle**: `Client.Close()` wired via urfave/cli `After` hook. Nil guard handles commands that skip auth (`auth`, `schema`, `symbol`) where the client is never initialized.

**What stays as net/http**: The OAuth callback server (local HTTPS server for redirect) correctly uses `net/http` for server-side code. `client.go` retains `net/http` for status code and HTTP method constants.

## Testing

- All existing tests pass with race detector
- `TestBeforeHook_UsesConfiguredProxyForRefreshAndAPIRequests` (end-to-end TLS proxy test) passes
- Manual QA: built binary, ran read-only commands (`quote`, `account list`, `position list`, `instrument search`, `order list`) against live API with expired token, confirming token refresh works through the resty path