### PR TITLE
feat: register CLI-facing enums with structcli

### DIFF
--- a/internal/commands/chain.go
+++ b/internal/commands/chain.go
@@ -12,19 +12,19 @@ import (
 
 // chainGetOpts holds the options for the chain get subcommand.
 type chainGetOpts struct {
-	Type                   string `flag:"type" flagdescr:"Contract type: CALL, PUT, or ALL" flaggroup:"contract"`
-	StrikeCount            string `flag:"strike-count" flagdescr:"Number of strikes to return" flaggroup:"filtering"`
-	Strategy               string `flag:"strategy" flagdescr:"Option pricing strategy" flaggroup:"contract"`
-	FromDate               string `flag:"from-date" flagdescr:"Start date (YYYY-MM-DD)" flaggroup:"filtering"`
-	ToDate                 string `flag:"to-date" flagdescr:"End date (YYYY-MM-DD)" flaggroup:"filtering"`
-	IncludeUnderlyingQuote bool   `flag:"include-underlying-quote" flagdescr:"Include underlying quote data in response" flaggroup:"filtering"`
-	Interval               string `flag:"interval" flagdescr:"Strike interval for spread strategy chains" flaggroup:"filtering"`
-	Strike                 string `flag:"strike" flagdescr:"Filter to a specific strike price" flaggroup:"filtering"`
-	StrikeRange            string `flag:"strike-range" flagdescr:"Moneyness filter: ITM, NTM, OTM, SAK, SBK, SNK, or ALL" flaggroup:"filtering"`
-	Volatility             string `flag:"volatility" flagdescr:"Volatility for theoretical pricing calculations" flaggroup:"pricing"`
-	UnderlyingPrice        string `flag:"underlying-price" flagdescr:"Override underlying price for theoretical calculations" flaggroup:"pricing"`
-	InterestRate           string `flag:"interest-rate" flagdescr:"Interest rate for theoretical pricing calculations" flaggroup:"pricing"`
-	DaysToExpiration       string `flag:"days-to-expiration" flagdescr:"Days to expiration for theoretical pricing calculations" flaggroup:"pricing"`
+	Type                   chainContractType `flag:"type" flagdescr:"Contract type: CALL, PUT, or ALL" flaggroup:"contract"`
+	StrikeCount            string            `flag:"strike-count" flagdescr:"Number of strikes to return" flaggroup:"filtering"`
+	Strategy               chainStrategy     `flag:"strategy" flagdescr:"Option pricing strategy" flaggroup:"contract"`
+	FromDate               string            `flag:"from-date" flagdescr:"Start date (YYYY-MM-DD)" flaggroup:"filtering"`
+	ToDate                 string            `flag:"to-date" flagdescr:"End date (YYYY-MM-DD)" flaggroup:"filtering"`
+	IncludeUnderlyingQuote bool              `flag:"include-underlying-quote" flagdescr:"Include underlying quote data in response" flaggroup:"filtering"`
+	Interval               string            `flag:"interval" flagdescr:"Strike interval for spread strategy chains" flaggroup:"filtering"`
+	Strike                 string            `flag:"strike" flagdescr:"Filter to a specific strike price" flaggroup:"filtering"`
+	StrikeRange            strikeRange       `flag:"strike-range" flagdescr:"Moneyness filter: ITM, NTM, OTM, SAK, SBK, SNK, or ALL" flaggroup:"filtering"`
+	Volatility             string            `flag:"volatility" flagdescr:"Volatility for theoretical pricing calculations" flaggroup:"pricing"`
+	UnderlyingPrice        string            `flag:"underlying-price" flagdescr:"Override underlying price for theoretical calculations" flaggroup:"pricing"`
+	InterestRate           string            `flag:"interest-rate" flagdescr:"Interest rate for theoretical pricing calculations" flaggroup:"pricing"`
+	DaysToExpiration       string            `flag:"days-to-expiration" flagdescr:"Days to expiration for theoretical pricing calculations" flaggroup:"pricing"`
 }
 
 // Attach implements structcli.Options interface.
@@ -78,15 +78,15 @@ specific moneyness with --strike-range (ITM, NTM, OTM, ALL).`,
 			}
 
 			params := client.ChainParams{
-				ContractType:           opts.Type,
+				ContractType:           string(opts.Type),
 				StrikeCount:            opts.StrikeCount,
-				Strategy:               opts.Strategy,
+				Strategy:               string(opts.Strategy),
 				FromDate:               opts.FromDate,
 				ToDate:                 opts.ToDate,
 				IncludeUnderlyingQuote: includeUnderlying,
 				Interval:               opts.Interval,
 				Strike:                 opts.Strike,
-				StrikeRange:            opts.StrikeRange,
+				StrikeRange:            string(opts.StrikeRange),
 				Volatility:             opts.Volatility,
 				UnderlyingPrice:        opts.UnderlyingPrice,
 				InterestRate:           opts.InterestRate,
@@ -104,6 +104,7 @@ specific moneyness with --strike-range (ITM, NTM, OTM, ALL).`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }

--- a/internal/commands/enums.go
+++ b/internal/commands/enums.go
@@ -1,0 +1,188 @@
+package commands
+
+import (
+	"github.com/leodido/structcli"
+
+	"github.com/major/schwab-agent/internal/models"
+)
+
+// chainContractType is a CLI-only enum because Schwab's chain endpoint accepts
+// ALL in addition to the CALL/PUT values represented by models.ContractType.
+type chainContractType string
+
+const (
+	chainContractTypeCall chainContractType = "CALL"
+	chainContractTypePut  chainContractType = "PUT"
+	chainContractTypeAll  chainContractType = "ALL"
+)
+
+// chainStrategy is a CLI-only enum for the option-chain strategy query param.
+type chainStrategy string
+
+const (
+	chainStrategySingle     chainStrategy = "SINGLE"
+	chainStrategyAnalytical chainStrategy = "ANALYTICAL"
+	chainStrategyCovered    chainStrategy = "COVERED"
+	chainStrategyVertical   chainStrategy = "VERTICAL"
+	chainStrategyCalendar   chainStrategy = "CALENDAR"
+	chainStrategyStrangle   chainStrategy = "STRANGLE"
+	chainStrategyStraddle   chainStrategy = "STRADDLE"
+	chainStrategyButterfly  chainStrategy = "BUTTERFLY"
+	chainStrategyCondor     chainStrategy = "CONDOR"
+	chainStrategyDiagonal   chainStrategy = "DIAGONAL"
+	chainStrategyCollar     chainStrategy = "COLLAR"
+	chainStrategyRoll       chainStrategy = "ROLL"
+)
+
+// strikeRange is a CLI-only enum for option-chain moneyness filters.
+type strikeRange string
+
+const (
+	strikeRangeITM strikeRange = "ITM"
+	strikeRangeNTM strikeRange = "NTM"
+	strikeRangeOTM strikeRange = "OTM"
+	strikeRangeSAK strikeRange = "SAK"
+	strikeRangeSBK strikeRange = "SBK"
+	strikeRangeSNK strikeRange = "SNK"
+	strikeRangeAll strikeRange = "ALL"
+)
+
+// historyPeriodType is a CLI-only enum for price history period type.
+type historyPeriodType string
+
+const (
+	historyPeriodTypeDay   historyPeriodType = "day"
+	historyPeriodTypeMonth historyPeriodType = "month"
+	historyPeriodTypeYear  historyPeriodType = "year"
+	historyPeriodTypeYTD   historyPeriodType = "ytd"
+)
+
+// historyFrequencyType is a CLI-only enum for price history frequency type.
+type historyFrequencyType string
+
+const (
+	historyFrequencyTypeMinute  historyFrequencyType = "minute"
+	historyFrequencyTypeDaily   historyFrequencyType = "daily"
+	historyFrequencyTypeWeekly  historyFrequencyType = "weekly"
+	historyFrequencyTypeMonthly historyFrequencyType = "monthly"
+)
+
+// historyFrequency is a CLI-only enum for known Schwab history frequencies.
+type historyFrequency string
+
+const (
+	historyFrequency1  historyFrequency = "1"
+	historyFrequency5  historyFrequency = "5"
+	historyFrequency10 historyFrequency = "10"
+	historyFrequency15 historyFrequency = "15"
+	historyFrequency30 historyFrequency = "30"
+)
+
+// instrumentProjection is a CLI-only enum for instrument search projection.
+type instrumentProjection string
+
+const (
+	instrumentProjectionSymbolSearch instrumentProjection = "symbol-search"
+	instrumentProjectionSymbolRegex  instrumentProjection = "symbol-regex"
+	instrumentProjectionDescSearch   instrumentProjection = "desc-search"
+	instrumentProjectionDescRegex    instrumentProjection = "desc-regex"
+	instrumentProjectionSearch       instrumentProjection = "search"
+	instrumentProjectionFundamental  instrumentProjection = "fundamental"
+)
+
+// moversSort is a CLI-only enum for market movers sorting.
+type moversSort string
+
+const (
+	moversSortVolume            moversSort = "VOLUME"
+	moversSortTrades            moversSort = "TRADES"
+	moversSortPercentChangeUp   moversSort = "PERCENT_CHANGE_UP"
+	moversSortPercentChangeDown moversSort = "PERCENT_CHANGE_DOWN"
+)
+
+// moversFrequency is a CLI-only enum for market movers minimum change filters.
+type moversFrequency string
+
+const (
+	moversFrequency0  moversFrequency = "0"
+	moversFrequency1  moversFrequency = "1"
+	moversFrequency5  moversFrequency = "5"
+	moversFrequency10 moversFrequency = "10"
+	moversFrequency30 moversFrequency = "30"
+	moversFrequency60 moversFrequency = "60"
+)
+
+// taInterval is a CLI-only enum shared by technical-analysis commands.
+type taInterval string
+
+const (
+	taIntervalDaily  taInterval = "daily"
+	taIntervalWeekly taInterval = "weekly"
+	taInterval1Min   taInterval = "1min"
+	taInterval5Min   taInterval = "5min"
+	taInterval15Min  taInterval = "15min"
+	taInterval30Min  taInterval = "30min"
+)
+
+// orderStatusFilter extends OrderStatus with the CLI-only ALL sentinel.
+type orderStatusFilter string
+
+const orderStatusFilterAll orderStatusFilter = "all"
+
+// init registers CLI-facing enums with structcli without adding a structcli
+// dependency to the pure models package. Registered enums populate JSON Schema,
+// shell completions, and pflag validation for typed option fields.
+func init() {
+	structcli.RegisterEnum(enumMapWithEmpty(validInstructions))
+	structcli.RegisterEnum(enumMapWithEmptyAndAliases(validOrderTypes, map[models.OrderType][]string{
+		models.OrderTypeMarketOnClose: []string{"MOC"},
+		models.OrderTypeLimitOnClose:  []string{"LOC"},
+	}))
+	structcli.RegisterEnum(enumMapWithEmptyAndAliases(validDurations, map[models.Duration][]string{
+		models.DurationGoodTillCancel:    []string{"GTC"},
+		models.DurationFillOrKill:        []string{"FOK"},
+		models.DurationImmediateOrCancel: []string{"IOC"},
+	}))
+	structcli.RegisterEnum(enumMapWithEmpty(validSessions))
+	structcli.RegisterEnum(enumMapWithEmpty(validStopPriceLinkBases))
+	structcli.RegisterEnum(enumMapWithEmpty(validStopPriceLinkTypes))
+	structcli.RegisterEnum(enumMapWithEmpty(validStopTypes))
+	structcli.RegisterEnum(enumMapWithEmpty(validSpecialInstructions))
+	structcli.RegisterEnum(enumMapWithEmpty(validDestinations))
+	structcli.RegisterEnum(enumMapWithEmpty(validPriceLinkBases))
+	structcli.RegisterEnum(enumMapWithEmpty(validPriceLinkTypes))
+
+	structcli.RegisterEnum(enumMap(validOrderStatusFilters))
+	structcli.RegisterEnum(enumMapWithEmpty([]chainContractType{chainContractTypeCall, chainContractTypePut, chainContractTypeAll}))
+	structcli.RegisterEnum(enumMapWithEmpty([]chainStrategy{chainStrategySingle, chainStrategyAnalytical, chainStrategyCovered, chainStrategyVertical, chainStrategyCalendar, chainStrategyStrangle, chainStrategyStraddle, chainStrategyButterfly, chainStrategyCondor, chainStrategyDiagonal, chainStrategyCollar, chainStrategyRoll}))
+	structcli.RegisterEnum(enumMapWithEmpty([]strikeRange{strikeRangeITM, strikeRangeNTM, strikeRangeOTM, strikeRangeSAK, strikeRangeSBK, strikeRangeSNK, strikeRangeAll}))
+	structcli.RegisterEnum(enumMapWithEmpty([]historyPeriodType{historyPeriodTypeDay, historyPeriodTypeMonth, historyPeriodTypeYear, historyPeriodTypeYTD}))
+	structcli.RegisterEnum(enumMapWithEmpty([]historyFrequencyType{historyFrequencyTypeMinute, historyFrequencyTypeDaily, historyFrequencyTypeWeekly, historyFrequencyTypeMonthly}))
+	structcli.RegisterEnum(enumMapWithEmpty([]historyFrequency{historyFrequency1, historyFrequency5, historyFrequency10, historyFrequency15, historyFrequency30}))
+	structcli.RegisterEnum(enumMap([]instrumentProjection{instrumentProjectionSymbolSearch, instrumentProjectionSymbolRegex, instrumentProjectionDescSearch, instrumentProjectionDescRegex, instrumentProjectionSearch, instrumentProjectionFundamental}))
+	structcli.RegisterEnum(enumMapWithEmpty([]moversSort{moversSortVolume, moversSortTrades, moversSortPercentChangeUp, moversSortPercentChangeDown}))
+	structcli.RegisterEnum(enumMapWithEmpty([]moversFrequency{moversFrequency0, moversFrequency1, moversFrequency5, moversFrequency10, moversFrequency30, moversFrequency60}))
+	structcli.RegisterEnum(enumMap([]taInterval{taIntervalDaily, taIntervalWeekly, taInterval1Min, taInterval5Min, taInterval15Min, taInterval30Min}))
+}
+
+func enumMap[E ~string](values []E) map[E][]string {
+	registered := make(map[E][]string, len(values))
+	for _, value := range values {
+		registered[value] = []string{string(value)}
+	}
+	return registered
+}
+
+func enumMapWithEmpty[E ~string](values []E) map[E][]string {
+	registered := enumMap(values)
+	registered[""] = []string{""}
+	return registered
+}
+
+func enumMapWithEmptyAndAliases[E ~string](values []E, aliases map[E][]string) map[E][]string {
+	registered := enumMapWithEmpty(values)
+	for value, valueAliases := range aliases {
+		registered[value] = append(registered[value], valueAliases...)
+	}
+	return registered
+}

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -62,6 +62,17 @@ func requireEnum[T ~string](raw string, valid []T, label string) (T, error) {
 	)
 }
 
+// requireTypedEnum validates that a typed enum flag with no useful zero value
+// was provided. Structcli validates explicit values, but omitted flags still
+// arrive as the enum type's zero value.
+func requireTypedEnum[T ~string](value T, label string) error {
+	if strings.TrimSpace(string(value)) == "" {
+		return newValidationError(label + " is required")
+	}
+
+	return nil
+}
+
 // validEnumString joins valid enum values into a comma-separated string for
 // error messages. Example: "BUY, SELL, BUY_TO_COVER".
 func validEnumString[T ~string](valid []T) string {
@@ -120,6 +131,31 @@ func suggestSubcommands(cmd *cobra.Command, err error) error {
 		),
 		err,
 	)
+}
+
+// normalizeFlagValidationError keeps enum flag errors consistent with the older
+// command-level validation messages while still letting structcli/pflag reject
+// invalid enum values before RunE starts.
+func normalizeFlagValidationError(err error) error {
+	message := err.Error()
+	if !strings.Contains(message, "invalid value") || !strings.Contains(message, " for \"--") {
+		return err
+	}
+
+	_, after, ok := strings.Cut(message, " for \"--")
+	if !ok {
+		return err
+	}
+	flagName, _, ok := strings.Cut(after, "\" flag")
+	if !ok || flagName == "" {
+		return err
+	}
+
+	return newValidationError("invalid " + flagName)
+}
+
+func normalizeFlagValidationErrorFunc(_ *cobra.Command, err error) error {
+	return normalizeFlagValidationError(err)
 }
 
 // visibleSubcommandNames returns only invokable subcommands for user-facing

--- a/internal/commands/history.go
+++ b/internal/commands/history.go
@@ -19,12 +19,12 @@ type priceHistoryData struct {
 
 // historyGetOpts holds the options for the history get subcommand.
 type historyGetOpts struct {
-	PeriodType    string `flag:"period-type" flagdescr:"Period type (day, month, year, ytd)" flaggroup:"period"`
-	Period        string `flag:"period" flagdescr:"Number of periods" flaggroup:"period"`
-	FrequencyType string `flag:"frequency-type" flagdescr:"Frequency type (minute, daily, weekly, monthly)" flaggroup:"frequency"`
-	Frequency     string `flag:"frequency" flagdescr:"Frequency value" flaggroup:"frequency"`
-	From          string `flag:"from" flagdescr:"Start date (milliseconds since epoch)" flaggroup:"range"`
-	To            string `flag:"to" flagdescr:"End date (milliseconds since epoch)" flaggroup:"range"`
+	PeriodType    historyPeriodType    `flag:"period-type" flagdescr:"Period type (day, month, year, ytd)" flaggroup:"period"`
+	Period        string               `flag:"period" flagdescr:"Number of periods" flaggroup:"period"`
+	FrequencyType historyFrequencyType `flag:"frequency-type" flagdescr:"Frequency type (minute, daily, weekly, monthly)" flaggroup:"frequency"`
+	Frequency     historyFrequency     `flag:"frequency" flagdescr:"Frequency value" flaggroup:"frequency"`
+	From          string               `flag:"from" flagdescr:"Start date (milliseconds since epoch)" flaggroup:"range"`
+	To            string               `flag:"to" flagdescr:"End date (milliseconds since epoch)" flaggroup:"range"`
 }
 
 // Attach implements structcli.Options interface.
@@ -67,10 +67,10 @@ date ranges via epoch milliseconds. Returns OHLCV candle data.`,
 			symbol := args[0]
 
 			params := client.HistoryParams{
-				PeriodType:    opts.PeriodType,
+				PeriodType:    string(opts.PeriodType),
 				Period:        opts.Period,
-				FrequencyType: opts.FrequencyType,
-				Frequency:     opts.Frequency,
+				FrequencyType: string(opts.FrequencyType),
+				Frequency:     string(opts.Frequency),
 				StartDate:     opts.From,
 				EndDate:       opts.To,
 			}
@@ -87,6 +87,7 @@ date ranges via epoch milliseconds. Returns OHLCV candle data.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }

--- a/internal/commands/instrument.go
+++ b/internal/commands/instrument.go
@@ -23,7 +23,7 @@ type instrumentGetData struct {
 
 // instrumentSearchOpts holds the options for the instrument search subcommand.
 type instrumentSearchOpts struct {
-	Projection string `flag:"projection" flagdescr:"Search projection (symbol-search, symbol-regex, desc-search, desc-regex, search, fundamental)" default:"symbol-search"`
+	Projection instrumentProjection `flag:"projection" flagdescr:"Search projection (symbol-search, symbol-regex, desc-search, desc-regex, search, fundamental)" default:"symbol-search"`
 }
 
 // Attach implements structcli.Options interface.
@@ -57,7 +57,7 @@ desc-regex, search, or fundamental.`,
 		Example: `  schwab-agent instrument search AAPL
   schwab-agent instrument search "Apple" --projection desc-search
   schwab-agent instrument search AAPL --projection fundamental`,
-		Args:    cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := structcli.Unmarshal(cmd, opts); err != nil {
 				return err
@@ -65,7 +65,7 @@ desc-regex, search, or fundamental.`,
 
 			query := args[0]
 
-			result, err := c.SearchInstruments(cmd.Context(), query, opts.Projection)
+			result, err := c.SearchInstruments(cmd.Context(), query, string(opts.Projection))
 			if err != nil {
 				return err
 			}
@@ -77,6 +77,7 @@ desc-regex, search, or fundamental.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }

--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -22,8 +22,8 @@ type moversData struct {
 
 // marketMoversOpts holds the options for the market movers subcommand.
 type marketMoversOpts struct {
-	Sort      string `flag:"sort" flagdescr:"Sort order (VOLUME, TRADES, PERCENT_CHANGE_UP, PERCENT_CHANGE_DOWN)"`
-	Frequency string `flag:"frequency" flagdescr:"Minimum percent change magnitude (0, 1, 5, 10, 30, 60)"`
+	Sort      moversSort      `flag:"sort" flagdescr:"Sort order (VOLUME, TRADES, PERCENT_CHANGE_UP, PERCENT_CHANGE_DOWN)"`
+	Frequency moversFrequency `flag:"frequency" flagdescr:"Minimum percent change magnitude (0, 1, 5, 10, 30, 60)"`
 }
 
 // Attach implements structcli.Attachable.
@@ -110,8 +110,8 @@ names (e.g. '$SPX').`,
 			}
 
 			params := client.MoversParams{
-				Sort:      opts.Sort,
-				Frequency: opts.Frequency,
+				Sort:      string(opts.Sort),
+				Frequency: string(opts.Frequency),
 			}
 
 			result, err := c.Movers(cmd.Context(), index, params)
@@ -126,6 +126,7 @@ names (e.g. '$SPX').`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }

--- a/internal/commands/order.go
+++ b/internal/commands/order.go
@@ -55,6 +55,9 @@ type orderReplaceData struct {
 
 // orderListOpts holds local flags for the order list subcommand.
 type orderListOpts struct {
+	// Keep status as []string because structcli v0.17 does not support slices of
+	// registered custom enum types. RunE still validates values against the same
+	// registered enum set after expanding comma-separated repeatable input.
 	Status []string `flag:"status" flagdescr:"Filter by order status (repeatable, use 'all' for unfiltered): WORKING, PENDING_ACTIVATION, FILLED, EXPIRED, CANCELED, REJECTED, etc."`
 	From   string   `flag:"from" flagdescr:"Filter by entered time lower bound"`
 	To     string   `flag:"to" flagdescr:"Filter by entered time upper bound"`
@@ -108,23 +111,23 @@ func (o *orderReplaceOpts) Attach(_ *cobra.Command) error { return nil }
 
 // equityPlaceOpts holds flags shared by equity place, build, and replace flows.
 type equityPlaceOpts struct {
-	Symbol             string  `flag:"symbol" flagdescr:"Equity symbol" flagrequired:"true" flaggroup:"order"`
-	Action             string  `flag:"action" flagdescr:"Order action" flagrequired:"true" flaggroup:"order"`
-	Quantity           float64 `flag:"quantity" flagdescr:"Share quantity" flagrequired:"true" flaggroup:"execution"`
-	Type               string  `flag:"type" flagdescr:"Order type" flaggroup:"order"`
-	Price              float64 `flag:"price" flagdescr:"Limit price" flaggroup:"pricing"`
-	StopPrice          float64 `flag:"stop-price" flagdescr:"Stop price" flaggroup:"pricing"`
-	StopOffset         float64 `flag:"stop-offset" flagdescr:"Trailing stop offset amount" flaggroup:"pricing"`
-	StopLinkBasis      string  `flag:"stop-link-basis" flagdescr:"Trailing stop reference price (LAST, BID, ASK, MARK)" flaggroup:"pricing"`
-	StopLinkType       string  `flag:"stop-link-type" flagdescr:"Trailing stop offset type (VALUE, PERCENT, TICK)" flaggroup:"pricing"`
-	StopType           string  `flag:"stop-type" flagdescr:"Trailing stop trigger type (STANDARD, BID, ASK, LAST, MARK)" flaggroup:"pricing"`
-	ActivationPrice    float64 `flag:"activation-price" flagdescr:"Price that activates the trailing stop" flaggroup:"pricing"`
-	Duration           string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session            string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
-	SpecialInstruction string  `flag:"special-instruction" flagdescr:"Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE)" flaggroup:"execution"`
-	Destination        string  `flag:"destination" flagdescr:"Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO)" flaggroup:"execution"`
-	PriceLinkBasis     string  `flag:"price-link-basis" flagdescr:"Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE)" flaggroup:"pricing"`
-	PriceLinkType      string  `flag:"price-link-type" flagdescr:"Price link offset type (VALUE, PERCENT, TICK)" flaggroup:"pricing"`
+	Symbol             string                      `flag:"symbol" flagdescr:"Equity symbol" flagrequired:"true" flaggroup:"order"`
+	Action             models.Instruction          `flag:"action" flagdescr:"Order action" flagrequired:"true" flaggroup:"order"`
+	Quantity           float64                     `flag:"quantity" flagdescr:"Share quantity" flagrequired:"true" flaggroup:"execution"`
+	Type               models.OrderType            `flag:"type" flagdescr:"Order type" flaggroup:"order"`
+	Price              float64                     `flag:"price" flagdescr:"Limit price" flaggroup:"pricing"`
+	StopPrice          float64                     `flag:"stop-price" flagdescr:"Stop price" flaggroup:"pricing"`
+	StopOffset         float64                     `flag:"stop-offset" flagdescr:"Trailing stop offset amount" flaggroup:"pricing"`
+	StopLinkBasis      models.StopPriceLinkBasis   `flag:"stop-link-basis" flagdescr:"Trailing stop reference price (LAST, BID, ASK, MARK)" flaggroup:"pricing"`
+	StopLinkType       models.StopPriceLinkType    `flag:"stop-link-type" flagdescr:"Trailing stop offset type (VALUE, PERCENT, TICK)" flaggroup:"pricing"`
+	StopType           models.StopType             `flag:"stop-type" flagdescr:"Trailing stop trigger type (STANDARD, BID, ASK, LAST, MARK)" flaggroup:"pricing"`
+	ActivationPrice    float64                     `flag:"activation-price" flagdescr:"Price that activates the trailing stop" flaggroup:"pricing"`
+	Duration           models.Duration             `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session            models.Session              `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	SpecialInstruction models.SpecialInstruction   `flag:"special-instruction" flagdescr:"Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE)" flaggroup:"execution"`
+	Destination        models.RequestedDestination `flag:"destination" flagdescr:"Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO)" flaggroup:"execution"`
+	PriceLinkBasis     models.PriceLinkBasis       `flag:"price-link-basis" flagdescr:"Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE)" flaggroup:"pricing"`
+	PriceLinkType      models.PriceLinkType        `flag:"price-link-type" flagdescr:"Price link offset type (VALUE, PERCENT, TICK)" flaggroup:"pricing"`
 }
 
 // Attach implements structcli.Options interface.
@@ -132,21 +135,21 @@ func (o *equityPlaceOpts) Attach(_ *cobra.Command) error { return nil }
 
 // optionPlaceOpts holds flags shared by option place and build flows.
 type optionPlaceOpts struct {
-	Underlying         string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	Expiration         string  `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	Strike             float64 `flag:"strike" flagdescr:"Strike price" flagrequired:"true" flaggroup:"contract"`
-	Call               bool    `flag:"call" flagdescr:"Call option" flaggroup:"contract"`
-	Put                bool    `flag:"put" flagdescr:"Put option" flaggroup:"contract"`
-	Action             string  `flag:"action" flagdescr:"Order action" flagrequired:"true" flaggroup:"order"`
-	Quantity           float64 `flag:"quantity" flagdescr:"Contract quantity" flagrequired:"true" flaggroup:"execution"`
-	Type               string  `flag:"type" flagdescr:"Order type" flaggroup:"order"`
-	Price              float64 `flag:"price" flagdescr:"Limit price" flaggroup:"pricing"`
-	Duration           string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session            string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
-	SpecialInstruction string  `flag:"special-instruction" flagdescr:"Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE)" flaggroup:"execution"`
-	Destination        string  `flag:"destination" flagdescr:"Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO)" flaggroup:"execution"`
-	PriceLinkBasis     string  `flag:"price-link-basis" flagdescr:"Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE)" flaggroup:"pricing"`
-	PriceLinkType      string  `flag:"price-link-type" flagdescr:"Price link offset type (VALUE, PERCENT, TICK)" flaggroup:"pricing"`
+	Underlying         string                      `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration         string                      `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	Strike             float64                     `flag:"strike" flagdescr:"Strike price" flagrequired:"true" flaggroup:"contract"`
+	Call               bool                        `flag:"call" flagdescr:"Call option" flaggroup:"contract"`
+	Put                bool                        `flag:"put" flagdescr:"Put option" flaggroup:"contract"`
+	Action             models.Instruction          `flag:"action" flagdescr:"Order action" flagrequired:"true" flaggroup:"order"`
+	Quantity           float64                     `flag:"quantity" flagdescr:"Contract quantity" flagrequired:"true" flaggroup:"execution"`
+	Type               models.OrderType            `flag:"type" flagdescr:"Order type" flaggroup:"order"`
+	Price              float64                     `flag:"price" flagdescr:"Limit price" flaggroup:"pricing"`
+	Duration           models.Duration             `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session            models.Session              `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	SpecialInstruction models.SpecialInstruction   `flag:"special-instruction" flagdescr:"Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE)" flaggroup:"execution"`
+	Destination        models.RequestedDestination `flag:"destination" flagdescr:"Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO)" flaggroup:"execution"`
+	PriceLinkBasis     models.PriceLinkBasis       `flag:"price-link-basis" flagdescr:"Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE)" flaggroup:"pricing"`
+	PriceLinkType      models.PriceLinkType        `flag:"price-link-type" flagdescr:"Price link offset type (VALUE, PERCENT, TICK)" flaggroup:"pricing"`
 }
 
 // Attach implements structcli.Options interface.
@@ -154,15 +157,15 @@ func (o *optionPlaceOpts) Attach(_ *cobra.Command) error { return nil }
 
 // bracketPlaceOpts holds flags shared by bracket place and build flows.
 type bracketPlaceOpts struct {
-	Symbol     string  `flag:"symbol" flagdescr:"Equity symbol" flagrequired:"true" flaggroup:"order"`
-	Action     string  `flag:"action" flagdescr:"Order action" flagrequired:"true" flaggroup:"order"`
-	Quantity   float64 `flag:"quantity" flagdescr:"Share quantity" flagrequired:"true" flaggroup:"execution"`
-	Type       string  `flag:"type" flagdescr:"Entry order type" flaggroup:"order"`
-	Price      float64 `flag:"price" flagdescr:"Entry price" flaggroup:"pricing"`
-	TakeProfit float64 `flag:"take-profit" flagdescr:"Take-profit exit price" flaggroup:"pricing"`
-	StopLoss   float64 `flag:"stop-loss" flagdescr:"Stop-loss exit price" flaggroup:"pricing"`
-	Duration   string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session    string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Symbol     string             `flag:"symbol" flagdescr:"Equity symbol" flagrequired:"true" flaggroup:"order"`
+	Action     models.Instruction `flag:"action" flagdescr:"Order action" flagrequired:"true" flaggroup:"order"`
+	Quantity   float64            `flag:"quantity" flagdescr:"Share quantity" flagrequired:"true" flaggroup:"execution"`
+	Type       models.OrderType   `flag:"type" flagdescr:"Entry order type" flaggroup:"order"`
+	Price      float64            `flag:"price" flagdescr:"Entry price" flaggroup:"pricing"`
+	TakeProfit float64            `flag:"take-profit" flagdescr:"Take-profit exit price" flaggroup:"pricing"`
+	StopLoss   float64            `flag:"stop-loss" flagdescr:"Stop-loss exit price" flaggroup:"pricing"`
+	Duration   models.Duration    `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session    models.Session     `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -170,13 +173,13 @@ func (o *bracketPlaceOpts) Attach(_ *cobra.Command) error { return nil }
 
 // ocoPlaceOpts holds flags shared by OCO place and build flows.
 type ocoPlaceOpts struct {
-	Symbol     string  `flag:"symbol" flagdescr:"Equity symbol" flagrequired:"true" flaggroup:"order"`
-	Action     string  `flag:"action" flagdescr:"Exit action (SELL to close long, BUY to close short)" flagrequired:"true" flaggroup:"order"`
-	Quantity   float64 `flag:"quantity" flagdescr:"Share quantity" flagrequired:"true" flaggroup:"execution"`
-	TakeProfit float64 `flag:"take-profit" flagdescr:"Take-profit exit price (limit order)" flaggroup:"pricing"`
-	StopLoss   float64 `flag:"stop-loss" flagdescr:"Stop-loss exit price (stop order)" flaggroup:"pricing"`
-	Duration   string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session    string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Symbol     string             `flag:"symbol" flagdescr:"Equity symbol" flagrequired:"true" flaggroup:"order"`
+	Action     models.Instruction `flag:"action" flagdescr:"Exit action (SELL to close long, BUY to close short)" flagrequired:"true" flaggroup:"order"`
+	Quantity   float64            `flag:"quantity" flagdescr:"Share quantity" flagrequired:"true" flaggroup:"execution"`
+	TakeProfit float64            `flag:"take-profit" flagdescr:"Take-profit exit price (limit order)" flaggroup:"pricing"`
+	StopLoss   float64            `flag:"stop-loss" flagdescr:"Stop-loss exit price (stop order)" flaggroup:"pricing"`
+	Duration   models.Duration    `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session    models.Session     `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -184,18 +187,18 @@ func (o *ocoPlaceOpts) Attach(_ *cobra.Command) error { return nil }
 
 // verticalBuildOpts holds flags for vertical spread build flows.
 type verticalBuildOpts struct {
-	Underlying  string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	Expiration  string  `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	LongStrike  float64 `flag:"long-strike" flagdescr:"Strike price of the option being bought" flagrequired:"true" flaggroup:"contract"`
-	ShortStrike float64 `flag:"short-strike" flagdescr:"Strike price of the option being sold" flagrequired:"true" flaggroup:"contract"`
-	Call        bool    `flag:"call" flagdescr:"Call spread" flaggroup:"contract"`
-	Put         bool    `flag:"put" flagdescr:"Put spread" flaggroup:"contract"`
-	Open        bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close       bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Quantity    float64 `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
-	Price       float64 `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration    string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session     string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying  string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration  string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	LongStrike  float64         `flag:"long-strike" flagdescr:"Strike price of the option being bought" flagrequired:"true" flaggroup:"contract"`
+	ShortStrike float64         `flag:"short-strike" flagdescr:"Strike price of the option being sold" flagrequired:"true" flaggroup:"contract"`
+	Call        bool            `flag:"call" flagdescr:"Call spread" flaggroup:"contract"`
+	Put         bool            `flag:"put" flagdescr:"Put spread" flaggroup:"contract"`
+	Open        bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close       bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity    float64         `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
+	Price       float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration    models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session     models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -203,18 +206,18 @@ func (o *verticalBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // ironCondorBuildOpts holds flags for iron condor build flows.
 type ironCondorBuildOpts struct {
-	Underlying      string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	Expiration      string  `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	PutLongStrike   float64 `flag:"put-long-strike" flagdescr:"Lowest strike: put being bought (protection)" flagrequired:"true" flaggroup:"contract"`
-	PutShortStrike  float64 `flag:"put-short-strike" flagdescr:"Put being sold (premium)" flagrequired:"true" flaggroup:"contract"`
-	CallShortStrike float64 `flag:"call-short-strike" flagdescr:"Call being sold (premium)" flagrequired:"true" flaggroup:"contract"`
-	CallLongStrike  float64 `flag:"call-long-strike" flagdescr:"Highest strike: call being bought (protection)" flagrequired:"true" flaggroup:"contract"`
-	Open            bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close           bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Quantity        float64 `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
-	Price           float64 `flag:"price" flagdescr:"Net credit or debit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration        string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session         string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying      string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration      string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	PutLongStrike   float64         `flag:"put-long-strike" flagdescr:"Lowest strike: put being bought (protection)" flagrequired:"true" flaggroup:"contract"`
+	PutShortStrike  float64         `flag:"put-short-strike" flagdescr:"Put being sold (premium)" flagrequired:"true" flaggroup:"contract"`
+	CallShortStrike float64         `flag:"call-short-strike" flagdescr:"Call being sold (premium)" flagrequired:"true" flaggroup:"contract"`
+	CallLongStrike  float64         `flag:"call-long-strike" flagdescr:"Highest strike: call being bought (protection)" flagrequired:"true" flaggroup:"contract"`
+	Open            bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close           bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity        float64         `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
+	Price           float64         `flag:"price" flagdescr:"Net credit or debit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration        models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session         models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -222,18 +225,18 @@ func (o *ironCondorBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // strangleBuildOpts holds flags for strangle build flows.
 type strangleBuildOpts struct {
-	Underlying string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	Expiration string  `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	CallStrike float64 `flag:"call-strike" flagdescr:"Strike price for the call leg" flagrequired:"true" flaggroup:"contract"`
-	PutStrike  float64 `flag:"put-strike" flagdescr:"Strike price for the put leg" flagrequired:"true" flaggroup:"contract"`
-	Buy        bool    `flag:"buy" flagdescr:"Buy the strangle (long, net debit)" flaggroup:"execution"`
-	Sell       bool    `flag:"sell" flagdescr:"Sell the strangle (short, net credit)" flaggroup:"execution"`
-	Open       bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close      bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Quantity   float64 `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
-	Price      float64 `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration   string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session    string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	CallStrike float64         `flag:"call-strike" flagdescr:"Strike price for the call leg" flagrequired:"true" flaggroup:"contract"`
+	PutStrike  float64         `flag:"put-strike" flagdescr:"Strike price for the put leg" flagrequired:"true" flaggroup:"contract"`
+	Buy        bool            `flag:"buy" flagdescr:"Buy the strangle (long, net debit)" flaggroup:"execution"`
+	Sell       bool            `flag:"sell" flagdescr:"Sell the strangle (short, net credit)" flaggroup:"execution"`
+	Open       bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close      bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity   float64         `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
+	Price      float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration   models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session    models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -241,17 +244,17 @@ func (o *strangleBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // straddleBuildOpts holds flags for straddle build flows.
 type straddleBuildOpts struct {
-	Underlying string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	Expiration string  `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	Strike     float64 `flag:"strike" flagdescr:"Strike price (shared by call and put legs)" flagrequired:"true" flaggroup:"contract"`
-	Buy        bool    `flag:"buy" flagdescr:"Buy the straddle (long, net debit)" flaggroup:"execution"`
-	Sell       bool    `flag:"sell" flagdescr:"Sell the straddle (short, net credit)" flaggroup:"execution"`
-	Open       bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close      bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Quantity   float64 `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
-	Price      float64 `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration   string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session    string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	Strike     float64         `flag:"strike" flagdescr:"Strike price (shared by call and put legs)" flagrequired:"true" flaggroup:"contract"`
+	Buy        bool            `flag:"buy" flagdescr:"Buy the straddle (long, net debit)" flaggroup:"execution"`
+	Sell       bool            `flag:"sell" flagdescr:"Sell the straddle (short, net credit)" flaggroup:"execution"`
+	Open       bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close      bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity   float64         `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
+	Price      float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration   models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session    models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -259,13 +262,13 @@ func (o *straddleBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // coveredCallBuildOpts holds flags for covered call build flows.
 type coveredCallBuildOpts struct {
-	Underlying string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	Expiration string  `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	Strike     float64 `flag:"strike" flagdescr:"Call strike price" flagrequired:"true" flaggroup:"contract"`
-	Quantity   float64 `flag:"quantity" flagdescr:"Number of contracts (1 contract = 100 shares)" flagrequired:"true" flaggroup:"execution"`
-	Price      float64 `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration   string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session    string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	Strike     float64         `flag:"strike" flagdescr:"Call strike price" flagrequired:"true" flaggroup:"contract"`
+	Quantity   float64         `flag:"quantity" flagdescr:"Number of contracts (1 contract = 100 shares)" flagrequired:"true" flaggroup:"execution"`
+	Price      float64         `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration   models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session    models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -273,16 +276,16 @@ func (o *coveredCallBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // collarBuildOpts holds flags for collar-with-stock build flows.
 type collarBuildOpts struct {
-	Underlying string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	PutStrike  float64 `flag:"put-strike" flagdescr:"Protective put strike price" flagrequired:"true" flaggroup:"contract"`
-	CallStrike float64 `flag:"call-strike" flagdescr:"Covered call strike price" flagrequired:"true" flaggroup:"contract"`
-	Expiration string  `flag:"expiration" flagdescr:"Expiration date for both options (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	Quantity   float64 `flag:"quantity" flagdescr:"Number of contracts (1 contract = 100 shares)" flagrequired:"true" flaggroup:"execution"`
-	Open       bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close      bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Price      float64 `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration   string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session    string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	PutStrike  float64         `flag:"put-strike" flagdescr:"Protective put strike price" flagrequired:"true" flaggroup:"contract"`
+	CallStrike float64         `flag:"call-strike" flagdescr:"Covered call strike price" flagrequired:"true" flaggroup:"contract"`
+	Expiration string          `flag:"expiration" flagdescr:"Expiration date for both options (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	Quantity   float64         `flag:"quantity" flagdescr:"Number of contracts (1 contract = 100 shares)" flagrequired:"true" flaggroup:"execution"`
+	Open       bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close      bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Price      float64         `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration   models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session    models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -290,18 +293,18 @@ func (o *collarBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // calendarBuildOpts holds flags for calendar spread build flows.
 type calendarBuildOpts struct {
-	Underlying     string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	NearExpiration string  `flag:"near-expiration" flagdescr:"Near-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	FarExpiration  string  `flag:"far-expiration" flagdescr:"Far-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	Strike         float64 `flag:"strike" flagdescr:"Strike price (shared by both legs)" flagrequired:"true" flaggroup:"contract"`
-	Call           bool    `flag:"call" flagdescr:"Call calendar spread" flaggroup:"contract"`
-	Put            bool    `flag:"put" flagdescr:"Put calendar spread" flaggroup:"contract"`
-	Open           bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close          bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Quantity       float64 `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
-	Price          float64 `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration       string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session        string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying     string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	NearExpiration string          `flag:"near-expiration" flagdescr:"Near-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	FarExpiration  string          `flag:"far-expiration" flagdescr:"Far-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	Strike         float64         `flag:"strike" flagdescr:"Strike price (shared by both legs)" flagrequired:"true" flaggroup:"contract"`
+	Call           bool            `flag:"call" flagdescr:"Call calendar spread" flaggroup:"contract"`
+	Put            bool            `flag:"put" flagdescr:"Put calendar spread" flaggroup:"contract"`
+	Open           bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close          bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity       float64         `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
+	Price          float64         `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration       models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session        models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -309,19 +312,19 @@ func (o *calendarBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
 // diagonalBuildOpts holds flags for diagonal spread build flows.
 type diagonalBuildOpts struct {
-	Underlying     string  `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
-	NearExpiration string  `flag:"near-expiration" flagdescr:"Near-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	FarExpiration  string  `flag:"far-expiration" flagdescr:"Far-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
-	NearStrike     float64 `flag:"near-strike" flagdescr:"Strike price for the near-term (sold) leg" flagrequired:"true" flaggroup:"contract"`
-	FarStrike      float64 `flag:"far-strike" flagdescr:"Strike price for the far-term (bought) leg" flagrequired:"true" flaggroup:"contract"`
-	Call           bool    `flag:"call" flagdescr:"Call diagonal spread" flaggroup:"contract"`
-	Put            bool    `flag:"put" flagdescr:"Put diagonal spread" flaggroup:"contract"`
-	Open           bool    `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
-	Close          bool    `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
-	Quantity       float64 `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
-	Price          float64 `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
-	Duration       string  `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
-	Session        string  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+	Underlying     string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	NearExpiration string          `flag:"near-expiration" flagdescr:"Near-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	FarExpiration  string          `flag:"far-expiration" flagdescr:"Far-term expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	NearStrike     float64         `flag:"near-strike" flagdescr:"Strike price for the near-term (sold) leg" flagrequired:"true" flaggroup:"contract"`
+	FarStrike      float64         `flag:"far-strike" flagdescr:"Strike price for the far-term (bought) leg" flagrequired:"true" flaggroup:"contract"`
+	Call           bool            `flag:"call" flagdescr:"Call diagonal spread" flaggroup:"contract"`
+	Put            bool            `flag:"put" flagdescr:"Put diagonal spread" flaggroup:"contract"`
+	Open           bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close          bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity       float64         `flag:"quantity" flagdescr:"Number of contracts" flagrequired:"true" flaggroup:"execution"`
+	Price          float64         `flag:"price" flagdescr:"Net debit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration       models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session        models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
 }
 
 // Attach implements structcli.Options interface.
@@ -414,6 +417,10 @@ merged, deduplicated results.`,
 
 			showAll := false
 			for _, s := range statuses {
+				if err := validateOrderStatusFilter(s); err != nil {
+					return err
+				}
+
 				if strings.EqualFold(s, "all") {
 					showAll = true
 					break
@@ -706,6 +713,7 @@ func makeCobraPlaceOrderCommand[O any, P any](
 			return output.WriteSuccess(w, orderPlaceData{OrderID: response.OrderID}, output.NewMetadata())
 		},
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	if flagSetup != nil {
 		flagSetup(cmd, opts)
@@ -902,6 +910,7 @@ REPLACED after the new order is created.`,
 			return output.WriteSuccess(w, orderReplaceData{OrderID: orderID, Replaced: true}, output.NewMetadata())
 		},
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	equityOrderFlagSetup(cmd, equityOpts)
 	if err := structcli.Define(cmd, opts); err != nil {
@@ -943,24 +952,18 @@ func ocoOrderFlagSetup(cmd *cobra.Command, opts *ocoPlaceOpts) {
 
 // parseOCOParams converts command flags into standalone OCO builder params.
 func parseOCOParams(opts *ocoPlaceOpts, _ []string) (*orderbuilder.OCOParams, error) {
-	action, err := parseInstruction(opts.Action)
-	if err != nil {
-		return nil, err
-	}
-
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
+	if err := requireTypedEnum(opts.Action, "action"); err != nil {
 		return nil, err
 	}
 
 	return &orderbuilder.OCOParams{
 		Symbol:     strings.TrimSpace(opts.Symbol),
-		Action:     action,
+		Action:     opts.Action,
 		Quantity:   opts.Quantity,
 		TakeProfit: opts.TakeProfit,
 		StopLoss:   opts.StopLoss,
-		Duration:   duration,
-		Session:    session,
+		Duration:   normalizeDuration(opts.Duration),
+		Session:    opts.Session,
 	}, nil
 }
 
@@ -996,11 +999,6 @@ func parseIronCondorParams(opts *ironCondorBuildOpts, _ []string) (*orderbuilder
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.IronCondorParams{
 		Underlying:      strings.TrimSpace(opts.Underlying),
 		Expiration:      expiration,
@@ -1011,98 +1009,41 @@ func parseIronCondorParams(opts *ironCondorBuildOpts, _ []string) (*orderbuilder
 		Open:            isOpen,
 		Quantity:        opts.Quantity,
 		Price:           opts.Price,
-		Duration:        duration,
-		Session:         session,
+		Duration:        normalizeDuration(opts.Duration),
+		Session:         opts.Session,
 	}, nil
 }
 
 // parseEquityParams converts command flags into equity order builder params.
 func parseEquityParams(opts *equityPlaceOpts, _ []string) (*orderbuilder.EquityParams, error) {
-	action, err := parseInstruction(opts.Action)
-	if err != nil {
-		return nil, err
-	}
-
-	orderType, err := parseOrderType(opts.Type, models.OrderTypeMarket)
-	if err != nil {
-		return nil, err
-	}
-
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
-	stopLinkBasis, err := parseStopPriceLinkBasis(opts.StopLinkBasis)
-	if err != nil {
-		return nil, err
-	}
-
-	stopLinkType, err := parseStopPriceLinkType(opts.StopLinkType)
-	if err != nil {
-		return nil, err
-	}
-
-	stopType, err := parseStopType(opts.StopType)
-	if err != nil {
-		return nil, err
-	}
-
-	specialInstruction, err := parseSpecialInstruction(opts.SpecialInstruction)
-	if err != nil {
-		return nil, err
-	}
-
-	destination, err := parseDestination(opts.Destination)
-	if err != nil {
-		return nil, err
-	}
-
-	priceLinkBasis, err := parsePriceLinkBasis(opts.PriceLinkBasis)
-	if err != nil {
-		return nil, err
-	}
-
-	priceLinkType, err := parsePriceLinkType(opts.PriceLinkType)
-	if err != nil {
+	if err := requireTypedEnum(opts.Action, "action"); err != nil {
 		return nil, err
 	}
 
 	return &orderbuilder.EquityParams{
 		Symbol:             strings.TrimSpace(opts.Symbol),
-		Action:             action,
+		Action:             opts.Action,
 		Quantity:           opts.Quantity,
-		OrderType:          orderType,
+		OrderType:          normalizeOrderType(opts.Type, models.OrderTypeMarket),
 		Price:              opts.Price,
 		StopPrice:          opts.StopPrice,
 		StopPriceOffset:    opts.StopOffset,
-		StopPriceLinkBasis: stopLinkBasis,
-		StopPriceLinkType:  stopLinkType,
-		StopType:           stopType,
+		StopPriceLinkBasis: defaultStopPriceLinkBasis(opts.StopLinkBasis),
+		StopPriceLinkType:  defaultStopPriceLinkType(opts.StopLinkType),
+		StopType:           defaultStopType(opts.StopType),
 		ActivationPrice:    opts.ActivationPrice,
-		SpecialInstruction: specialInstruction,
-		Destination:        destination,
-		PriceLinkBasis:     priceLinkBasis,
-		PriceLinkType:      priceLinkType,
-		Duration:           duration,
-		Session:            session,
+		SpecialInstruction: opts.SpecialInstruction,
+		Destination:        opts.Destination,
+		PriceLinkBasis:     opts.PriceLinkBasis,
+		PriceLinkType:      opts.PriceLinkType,
+		Duration:           normalizeDuration(opts.Duration),
+		Session:            opts.Session,
 	}, nil
 }
 
 // parseOptionParams converts command flags into option order builder params.
 func parseOptionParams(opts *optionPlaceOpts, _ []string) (*orderbuilder.OptionParams, error) {
-	action, err := parseInstruction(opts.Action)
-	if err != nil {
-		return nil, err
-	}
-
-	orderType, err := parseOrderType(opts.Type, models.OrderTypeMarket)
-	if err != nil {
-		return nil, err
-	}
-
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
+	if err := requireTypedEnum(opts.Action, "action"); err != nil {
 		return nil, err
 	}
 
@@ -1116,71 +1057,40 @@ func parseOptionParams(opts *optionPlaceOpts, _ []string) (*orderbuilder.OptionP
 		return nil, err
 	}
 
-	specialInstruction, err := parseSpecialInstruction(opts.SpecialInstruction)
-	if err != nil {
-		return nil, err
-	}
-
-	destination, err := parseDestination(opts.Destination)
-	if err != nil {
-		return nil, err
-	}
-
-	priceLinkBasis, err := parsePriceLinkBasis(opts.PriceLinkBasis)
-	if err != nil {
-		return nil, err
-	}
-
-	priceLinkType, err := parsePriceLinkType(opts.PriceLinkType)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.OptionParams{
 		Underlying:         strings.TrimSpace(opts.Underlying),
 		Expiration:         expiration,
 		Strike:             opts.Strike,
 		PutCall:            putCall,
-		Action:             action,
+		Action:             opts.Action,
 		Quantity:           opts.Quantity,
-		OrderType:          orderType,
+		OrderType:          normalizeOrderType(opts.Type, models.OrderTypeMarket),
 		Price:              opts.Price,
-		SpecialInstruction: specialInstruction,
-		Destination:        destination,
-		PriceLinkBasis:     priceLinkBasis,
-		PriceLinkType:      priceLinkType,
-		Duration:           duration,
-		Session:            session,
+		SpecialInstruction: opts.SpecialInstruction,
+		Destination:        opts.Destination,
+		PriceLinkBasis:     opts.PriceLinkBasis,
+		PriceLinkType:      opts.PriceLinkType,
+		Duration:           normalizeDuration(opts.Duration),
+		Session:            opts.Session,
 	}, nil
 }
 
 // parseBracketParams converts command flags into bracket order builder params.
 func parseBracketParams(opts *bracketPlaceOpts, _ []string) (*orderbuilder.BracketParams, error) {
-	action, err := parseInstruction(opts.Action)
-	if err != nil {
-		return nil, err
-	}
-
-	orderType, err := parseOrderType(opts.Type, models.OrderTypeMarket)
-	if err != nil {
-		return nil, err
-	}
-
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
+	if err := requireTypedEnum(opts.Action, "action"); err != nil {
 		return nil, err
 	}
 
 	return &orderbuilder.BracketParams{
 		Symbol:     strings.TrimSpace(opts.Symbol),
-		Action:     action,
+		Action:     opts.Action,
 		Quantity:   opts.Quantity,
-		OrderType:  orderType,
+		OrderType:  normalizeOrderType(opts.Type, models.OrderTypeMarket),
 		Price:      opts.Price,
 		TakeProfit: opts.TakeProfit,
 		StopLoss:   opts.StopLoss,
-		Duration:   duration,
-		Session:    session,
+		Duration:   normalizeDuration(opts.Duration),
+		Session:    opts.Session,
 	}, nil
 }
 
@@ -1416,7 +1326,93 @@ var (
 		models.PriceLinkTypePercent,
 		models.PriceLinkTypeTick,
 	}
+
+	validOrderStatusFilters = []orderStatusFilter{
+		orderStatusFilterAll,
+		orderStatusFilter(models.OrderStatusAwaitingParentOrder),
+		orderStatusFilter(models.OrderStatusAwaitingCondition),
+		orderStatusFilter(models.OrderStatusAwaitingStopCondition),
+		orderStatusFilter(models.OrderStatusAwaitingManualReview),
+		orderStatusFilter(models.OrderStatusAccepted),
+		orderStatusFilter(models.OrderStatusAwaitingUROut),
+		orderStatusFilter(models.OrderStatusPendingActivation),
+		orderStatusFilter(models.OrderStatusQueued),
+		orderStatusFilter(models.OrderStatusWorking),
+		orderStatusFilter(models.OrderStatusRejected),
+		orderStatusFilter(models.OrderStatusPendingCancel),
+		orderStatusFilter(models.OrderStatusCanceled),
+		orderStatusFilter(models.OrderStatusPendingReplace),
+		orderStatusFilter(models.OrderStatusReplaced),
+		orderStatusFilter(models.OrderStatusFilled),
+		orderStatusFilter(models.OrderStatusExpired),
+		orderStatusFilter(models.OrderStatusNew),
+		orderStatusFilter(models.OrderStatusAwaitingReleaseTime),
+		orderStatusFilter(models.OrderStatusPendingAcknowledgement),
+		orderStatusFilter(models.OrderStatusPendingRecall),
+		orderStatusFilter(models.OrderStatusUnknown),
+	}
 )
+
+// normalizeOrderType preserves legacy CLI aliases after structcli has already
+// validated the typed enum flag value.
+func normalizeOrderType(orderType, fallback models.OrderType) models.OrderType {
+	switch orderType {
+	case "":
+		return fallback
+	case models.OrderType("MOC"):
+		return models.OrderTypeMarketOnClose
+	case models.OrderType("LOC"):
+		return models.OrderTypeLimitOnClose
+	default:
+		return orderType
+	}
+}
+
+// normalizeDuration preserves common trading abbreviations after structcli
+// validation so order builders still receive canonical API enum values.
+func normalizeDuration(duration models.Duration) models.Duration {
+	switch duration {
+	case models.Duration("GTC"):
+		return models.DurationGoodTillCancel
+	case models.Duration("FOK"):
+		return models.DurationFillOrKill
+	case models.Duration("IOC"):
+		return models.DurationImmediateOrCancel
+	default:
+		return duration
+	}
+}
+
+func defaultStopPriceLinkBasis(value models.StopPriceLinkBasis) models.StopPriceLinkBasis {
+	if value == "" {
+		return models.StopPriceLinkBasisLast
+	}
+	return value
+}
+
+func defaultStopPriceLinkType(value models.StopPriceLinkType) models.StopPriceLinkType {
+	if value == "" {
+		return models.StopPriceLinkTypeValue
+	}
+	return value
+}
+
+func defaultStopType(value models.StopType) models.StopType {
+	if value == "" {
+		return models.StopTypeStandard
+	}
+	return value
+}
+
+func validateOrderStatusFilter(raw string) error {
+	for _, valid := range validOrderStatusFilters {
+		if strings.EqualFold(raw, string(valid)) {
+			return nil
+		}
+	}
+
+	return newValidationError("invalid status")
+}
 
 // parseInstruction converts CLI input to an instruction enum.
 func parseInstruction(raw string) (models.Instruction, error) {
@@ -1439,14 +1435,11 @@ func parseOrderType(raw string, fallback models.OrderType) (models.OrderType, er
 	return parseEnum(raw, validOrderTypes, fallback, "type")
 }
 
-// parseDuration converts CLI input to a duration enum.
-// Supports standard trading abbreviations: GTC (GOOD_TILL_CANCEL),
-// FOK (FILL_OR_KILL), and IOC (IMMEDIATE_OR_CANCEL).
+// parseDuration converts CLI input to a duration enum for focused unit tests and
+// legacy helper coverage. Runtime flag decoding is handled by structcli enums.
 func parseDuration(raw string) (models.Duration, error) {
 	upper := strings.ToUpper(strings.TrimSpace(raw))
 
-	// Resolve common trading abbreviations before standard enum validation.
-	// These are universal across brokers and trading platforms.
 	switch upper {
 	case "GTC":
 		return models.DurationGoodTillCancel, nil
@@ -1457,11 +1450,6 @@ func parseDuration(raw string) (models.Duration, error) {
 	}
 
 	return parseEnum(raw, validDurations, "", "duration")
-}
-
-// parseSession converts CLI input to a session enum.
-func parseSession(raw string) (models.Session, error) {
-	return parseEnum(raw, validSessions, "", "session")
 }
 
 // parseVerticalParams converts command flags into vertical spread builder params.
@@ -1481,11 +1469,6 @@ func parseVerticalParams(opts *verticalBuildOpts, _ []string) (*orderbuilder.Ver
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.VerticalParams{
 		Underlying:  strings.TrimSpace(opts.Underlying),
 		Expiration:  expiration,
@@ -1495,8 +1478,8 @@ func parseVerticalParams(opts *verticalBuildOpts, _ []string) (*orderbuilder.Ver
 		Open:        isOpen,
 		Quantity:    opts.Quantity,
 		Price:       opts.Price,
-		Duration:    duration,
-		Session:     session,
+		Duration:    normalizeDuration(opts.Duration),
+		Session:     opts.Session,
 	}, nil
 }
 
@@ -1528,11 +1511,6 @@ func parseStrangleParams(opts *strangleBuildOpts, _ []string) (*orderbuilder.Str
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.StrangleParams{
 		Underlying: strings.TrimSpace(opts.Underlying),
 		Expiration: expiration,
@@ -1542,8 +1520,8 @@ func parseStrangleParams(opts *strangleBuildOpts, _ []string) (*orderbuilder.Str
 		Open:       isOpen,
 		Quantity:   opts.Quantity,
 		Price:      opts.Price,
-		Duration:   duration,
-		Session:    session,
+		Duration:   normalizeDuration(opts.Duration),
+		Session:    opts.Session,
 	}, nil
 }
 
@@ -1575,11 +1553,6 @@ func parseStraddleParams(opts *straddleBuildOpts, _ []string) (*orderbuilder.Str
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.StraddleParams{
 		Underlying: strings.TrimSpace(opts.Underlying),
 		Expiration: expiration,
@@ -1588,8 +1561,8 @@ func parseStraddleParams(opts *straddleBuildOpts, _ []string) (*orderbuilder.Str
 		Open:       isOpen,
 		Quantity:   opts.Quantity,
 		Price:      opts.Price,
-		Duration:   duration,
-		Session:    session,
+		Duration:   normalizeDuration(opts.Duration),
+		Session:    opts.Session,
 	}, nil
 }
 
@@ -1607,19 +1580,14 @@ func parseCoveredCallParams(opts *coveredCallBuildOpts, _ []string) (*orderbuild
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.CoveredCallParams{
 		Underlying: strings.TrimSpace(opts.Underlying),
 		Expiration: expiration,
 		Strike:     opts.Strike,
 		Quantity:   opts.Quantity,
 		Price:      opts.Price,
-		Duration:   duration,
-		Session:    session,
+		Duration:   normalizeDuration(opts.Duration),
+		Session:    opts.Session,
 	}, nil
 }
 
@@ -1644,11 +1612,6 @@ func parseCollarParams(opts *collarBuildOpts, _ []string) (*orderbuilder.CollarP
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.CollarParams{
 		Underlying: strings.TrimSpace(opts.Underlying),
 		PutStrike:  opts.PutStrike,
@@ -1657,8 +1620,8 @@ func parseCollarParams(opts *collarBuildOpts, _ []string) (*orderbuilder.CollarP
 		Quantity:   opts.Quantity,
 		Open:       isOpen,
 		Price:      opts.Price,
-		Duration:   duration,
-		Session:    session,
+		Duration:   normalizeDuration(opts.Duration),
+		Session:    opts.Session,
 	}, nil
 }
 
@@ -1695,11 +1658,6 @@ func parseCalendarParams(opts *calendarBuildOpts, _ []string) (*orderbuilder.Cal
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.CalendarParams{
 		Underlying:     strings.TrimSpace(opts.Underlying),
 		NearExpiration: nearExpiration,
@@ -1709,8 +1667,8 @@ func parseCalendarParams(opts *calendarBuildOpts, _ []string) (*orderbuilder.Cal
 		Open:           isOpen,
 		Quantity:       opts.Quantity,
 		Price:          opts.Price,
-		Duration:       duration,
-		Session:        session,
+		Duration:       normalizeDuration(opts.Duration),
+		Session:        opts.Session,
 	}, nil
 }
 
@@ -1747,11 +1705,6 @@ func parseDiagonalParams(opts *diagonalBuildOpts, _ []string) (*orderbuilder.Dia
 		return nil, err
 	}
 
-	duration, session, err := parseDurationSession(opts.Duration, opts.Session)
-	if err != nil {
-		return nil, err
-	}
-
 	return &orderbuilder.DiagonalParams{
 		Underlying:     strings.TrimSpace(opts.Underlying),
 		NearExpiration: nearExpiration,
@@ -1762,8 +1715,8 @@ func parseDiagonalParams(opts *diagonalBuildOpts, _ []string) (*orderbuilder.Dia
 		Open:           isOpen,
 		Quantity:       opts.Quantity,
 		Price:          opts.Price,
-		Duration:       duration,
-		Session:        session,
+		Duration:       normalizeDuration(opts.Duration),
+		Session:        opts.Session,
 	}, nil
 }
 
@@ -1787,22 +1740,6 @@ func parseExpiration(raw string) (time.Time, error) {
 	}
 
 	return expiration, nil
-}
-
-// parseDurationSession parses the --duration and --session flags together.
-// Every order parse function needs both, so this eliminates the repeated pair.
-func parseDurationSession(rawDuration, rawSession string) (models.Duration, models.Session, error) {
-	duration, err := parseDuration(rawDuration)
-	if err != nil {
-		return "", "", err
-	}
-
-	session, err := parseSession(rawSession)
-	if err != nil {
-		return "", "", err
-	}
-
-	return duration, session, nil
 }
 
 // parseBuySell validates mutually exclusive buy/sell flags.
@@ -1834,46 +1771,4 @@ func parsePutCall(call, put bool) (models.PutCall, error) {
 	}
 
 	return models.PutCallPut, nil
-}
-
-// parseStopPriceLinkBasis converts CLI input to a stop price link basis enum.
-// Defaults to LAST when empty, which is the most common trailing stop reference.
-func parseStopPriceLinkBasis(raw string) (models.StopPriceLinkBasis, error) {
-	return parseEnum(raw, validStopPriceLinkBases, models.StopPriceLinkBasisLast, "stop-link-basis")
-}
-
-// parseStopPriceLinkType converts CLI input to a stop price link type enum.
-// Defaults to VALUE when empty, which means the offset is a dollar amount.
-func parseStopPriceLinkType(raw string) (models.StopPriceLinkType, error) {
-	return parseEnum(raw, validStopPriceLinkTypes, models.StopPriceLinkTypeValue, "stop-link-type")
-}
-
-// parseStopType converts CLI input to a stop type enum.
-// Defaults to STANDARD when empty.
-func parseStopType(raw string) (models.StopType, error) {
-	return parseEnum(raw, validStopTypes, models.StopTypeStandard, "stop-type")
-}
-
-// parseSpecialInstruction converts a CLI flag value into a SpecialInstruction constant.
-// Returns an empty value when the flag is not set.
-func parseSpecialInstruction(raw string) (models.SpecialInstruction, error) {
-	return parseEnum(raw, validSpecialInstructions, "", "special-instruction")
-}
-
-// parseDestination converts CLI input to a requested destination enum.
-// Returns empty when not set (optional field).
-func parseDestination(raw string) (models.RequestedDestination, error) {
-	return parseEnum(raw, validDestinations, "", "destination")
-}
-
-// parsePriceLinkBasis converts CLI input to a price link basis enum.
-// Returns empty when not set (optional field).
-func parsePriceLinkBasis(raw string) (models.PriceLinkBasis, error) {
-	return parseEnum(raw, validPriceLinkBases, "", "price-link-basis")
-}
-
-// parsePriceLinkType converts CLI input to a price link type enum.
-// Returns empty when not set (optional field).
-func parsePriceLinkType(raw string) (models.PriceLinkType, error) {
-	return parseEnum(raw, validPriceLinkTypes, "", "price-link-type")
 }

--- a/internal/commands/order_build.go
+++ b/internal/commands/order_build.go
@@ -58,6 +58,7 @@ func makeCobraBuildOrderCommand[O any, P any](
 			return writeOrderRequestJSON(w, order)
 		},
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	if flagSetup != nil {
 		flagSetup(cmd, opts)

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -172,8 +172,8 @@ func maxPeriod(periods []int) int {
 // (cfg.defaultPeriod) and structcli tags require static defaults.
 type simpleTAOpts struct {
 	Period   []int
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int    `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -181,11 +181,11 @@ func (o *simpleTAOpts) Attach(_ *cobra.Command) error { return nil }
 
 // macdOpts holds CLI flags for the MACD subcommand.
 type macdOpts struct {
-	Fast     int    `flag:"fast" flagdescr:"Fast EMA period" default:"12" flaggroup:"indicator"`
-	Slow     int    `flag:"slow" flagdescr:"Slow EMA period" default:"26" flaggroup:"indicator"`
-	Signal   int    `flag:"signal" flagdescr:"Signal EMA period" default:"9" flaggroup:"indicator"`
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int    `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	Fast     int        `flag:"fast" flagdescr:"Fast EMA period" default:"12" flaggroup:"indicator"`
+	Slow     int        `flag:"slow" flagdescr:"Slow EMA period" default:"26" flaggroup:"indicator"`
+	Signal   int        `flag:"signal" flagdescr:"Signal EMA period" default:"9" flaggroup:"indicator"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -193,9 +193,9 @@ func (o *macdOpts) Attach(_ *cobra.Command) error { return nil }
 
 // atrOpts holds CLI flags for the ATR subcommand.
 type atrOpts struct {
-	Period   int    `flag:"period" flagdescr:"Indicator period" default:"14" flaggroup:"indicator"`
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int    `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	Period   int        `flag:"period" flagdescr:"Indicator period" default:"14" flaggroup:"indicator"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -203,10 +203,10 @@ func (o *atrOpts) Attach(_ *cobra.Command) error { return nil }
 
 // bbandsOpts holds CLI flags for the Bollinger Bands subcommand.
 type bbandsOpts struct {
-	Period   int     `flag:"period" flagdescr:"BBands period" default:"20" flaggroup:"indicator"`
-	StdDev   float64 `flag:"std-dev" flagdescr:"Standard deviations" default:"2.0" flaggroup:"indicator"`
-	Interval string  `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int     `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	Period   int        `flag:"period" flagdescr:"BBands period" default:"20" flaggroup:"indicator"`
+	StdDev   float64    `flag:"std-dev" flagdescr:"Standard deviations" default:"2.0" flaggroup:"indicator"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -214,11 +214,11 @@ func (o *bbandsOpts) Attach(_ *cobra.Command) error { return nil }
 
 // stochOpts holds CLI flags for the Stochastic Oscillator subcommand.
 type stochOpts struct {
-	KPeriod  int    `flag:"k-period" flagdescr:"Fast %K lookback period" default:"14" flaggroup:"indicator"`
-	SmoothK  int    `flag:"smooth-k" flagdescr:"Slow %K smoothing period" default:"3" flaggroup:"indicator"`
-	DPeriod  int    `flag:"d-period" flagdescr:"Slow %D period" default:"3" flaggroup:"indicator"`
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int    `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	KPeriod  int        `flag:"k-period" flagdescr:"Fast %K lookback period" default:"14" flaggroup:"indicator"`
+	SmoothK  int        `flag:"smooth-k" flagdescr:"Slow %K smoothing period" default:"3" flaggroup:"indicator"`
+	DPeriod  int        `flag:"d-period" flagdescr:"Slow %D period" default:"3" flaggroup:"indicator"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -226,9 +226,9 @@ func (o *stochOpts) Attach(_ *cobra.Command) error { return nil }
 
 // adxOpts holds CLI flags for the ADX subcommand.
 type adxOpts struct {
-	Period   int    `flag:"period" flagdescr:"Indicator period" default:"14" flaggroup:"indicator"`
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int    `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	Period   int        `flag:"period" flagdescr:"Indicator period" default:"14" flaggroup:"indicator"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -236,8 +236,8 @@ func (o *adxOpts) Attach(_ *cobra.Command) error { return nil }
 
 // vwapOpts holds CLI flags for the VWAP subcommand.
 type vwapOpts struct {
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
-	Points   int    `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -245,8 +245,8 @@ func (o *vwapOpts) Attach(_ *cobra.Command) error { return nil }
 
 // hvOpts holds CLI flags for the Historical Volatility subcommand.
 type hvOpts struct {
-	Period   int    `flag:"period" flagdescr:"Indicator period" default:"20" flaggroup:"indicator"`
-	Interval string `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Period   int        `flag:"period" flagdescr:"Indicator period" default:"20" flaggroup:"indicator"`
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
 }
 
 // Attach implements structcli.Options interface.
@@ -378,7 +378,8 @@ func makeCobraSimpleTACommand(cfg *simpleTAConfig, c *client.Ref, w io.Writer) *
 			}
 			period := maxPeriod(periods)
 
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, period*cfg.multiplier, cfg.name)
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, period*cfg.multiplier, cfg.name)
 			if err != nil {
 				return err
 			}
@@ -398,10 +399,10 @@ func makeCobraSimpleTACommand(cfg *simpleTAConfig, c *client.Ref, w io.Writer) *
 			}
 
 			if len(periods) == 1 {
-				return writeTAOutput(w, cfg.name, symbol, opts.Interval, periods[0], opts.Points, timestamps, valuesByPeriod[periods[0]])
+				return writeTAOutput(w, cfg.name, symbol, interval, periods[0], opts.Points, timestamps, valuesByPeriod[periods[0]])
 			}
 
-			return writeMultiTAOutput(w, cfg.name, symbol, opts.Interval, periods, opts.Points, timestamps, valuesByPeriod)
+			return writeMultiTAOutput(w, cfg.name, symbol, interval, periods, opts.Points, timestamps, valuesByPeriod)
 		},
 	}
 
@@ -419,6 +420,7 @@ func makeCobraSimpleTACommand(cfg *simpleTAConfig, c *client.Ref, w io.Writer) *
 	if err := structcli.Define(cmd, opts, structcli.WithExclusions("period")); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -444,7 +446,8 @@ slow=26, signal=9.`,
 			symbol := args[0]
 
 			// MACD layers slow EMA + signal EMA; 2x the combined period provides convergence.
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, (opts.Slow+opts.Signal)*2, "macd")
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, (opts.Slow+opts.Signal)*2, "macd")
 			if err != nil {
 				return err
 			}
@@ -479,7 +482,7 @@ slow=26, signal=9.`,
 			data := macdOutput{
 				Indicator: "macd",
 				Symbol:    symbol,
-				Interval:  opts.Interval,
+				Interval:  interval,
 				Fast:      opts.Fast,
 				Slow:      opts.Slow,
 				Signal:    opts.Signal,
@@ -492,6 +495,7 @@ slow=26, signal=9.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -515,7 +519,8 @@ data with Wilder smoothing. Default period is 14.`,
 			symbol := args[0]
 
 			// ATR uses Wilder smoothing; 3x period provides convergence stability.
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, opts.Period*3, "atr")
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, opts.Period*3, "atr")
 			if err != nil {
 				return err
 			}
@@ -538,13 +543,14 @@ data with Wilder smoothing. Default period is 14.`,
 				return err
 			}
 
-			return writeTAOutput(w, "atr", symbol, opts.Interval, opts.Period, opts.Points, timestamps, values)
+			return writeTAOutput(w, "atr", symbol, interval, opts.Period, opts.Points, timestamps, values)
 		},
 	}
 
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -568,7 +574,8 @@ relatively low. Use --std-dev to widen or narrow the bands (default 2.0).`,
 
 			symbol := args[0]
 
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, opts.Period, "bbands")
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, opts.Period, "bbands")
 			if err != nil {
 				return err
 			}
@@ -603,7 +610,7 @@ relatively low. Use --std-dev to widen or narrow the bands (default 2.0).`,
 			data := bbandsOutput{
 				Indicator: "bbands",
 				Symbol:    symbol,
-				Interval:  opts.Interval,
+				Interval:  interval,
 				Period:    opts.Period,
 				StdDev:    opts.StdDev,
 				Values:    out,
@@ -615,6 +622,7 @@ relatively low. Use --std-dev to widen or narrow the bands (default 2.0).`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -639,7 +647,8 @@ Configurable via --k-period, --smooth-k, and --d-period.`,
 
 			// Stochastic chains three windowed ops (raw %K, smoothed %K, %D);
 			// total depth is the sum of all window sizes.
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, opts.KPeriod+opts.SmoothK+opts.DPeriod, "stoch")
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, opts.KPeriod+opts.SmoothK+opts.DPeriod, "stoch")
 			if err != nil {
 				return err
 			}
@@ -681,7 +690,7 @@ Configurable via --k-period, --smooth-k, and --d-period.`,
 			data := stochOutput{
 				Indicator: "stoch",
 				Symbol:    symbol,
-				Interval:  opts.Interval,
+				Interval:  interval,
 				KPeriod:   opts.KPeriod,
 				SmoothK:   opts.SmoothK,
 				DPeriod:   opts.DPeriod,
@@ -694,6 +703,7 @@ Configurable via --k-period, --smooth-k, and --d-period.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -717,7 +727,8 @@ plus_di, and minus_di for directional bias. Default period is 14.`,
 			symbol := args[0]
 
 			// ADX double-smooths (DI pass + ADX pass); 4x period ensures both converge.
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, opts.Period*4, "adx")
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, opts.Period*4, "adx")
 			if err != nil {
 				return err
 			}
@@ -760,7 +771,7 @@ plus_di, and minus_di for directional bias. Default period is 14.`,
 			data := adxOutput{
 				Indicator: "adx",
 				Symbol:    symbol,
-				Interval:  opts.Interval,
+				Interval:  interval,
 				Period:    opts.Period,
 				Values:    out,
 			}
@@ -771,6 +782,7 @@ plus_di, and minus_di for directional bias. Default period is 14.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -797,7 +809,8 @@ suggests bearish.`,
 
 			// Use 20 as minimum candle count - VWAP works with any count >= 1
 			// but 20 gives meaningful output for typical use cases.
-			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, 20, "vwap")
+			interval := string(opts.Interval)
+			candles, timestamps, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, 20, "vwap")
 			if err != nil {
 				return err
 			}
@@ -825,13 +838,14 @@ suggests bearish.`,
 			}
 
 			// period=0 because VWAP is cumulative (no windowed period)
-			return writeTAOutput(w, "vwap", symbol, opts.Interval, 0, opts.Points, timestamps, values)
+			return writeTAOutput(w, "vwap", symbol, interval, 0, opts.Points, timestamps, values)
 		},
 	}
 
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }
@@ -857,7 +871,8 @@ monthly volatility breakdowns.`,
 
 			// Need period+1 closes for N returns, plus extra for rolling window warmup.
 			// period+21 provides a safety margin for the rolling window.
-			candles, _, err := fetchAndValidateCandles(cmd.Context(), c, symbol, opts.Interval, opts.Period+21, "hv")
+			interval := string(opts.Interval)
+			candles, _, err := fetchAndValidateCandles(cmd.Context(), c, symbol, interval, opts.Period+21, "hv")
 			if err != nil {
 				return err
 			}
@@ -877,7 +892,7 @@ monthly volatility breakdowns.`,
 			data := hvOutput{
 				Indicator:      "hv",
 				Symbol:         symbol,
-				Interval:       opts.Interval,
+				Interval:       interval,
 				Period:         opts.Period,
 				DailyVol:       result.DailyVol,
 				WeeklyVol:      result.WeeklyVol,
@@ -896,6 +911,7 @@ monthly volatility breakdowns.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- Register CLI-facing enum flag types with structcli so JSON Schema and help/completions expose allowed values.
- Replace repeated manual enum parsing on command paths with typed enum decoding while preserving legacy aliases like GTC, FOK, IOC, MOC, and LOC.
- Keep order status list validation manual because structcli v0.17 panics on enum slices.

## Verification
- LSP diagnostics clean for internal/commands
- make test
- make lint
- make build
- CLI schema/help smoke checks