### PR TITLE
feat: add MCP server mode for JSON-RPC tool access

### DIFF
--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/debug"
+	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
 
 	"github.com/major/schwab-agent/internal/apperr"
@@ -46,6 +47,45 @@ func buildApp(w io.Writer) *cobra.Command {
 
 // buildAppWithDeps constructs the CLI root command with the given dependencies.
 func buildAppWithDeps(w io.Writer, deps commands.RootDeps) *cobra.Command {
+	root := buildCommandTree(w, deps)
+
+	if err := structcli.Setup(root,
+		structcli.WithJSONSchema(),
+		structcli.WithHelpTopics(),
+		structcli.WithFlagErrors(),
+		structcli.WithAppName("schwab-agent"),
+		structcli.WithDebug(debug.Options{Exit: true}),
+		structcli.WithMCP(structclimcp.Options{
+			Name:    "schwab-agent",
+			Version: version,
+			Exclude: []string{
+				// Interactive browser-based OAuth flow, not usable from MCP clients.
+				"auth-login",
+				// Shell completion generators are irrelevant in MCP mode.
+				"completion-bash",
+				"completion-zsh",
+				"completion-fish",
+				"completion-powershell",
+			},
+			// CommandFactory builds a fresh command tree per MCP tool call so that
+			// PersistentPreRunE (auth lifecycle) runs for each invocation. Without
+			// this, MCP mode skips PersistentPreRunE entirely and commands that
+			// need an authenticated API client would fail.
+			CommandFactory: func(_ []string, stdout io.Writer, _ io.Writer) (*cobra.Command, error) {
+				return buildCommandTree(stdout, deps), nil
+			},
+		}),
+	); err != nil {
+		panic(err)
+	}
+
+	return root
+}
+
+// buildCommandTree constructs the full command tree without calling structcli.Setup.
+// Used by buildAppWithDeps for the main CLI and by the MCP CommandFactory for
+// per-tool-call fresh command trees (each with its own client.Ref and auth lifecycle).
+func buildCommandTree(w io.Writer, deps commands.RootDeps) *cobra.Command {
 	configPath := defaultConfigPath()
 	tokenPath := defaultTokenPath()
 
@@ -66,10 +106,6 @@ func buildAppWithDeps(w io.Writer, deps commands.RootDeps) *cobra.Command {
 	root.AddCommand(commands.NewAuthCmd(configPath, tokenPath, w, commands.DefaultAuthDeps()))
 	root.AddCommand(commands.NewOrderCmd(ref, configPath, w))
 	root.AddCommand(commands.NewCompletionCmd(w))
-
-	if err := structcli.Setup(root, structcli.WithJSONSchema(), structcli.WithHelpTopics(), structcli.WithFlagErrors(), structcli.WithAppName("schwab-agent"), structcli.WithDebug(debug.Options{Exit: true})); err != nil {
-		panic(err)
-	}
 
 	return root
 }

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -592,4 +594,198 @@ func TestDebugOptions_BareFlag(t *testing.T) {
 
 	assert.Contains(t, stdout, "Command:")
 	assert.Contains(t, stdout, "Flags:")
+}
+
+// --- MCP server tests ---
+
+// runMCP sends newline-delimited JSON-RPC requests to the MCP server and returns
+// the raw stdout output. The MCP server reads from stdin and writes responses to
+// stdout, terminating when stdin reaches EOF.
+func runMCP(t *testing.T, requests ...string) (string, error) {
+	t.Helper()
+
+	input := strings.Join(requests, "\n") + "\n"
+	var stdout bytes.Buffer
+	app := buildApp(&stdout)
+	app.SetIn(strings.NewReader(input))
+	app.SetOut(&stdout)
+	app.SetArgs([]string{"--mcp"})
+
+	err := app.Execute()
+
+	return stdout.String(), err
+}
+
+// runMCPWithDeps is like runMCP but injects custom dependencies.
+func runMCPWithDeps(t *testing.T, deps commands.RootDeps, requests ...string) (string, error) {
+	t.Helper()
+
+	input := strings.Join(requests, "\n") + "\n"
+	var stdout bytes.Buffer
+	app := buildAppWithDeps(&stdout, deps)
+	app.SetIn(strings.NewReader(input))
+	app.SetOut(&stdout)
+	app.SetArgs([]string{"--mcp"})
+
+	err := app.Execute()
+
+	return stdout.String(), err
+}
+
+// mcpResponse represents a JSON-RPC 2.0 response for test decoding.
+type mcpResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// parseMCPResponses decodes newline-delimited JSON-RPC responses from MCP output.
+func parseMCPResponses(t *testing.T, output string) []mcpResponse {
+	t.Helper()
+
+	var responses []mcpResponse
+	dec := json.NewDecoder(strings.NewReader(output))
+	for dec.More() {
+		var resp mcpResponse
+		require.NoError(t, dec.Decode(&resp))
+		responses = append(responses, resp)
+	}
+
+	return responses
+}
+
+func TestMCP_ToolsList(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	output, err := runMCP(t,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	)
+	require.NoError(t, err)
+
+	responses := parseMCPResponses(t, output)
+	require.Len(t, responses, 2)
+
+	// Verify initialize response.
+	var initResult structclimcp.InitializeResult
+	require.NoError(t, json.Unmarshal(responses[0].Result, &initResult))
+	assert.Equal(t, structclimcp.ProtocolVersion, initResult.ProtocolVersion)
+	assert.Equal(t, "schwab-agent", initResult.ServerInfo.Name)
+
+	// Verify tools/list response.
+	var toolsList structclimcp.ToolsListResult
+	require.NoError(t, json.Unmarshal(responses[1].Result, &toolsList))
+
+	toolNames := make([]string, len(toolsList.Tools))
+	for i, tool := range toolsList.Tools {
+		toolNames[i] = tool.Name
+	}
+
+	// Spot-check expected tools are present.
+	for _, expected := range []string{
+		"quote-get", "account-list", "symbol-build",
+		"ta-sma", "order-place-equity",
+	} {
+		assert.Contains(t, toolNames, expected, "expected tool %q in tools/list", expected)
+	}
+
+	// Verify excluded tools are absent.
+	for _, excluded := range []string{
+		"auth-login",
+		"completion-bash", "completion-zsh",
+		"completion-fish", "completion-powershell",
+	} {
+		assert.NotContains(t, toolNames, excluded, "excluded tool %q should not be in tools/list", excluded)
+	}
+
+	// Non-excluded auth commands should still be available.
+	assert.Contains(t, toolNames, "auth-status")
+	assert.Contains(t, toolNames, "auth-refresh")
+}
+
+func TestMCP_ToolCall_SymbolBuild(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	output, err := runMCP(t,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"symbol-build","arguments":{"underlying":"AAPL","expiration":"2026-12-19","strike":200,"call":true}}}`,
+	)
+	require.NoError(t, err)
+
+	responses := parseMCPResponses(t, output)
+	require.Len(t, responses, 2)
+
+	var result structclimcp.ToolCallResult
+	require.NoError(t, json.Unmarshal(responses[1].Result, &result))
+	assert.False(t, result.IsError, "symbol-build should succeed without auth")
+	require.NotEmpty(t, result.Content)
+	// symbol build outputs a JSON envelope with the OCC symbol.
+	assert.Contains(t, result.Content[0].Text, "AAPL")
+}
+
+func TestMCP_ToolCall_AuthRequired(t *testing.T) {
+	// Calling an API-dependent tool without credentials should return an
+	// MCP error response (isError: true) rather than crashing.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	output, err := runMCP(t,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"account-list","arguments":{}}}`,
+	)
+	require.NoError(t, err)
+
+	responses := parseMCPResponses(t, output)
+	require.Len(t, responses, 2)
+
+	var result structclimcp.ToolCallResult
+	require.NoError(t, json.Unmarshal(responses[1].Result, &result))
+	assert.True(t, result.IsError, "tool call without credentials should return isError: true")
+	require.NotEmpty(t, result.Content)
+	assert.Contains(t, result.Content[0].Text, "credentials")
+}
+
+func TestMCP_ToolCall_WithAuth(t *testing.T) {
+	// End-to-end: authenticated MCP tool call returns real data.
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configPath := filepath.Join(tmpDir, "schwab-agent", "config.json")
+	tokenPath := filepath.Join(tmpDir, "schwab-agent", "token.json")
+	writeTestConfig(t, configPath)
+	writeTestToken(t, tokenPath, freshToken())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			_, _ = w.Write([]byte(`[{"accountNumber":"123456789","hashValue":"hash-123"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	deps := commands.DefaultRootDeps()
+	deps.NewClient = func(token string, _ ...client.Option) *client.Client {
+		return client.NewClient(token, client.WithBaseURL(server.URL))
+	}
+
+	output, err := runMCPWithDeps(t, deps,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"test"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"account-numbers","arguments":{}}}`,
+	)
+	require.NoError(t, err)
+
+	responses := parseMCPResponses(t, output)
+	require.Len(t, responses, 2)
+
+	var result structclimcp.ToolCallResult
+	require.NoError(t, json.Unmarshal(responses[1].Result, &result))
+	assert.False(t, result.IsError, "authenticated tool call should succeed")
+	require.NotEmpty(t, result.Content)
+	assert.Contains(t, result.Content[0].Text, "hash-123")
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -51,6 +51,13 @@ func NewRootCmd(
 		SilenceUsage:               true,
 		SuggestionsMinimumDistance: 2,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// In MCP server mode the root command runs just to start the
+			// JSON-RPC loop. Auth is handled per-tool-call via the
+			// CommandFactory fresh trees, so skip it here.
+			if isMCPMode(cmd) {
+				return nil
+			}
+
 			if hasSkipAuthAnnotation(cmd) {
 				return nil
 			}
@@ -176,6 +183,16 @@ func completeRootDeps(deps RootDeps) RootDeps {
 	}
 
 	return deps
+}
+
+// isMCPMode returns true when the root --mcp flag is set, meaning the CLI is
+// running as an MCP JSON-RPC server rather than executing a single command.
+func isMCPMode(cmd *cobra.Command) bool {
+	if f := cmd.Root().PersistentFlags().Lookup("mcp"); f != nil {
+		return f.Changed
+	}
+
+	return false
 }
 
 // hasSkipAuthAnnotation checks the current command and ancestors for auth bypass.


### PR DESCRIPTION
## Summary

- Enables `--mcp` flag to run schwab-agent as an MCP (Model Context Protocol) server over stdio, exposing 52 leaf commands as JSON-RPC 2.0 tools
- Uses structcli's `WithMCP` with a `CommandFactory` that builds a fresh command tree per tool call, giving each invocation its own auth lifecycle
- Excludes `auth-login` (interactive browser flow) and shell `completion-*` generators from MCP tools

## Details

**main.go**: Extracted `buildCommandTree()` from `buildAppWithDeps()` so both the main CLI and the MCP CommandFactory share the same tree construction logic. Each factory-built tree gets its own `client.Ref` and PersistentPreRunE auth hook.

**root.go**: Added `isMCPMode()` check in PersistentPreRunE to skip auth when `--mcp` is set on the root command. Auth is handled per-tool-call via the fresh factory trees instead.

**Tests**: 4 new MCP tests covering tools/list verification (expected tools present, excluded tools absent), no-auth tool call (symbol-build), auth-required error propagation, and authenticated end-to-end tool call with httptest server.

## Known limitation

Commands that accept positional arguments (quote-get, ta-sma, history-get, chain-get, etc.) cannot receive those arguments via MCP since the MCP layer only maps flag-based arguments. This is a structcli constraint, not a schwab-agent bug. Flag-only commands (account-list, order-place-equity, symbol-build, etc.) work correctly.