### PR TITLE
feat: implement Validatable interface for opts struct validation

### DIFF
--- a/internal/apperr/errors.go
+++ b/internal/apperr/errors.go
@@ -3,6 +3,8 @@ package apperr
 
 import (
 	"errors"
+
+	structclierrors "github.com/leodido/structcli/errors"
 )
 
 // ErrorOption configures optional fields on SchwabError during construction.
@@ -329,6 +331,13 @@ func ErrorCode(err error) string {
 
 	if _, ok := errors.AsType[*OrderBuildError](err); ok {
 		return "ORDER_BUILD_ERROR"
+	}
+
+	// structcli's Validatable interface produces its own ValidationError type
+	// when Validate() returns errors during Unmarshal(). Classify it the same
+	// as our internal ValidationError so JSON output stays consistent.
+	if _, ok := errors.AsType[*structclierrors.ValidationError](err); ok {
+		return "VALIDATION_ERROR"
 	}
 
 	return "UNKNOWN"

--- a/internal/apperr/errors_test.go
+++ b/internal/apperr/errors_test.go
@@ -2,7 +2,10 @@ package apperr
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+
+	structclierrors "github.com/leodido/structcli/errors"
 )
 
 // TestExitCodeForAuthRequiredError verifies AuthRequiredError maps to exit code 3.
@@ -190,6 +193,33 @@ func TestErrorCodeForOrderBuildError(t *testing.T) {
 	code := ErrorCode(err)
 	if code != "ORDER_BUILD_ERROR" {
 		t.Errorf("ErrorCode(OrderBuildError) = %q, want %q", code, "ORDER_BUILD_ERROR")
+	}
+}
+
+// TestErrorCodeForStructcliValidationError verifies structcli's ValidationError
+// (produced by the Validatable interface) maps to VALIDATION_ERROR, same as
+// our internal ValidationError.
+func TestErrorCodeForStructcliValidationError(t *testing.T) {
+	err := &structclierrors.ValidationError{
+		ContextName: "test-cmd",
+		Errors:      []error{fmt.Errorf("field is invalid")},
+	}
+	code := ErrorCode(err)
+	if code != "VALIDATION_ERROR" {
+		t.Errorf("ErrorCode(structcli ValidationError) = %q, want %q", code, "VALIDATION_ERROR")
+	}
+}
+
+// TestExitCodeForStructcliValidationError verifies structcli's ValidationError
+// maps to exit code 1 (default for non-exitCoder errors).
+func TestExitCodeForStructcliValidationError(t *testing.T) {
+	err := &structclierrors.ValidationError{
+		ContextName: "test-cmd",
+		Errors:      []error{fmt.Errorf("field is invalid")},
+	}
+	code := ExitCodeFor(err)
+	if code != 1 {
+		t.Errorf("ExitCodeFor(structcli ValidationError) = %d, want 1", code)
 	}
 }
 

--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -11,7 +11,6 @@ import (
 	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
 
-	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/output"
 )
@@ -53,6 +52,31 @@ type quoteGetOpts struct {
 // Attach implements structcli.Options interface.
 func (o *quoteGetOpts) Attach(_ *cobra.Command) error { return nil }
 
+// Validate implements structcli.Validatable. Called automatically during
+// Unmarshal() after flag decoding. Checks that all --fields values are
+// recognized quote field names.
+func (o *quoteGetOpts) Validate(_ context.Context) []error {
+	var errs []error
+	for _, f := range o.Fields {
+		for part := range strings.SplitSeq(f, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			lower := strings.ToLower(trimmed)
+			if !validQuoteFields[lower] {
+				errs = append(errs, fmt.Errorf("invalid field %q: must be one of %s", trimmed, sortedQuoteFieldNames()))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
 // newQuoteGetCmd returns the Cobra subcommand for retrieving quotes.
 func newQuoteGetCmd(c *client.Ref, w io.Writer) *cobra.Command {
 	opts := &quoteGetOpts{}
@@ -70,14 +94,13 @@ market cap.`,
   schwab-agent quote get AAPL --fields fundamental --indicative`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Unmarshal decodes flags and runs quoteGetOpts.Validate(),
+			// which rejects unrecognized --fields values.
 			if err := structcli.Unmarshal(cmd, opts); err != nil {
 				return err
 			}
 
-			params, err := buildCobraQuoteParams(opts)
-			if err != nil {
-				return err
-			}
+			params := buildCobraQuoteParams(opts)
 
 			if len(args) == 1 {
 				return quoteSingle(cmd.Context(), c, w, args[0], params)
@@ -93,33 +116,25 @@ market cap.`,
 	return cmd
 }
 
-// buildCobraQuoteParams constructs a QuoteParams from option struct, validating
-// field values against the allowed set (case-insensitive).
-func buildCobraQuoteParams(opts *quoteGetOpts) (client.QuoteParams, error) {
+// buildCobraQuoteParams constructs a QuoteParams from the validated option struct.
+// Field validation has already been performed by quoteGetOpts.Validate().
+func buildCobraQuoteParams(opts *quoteGetOpts) client.QuoteParams {
 	fields := make([]string, 0, len(opts.Fields))
 	for _, f := range opts.Fields {
 		// Support both repeatable (--fields QUOTE --fields FUNDAMENTAL)
 		// and comma-separated (--fields QUOTE,FUNDAMENTAL) forms.
-		parts := strings.SplitSeq(f, ",")
-		for part := range parts {
+		for part := range strings.SplitSeq(f, ",") {
 			trimmed := strings.TrimSpace(part)
 			if trimmed == "" {
 				continue
 			}
-			lower := strings.ToLower(trimmed)
-			if !validQuoteFields[lower] {
-				return client.QuoteParams{}, apperr.NewValidationError(
-					fmt.Sprintf("invalid field %q: must be one of %s", trimmed, sortedQuoteFieldNames()),
-					nil,
-				)
-			}
-			fields = append(fields, lower)
+			fields = append(fields, strings.ToLower(trimmed))
 		}
 	}
 	return client.QuoteParams{
 		Fields:     fields,
 		Indicative: opts.Indicative,
-	}, nil
+	}
 }
 
 // sortedQuoteFieldNames returns the valid field names sorted alphabetically,

--- a/internal/commands/quote_test.go
+++ b/internal/commands/quote_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	structclierrors "github.com/leodido/structcli/errors"
+
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 	"github.com/stretchr/testify/assert"
@@ -259,7 +261,9 @@ func TestNewQuoteGetInvalidField(t *testing.T) {
 	)
 	require.Error(t, err)
 
-	var valErr *apperr.ValidationError
+	// Validation now runs inside structcli.Unmarshal via quoteGetOpts.Validate(),
+	// producing structcli's ValidationError instead of apperr's.
+	var valErr *structclierrors.ValidationError
 	assert.ErrorAs(t, err, &valErr)
 	assert.Contains(t, err.Error(), "bogus")
 	assert.Empty(t, buf.String())

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -179,6 +179,34 @@ type simpleTAOpts struct {
 // Attach implements structcli.Options interface.
 func (o *simpleTAOpts) Attach(_ *cobra.Command) error { return nil }
 
+// Validate implements structcli.Validatable. Called automatically during
+// Unmarshal() after flag decoding. Checks that all requested periods are
+// positive and unique.
+func (o *simpleTAOpts) Validate(_ context.Context) []error {
+	if len(o.Period) == 0 {
+		return []error{fmt.Errorf("at least one period is required")}
+	}
+
+	var errs []error
+	seen := make(map[int]struct{}, len(o.Period))
+	for _, period := range o.Period {
+		if period <= 0 {
+			errs = append(errs, fmt.Errorf("period must be greater than 0"))
+		}
+
+		if _, ok := seen[period]; ok {
+			errs = append(errs, fmt.Errorf("duplicate period: %d", period))
+		}
+		seen[period] = struct{}{}
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}
+
 // macdOpts holds CLI flags for the MACD subcommand.
 type macdOpts struct {
 	Fast     int        `flag:"fast" flagdescr:"Fast EMA period" default:"12" flaggroup:"indicator"`
@@ -329,31 +357,6 @@ can be repeated or comma-separated for multiple lookbacks. Default period is 14.
 	return cmd
 }
 
-// cobraParseTAPeriods returns the requested indicator windows from the option struct.
-// Cobra's IntSlice flag accepts both repeated flags and comma-separated values,
-// which lets a user ask for "21, 50, and 200 day moving averages" in a single
-// command while keeping the old single --period form working unchanged.
-func cobraParseTAPeriods(opts *simpleTAOpts) ([]int, error) {
-	periods := opts.Period
-	if len(periods) == 0 {
-		return nil, newValidationError("at least one period is required")
-	}
-
-	seen := make(map[int]struct{}, len(periods))
-	for _, period := range periods {
-		if period <= 0 {
-			return nil, newValidationError("period must be greater than 0")
-		}
-
-		if _, ok := seen[period]; ok {
-			return nil, newValidationError(fmt.Sprintf("duplicate period: %d", period))
-		}
-		seen[period] = struct{}{}
-	}
-
-	return periods, nil
-}
-
 // makeCobraSimpleTACommand builds a Cobra command for a closes-only indicator.
 // The returned command fetches candles, extracts close prices, runs the
 // indicator's compute function, and writes the result envelope.
@@ -366,16 +369,14 @@ func makeCobraSimpleTACommand(cfg *simpleTAConfig, c *client.Ref, w io.Writer) *
 		Example: cfg.example,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Unmarshal decodes flags and runs simpleTAOpts.Validate(),
+			// which rejects zero/negative and duplicate periods.
 			if err := structcli.Unmarshal(cmd, opts); err != nil {
 				return err
 			}
 
 			symbol := args[0]
-
-			periods, err := cobraParseTAPeriods(opts)
-			if err != nil {
-				return err
-			}
+			periods := opts.Period
 			period := maxPeriod(periods)
 
 			interval := string(opts.Interval)

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	structclierrors "github.com/leodido/structcli/errors"
+
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/output"
 )
@@ -418,9 +420,10 @@ func TestTASimplePeriodValidation(t *testing.T) {
 			cmd := NewTACmd(testClient(t, server), &buf)
 			_, err := runTestCommand(t, cmd, tt.args...)
 
-			// Assert
+			// Assert: validation now runs inside structcli.Unmarshal via
+			// simpleTAOpts.Validate(), producing structcli's ValidationError.
 			require.Error(t, err)
-			var valErr *apperr.ValidationError
+			var valErr *structclierrors.ValidationError
 			assert.ErrorAs(t, err, &valErr)
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `Validate()` methods to `simpleTAOpts` (period validation) and `quoteGetOpts` (field name validation) using structcli's `Validatable` interface
- Validation now runs automatically during `Unmarshal()` instead of manual checks in RunE handlers
- Remove `cobraParseTAPeriods()` (logic moved to `Validate()`) and simplify `buildCobraQuoteParams()` to no longer return an error
- Add `structclierrors.ValidationError` handling to `apperr.ErrorCode()` so both internal and structcli validation errors produce consistent `VALIDATION_ERROR` JSON code