### PR TITLE
feat: add --debug-options flag for flag source attribution

### DIFF
--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/leodido/structcli"
+	"github.com/leodido/structcli/debug"
 	"github.com/spf13/cobra"
 
 	"github.com/major/schwab-agent/internal/apperr"
@@ -66,7 +67,7 @@ func buildAppWithDeps(w io.Writer, deps commands.RootDeps) *cobra.Command {
 	root.AddCommand(commands.NewOrderCmd(ref, configPath, w))
 	root.AddCommand(commands.NewCompletionCmd(w))
 
-	if err := structcli.Setup(root, structcli.WithJSONSchema(), structcli.WithHelpTopics(), structcli.WithFlagErrors(), structcli.WithAppName("schwab-agent")); err != nil {
+	if err := structcli.Setup(root, structcli.WithJSONSchema(), structcli.WithHelpTopics(), structcli.WithFlagErrors(), structcli.WithAppName("schwab-agent"), structcli.WithDebug(debug.Options{Exit: true})); err != nil {
 		panic(err)
 	}
 

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -537,3 +537,59 @@ func TestBuildApp_VersionFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "dev")
 }
+
+func TestDebugOptions_TextFormat(t *testing.T) {
+	// --debug-options should print text flag attribution without requiring
+	// auth credentials or a valid token.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	stdout, err := runApp(t, "schwab-agent", "--debug-options", "account", "list")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Command:")
+	assert.Contains(t, stdout, "Flags:")
+}
+
+func TestDebugOptions_JSONFormat(t *testing.T) {
+	// --debug-options=json should produce structured JSON output.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	stdout, err := runApp(t, "schwab-agent", "--debug-options=json", "account", "list")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, `"command"`)
+	assert.Contains(t, stdout, `"flags"`)
+	assert.Contains(t, stdout, `"source"`)
+}
+
+func TestDebugOptions_SkipsAuth(t *testing.T) {
+	// Debug mode on a command that normally requires auth should not attempt
+	// authentication at all (no config/token files needed).
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Point config/token at non-existent paths to prove auth is skipped.
+	stdout, err := runApp(t,
+		"schwab-agent",
+		"--debug-options",
+		"--config", filepath.Join(tmpDir, "does-not-exist.json"),
+		"--token", filepath.Join(tmpDir, "no-token.json"),
+		"account", "list",
+	)
+	require.NoError(t, err)
+
+	// Should get debug output, not an auth error.
+	assert.Contains(t, stdout, "Command:")
+	assert.Contains(t, stdout, "Flags:")
+}
+
+func TestDebugOptions_BareFlag(t *testing.T) {
+	// Bare --debug-options (no value) should default to text format.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	stdout, err := runApp(t, "schwab-agent", "--debug-options", "account", "list")
+	require.NoError(t, err)
+
+	assert.Contains(t, stdout, "Command:")
+	assert.Contains(t, stdout, "Flags:")
+}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -55,6 +55,14 @@ func NewRootCmd(
 				return nil
 			}
 
+			// Debug mode prints flag source attribution and exits without
+			// executing the command. Skip auth since introspection doesn't
+			// need API access.
+			if structcli.IsDebugActive(cmd) {
+				structcli.UseDebug(cmd, cmd.OutOrStdout())
+				return nil
+			}
+
 			verbose, err := cmd.Flags().GetBool("verbose")
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

- Enables structcli `WithDebug(debug.Options{Exit: true})` to add a `--debug-options` persistent flag showing where each flag value comes from (flag, env, config, or default)
- Supports text (`--debug-options`) and JSON (`--debug-options=json`) output formats, plus the `SCHWAB_AGENT_DEBUG_OPTIONS` env var
- Skips authentication when debug mode is active since introspection doesn't need API access

## Example output

```text
$ schwab-agent --debug-options account list
Command: schwab-agent account list

Flags:
  --account                                                      (default)
  --config         /home/major/.config/schwab-agent/config.json  (default)
  --debug-options  text                                          (flag)
  --positions      false                                         (default)
  --token          /home/major/.config/schwab-agent/token.json   (default)
  --verbose        false                                         (default)
```