### PR TITLE
fix(commands): use cmd.Context() instead of context.Background() in history

### DIFF
--- a/internal/commands/history.go
+++ b/internal/commands/history.go
@@ -2,7 +2,6 @@
 package commands
 
 import (
-	"context"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -49,7 +48,7 @@ Examples:
 				EndDate:       flagString(cmd, "to"),
 			}
 
-			result, err := c.PriceHistory(context.Background(), symbol, &params)
+			result, err := c.PriceHistory(cmd.Context(), symbol, &params)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

- Use `cmd.Context()` instead of `context.Background()` in history command so parent timeouts/cancellations propagate
- All other 36 API call sites already use `cmd.Context()`; `history.go` was the sole outlier

Found via CodeRabbit local review of the cobra migration.