### PR TITLE
feat: add WithFlagErrors and WithAppName to structcli Setup

### DIFF
--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -66,7 +66,7 @@ func buildAppWithDeps(w io.Writer, deps commands.RootDeps) *cobra.Command {
 	root.AddCommand(commands.NewOrderCmd(ref, configPath, w))
 	root.AddCommand(commands.NewCompletionCmd(w))
 
-	if err := structcli.Setup(root, structcli.WithJSONSchema(), structcli.WithHelpTopics()); err != nil {
+	if err := structcli.Setup(root, structcli.WithJSONSchema(), structcli.WithHelpTopics(), structcli.WithFlagErrors(), structcli.WithAppName("schwab-agent")); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## Summary
- Add WithFlagErrors() for structured JSON flag parse errors (helps agents self-correct)
- Add WithAppName("schwab-agent") for proper env var prefixing in help topics

## Verification
- make test passes
- make lint passes