### PR TITLE
Improve agent-facing CLI output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ CI runs lint (golangci-lint v2.11), test (race detector + coverage + build verif
 
 Shell script at `scripts/smoke-test.sh`. Two tiers:
 
-- **Tier 1** (no auth, CI-safe): help text for all 64 commands/subcommands, symbol build/parse, all 13 order build sub-types with full permutations (135 tests). Runs in CI and locally via `make smoke-ci`.
+- **Tier 1** (no auth, CI-safe): help text for all 65 commands/subcommands, symbol build/parse, all 13 order build sub-types with full permutations (136 tests). Runs in CI and locally via `make smoke-ci`.
 - **Tier 2** (auth required, local only): read-only API commands (account, position, quote, order list, chain, history, instrument, market, all 11 TA indicators). Requires a valid token. Runs locally via `make smoke` (both tiers) or `SMOKE_TIER=2 ./scripts/smoke-test.sh` (tier 2 only).
 
 Each test validates exit code 0, valid JSON output, and the correct envelope structure (`.data` for API commands, raw JSON for order builds). `SMOKE_BIN` env var overrides the binary path.
@@ -90,7 +90,7 @@ spf13/cobra + leodido/structcli. `buildApp()` in main.go constructs the command 
 
 Command flags use structcli struct tags (`flag`, `flagdescr`, `default`, `flagshort`) with `Define()` for registration and `Unmarshal()` in RunE for parsing. Most order commands use `defineAndConstrain[O]()` from helpers.go, which wraps `Define()` + `MarkFlagsMutuallyExclusive`/`MarkFlagsOneRequired` in a single call. Root persistent flags (--account, --verbose, --config, --token) stay as manual Cobra registrations.
 
-11 subcommands: auth (setup/login/status), account (list/get/numbers/set-default/transaction), position (list with --all-accounts/--account), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), ta (sma/ema/rsi/macd/atr/bbands/stoch/adx/vwap/hv/expected-move). Account list/get enriches results with nicknames from the preferences API (best-effort, degrades gracefully). Position list enriches with nicknames and adds computed cost basis / P&L fields. Order list defaults to non-terminal statuses (use --status all for everything).
+11 subcommands: auth (login/status/refresh), account (summary/list/get/numbers/set-default/transaction), position (list with --all-accounts/--account), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), ta (sma/ema/rsi/macd/atr/bbands/stoch/adx/vwap/hv/expected-move). Account summary is the token-efficient account picker for agents: it joins account hashes from account numbers with nicknames/primary/type from user preferences without fetching full balances. Account list/get enrich full results with nicknames from the preferences API (best-effort, degrades gracefully). Position list enriches with nicknames and adds computed cost basis / P&L fields. Order list defaults to non-terminal statuses (use --status all for everything).
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ Run any command with `--help` to see detailed usage, examples, and available fla
 # Get a quote
 schwab-agent quote get AAPL
 
-# List accounts
+# List compact account identifiers for agent workflows
+schwab-agent account summary
+
+# List full account details and balances
 schwab-agent account list
 
 # Get option chains
@@ -108,7 +111,7 @@ schwab-agent order place equity \
   --symbol AAPL \
   --action BUY \
   --quantity 10 \
-  --order-type LIMIT \
+  --type LIMIT \
   --price 150.00 \
   --duration DAY
 
@@ -117,14 +120,14 @@ schwab-agent order preview equity \
   --symbol AAPL \
   --action BUY \
   --quantity 10 \
-  --order-type MARKET
+  --type MARKET
 
 # Build order JSON offline
 schwab-agent order build equity \
   --symbol AAPL \
   --action BUY \
   --quantity 10 \
-  --order-type LIMIT \
+  --type LIMIT \
   --price 150.00 \
   --duration DAY
 
@@ -137,7 +140,7 @@ schwab-agent order place --spec @order.json
 | Command | Description |
 |---|---|
 | `auth` | Login, status, token refresh |
-| `account` | List (with nicknames), get details, set default, transactions |
+| `account` | Compact summaries, full account details, hashes, set default, transactions |
 | `position` | List positions for one or all accounts (with computed cost basis and P&L) |
 | `quote` | Get quotes for one or more symbols |
 | `order` | List, get, place, preview, build, cancel, replace |

--- a/README.md
+++ b/README.md
@@ -167,17 +167,17 @@ This prevents accidental trades from misconfigured agents.
 
 ## Agent integration
 
-Every command includes detailed `--help` output with usage descriptions and concrete examples that agents can reference. The `--jsonschema` flag provides machine-readable CLI introspection:
+For LLM agents: run `schwab-agent --jsonschema=tree` first when you need to discover commands, flags, enum values, defaults, config keys, or environment variable bindings. Treat this JSON Schema tree as the authoritative command contract for shell-based automation. Use `llms.txt`, `SKILL.md`, and `--help` for workflow guidance and examples after choosing the command and flags from the schema.
 
 ```bash
-# Full JSON Schema for the entire CLI
-schwab-agent --jsonschema
-
-# Tree view showing all commands with their flags
+# Canonical shell-agent discovery path for the full CLI contract
 schwab-agent --jsonschema=tree
 
 # Schema for a specific subcommand
 schwab-agent quote --jsonschema
+
+# Flat JSON Schema for the entire CLI, useful for tools that do not need hierarchy
+schwab-agent --jsonschema
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ schwab-agent auth status
 
 ## Usage
 
-Every command returns structured JSON. Success responses use a `{"data": ..., "metadata": ...}` envelope. Errors use `{"error": {"code": ..., "message": ..., "details": ...}}`.
+Every command returns structured JSON. Success responses use a `{"data": ..., "metadata": ...}` envelope. Errors use structcli's top-level `StructuredError` shape, for example `{"error":"unknown_flag","exit_code":12,"message":"unknown flag: --bogus","command":"schwab-agent quote get","flag":"bogus"}`. Domain errors use the same shape, with remediation text in `hint` when available.
 
 Run any command with `--help` to see detailed usage, examples, and available flags.
 
@@ -203,7 +203,7 @@ internal/
   apperr/               Typed error hierarchy with exit codes
   models/               API data structures
   orderbuilder/         Order construction and validation
-  output/               JSON envelope output
+  output/               JSON success envelopes and structured error output
 ```
 
 ## Exit codes
@@ -216,6 +216,8 @@ internal/
 | 3 | Authentication required, expired, or failed |
 | 4 | HTTP error from Schwab API |
 | 5 | Order rejected |
+| 10-19 | structcli input errors, such as missing flags, invalid flag values, and unknown commands |
+| 20-29 | structcli config or environment errors |
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,6 +22,14 @@ metadata:
 
 ## Instructions
 
+## Agent discovery
+
+Run `schwab-agent --jsonschema=tree` first when you need to discover commands, flags, enum values, defaults, config keys, or environment variable bindings. Treat that JSON Schema tree as the authoritative shell command contract. Use this skill file for workflow guidance and examples after choosing the command and flags from the schema.
+
+```bash
+schwab-agent --jsonschema=tree
+```
+
 ### Available Commands
 
 #### `schwab-agent`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: schwab-agent
 description: |
-  CLI tool for AI agents to trade via Schwab APIs. Use when you need to: manage schwab trading accounts. list accounts with nicknames, view account
+  CLI tool for AI agents to trade via Schwab APIs. Use when you need to: manage schwab trading accounts. list compact account summaries with hashes and nicknames, view account
   details, look up account numbers and hash values, set a default account, and
-  query transaction history. account list and get enrich results with nicknames
+  query transaction history. account summary is the token-efficient account picker for agents. account list and get enrich results with nicknames
   from the preferences api (best-effort, degrades gracefully), get details for a single account by hash value. the hash can be passed as a
   positional argument, via --account, or resolved from the default_account
   config. results are enriched with nicknames from the preferences api. use
@@ -69,7 +69,9 @@ schwab-agent account get
 List all linked Schwab accounts with nicknames and settings enriched from
 the preferences API. Use --positions to include current positions for each
 account in the response. Nicknames are loaded best-effort and omitted if
-the preferences API is unavailable.
+the preferences API is unavailable. Agents that only need account hashes,
+nicknames, and primary account markers should use account summary for a smaller
+one-command account picker.
 
 **Flags:**
 
@@ -82,6 +84,20 @@ the preferences API is unavailable.
 ```
 schwab-agent account list
   schwab-agent account list --positions
+```
+
+#### `schwab-agent account summary`
+
+List linked Schwab accounts in a compact, token-efficient shape for agents.
+Each entry includes the account hash required by other commands, the readable
+account number, and best-effort nickname/primary/type data from user preferences.
+Use account list when you need full balances or account list --positions when
+you need the full Schwab account payload with positions.
+
+**Example:**
+
+```bash
+schwab-agent account summary
 ```
 
 #### `schwab-agent account numbers`
@@ -1449,6 +1465,12 @@ schwab-agent account get
 ```
 schwab-agent account list
   schwab-agent account list --positions
+```
+
+#### schwab-agent account summary
+
+```bash
+schwab-agent account summary
 ```
 
 #### schwab-agent account numbers

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -9,14 +9,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/debug"
 	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/spf13/cobra"
 
-	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/commands"
 	"github.com/major/schwab-agent/internal/output"
 )
@@ -27,15 +25,13 @@ var version = "dev"
 func main() {
 	root := buildApp(os.Stdout)
 
-	if err := root.Execute(); err != nil {
-		// Cobra returns plain fmt.Errorf errors for unknown commands. Wrap them
-		// in ValidationError so the JSON output uses VALIDATION_ERROR instead of
-		// UNKNOWN, which is more useful for agents parsing the output.
-		if strings.HasPrefix(err.Error(), "unknown command") {
-			err = apperr.NewValidationError(err.Error(), err)
+	cmd, err := structcli.ExecuteC(root)
+	if err != nil {
+		exitCode, writeErr := output.WriteCommandError(os.Stdout, cmd, err)
+		if writeErr != nil {
+			os.Exit(1)
 		}
-		_ = output.WriteError(os.Stdout, err)
-		os.Exit(apperr.ExitCodeFor(err))
+		os.Exit(exitCode)
 	}
 }
 

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/leodido/structcli"
 	structclimcp "github.com/leodido/structcli/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func runApp(t *testing.T, args ...string) (string, error) {
 	app.SetErr(&stdout)
 	app.SetArgs(cobraArgs(args))
 
-	err := app.Execute()
+	_, err := structcli.ExecuteC(app)
 
 	return stdout.String(), err
 }
@@ -82,7 +83,7 @@ func runAppWithDeps(t *testing.T, deps commands.RootDeps, args ...string) (strin
 	app.SetErr(&stdout)
 	app.SetArgs(cobraArgs(args))
 
-	err := app.Execute()
+	_, err := structcli.ExecuteC(app)
 
 	return stdout.String(), err
 }
@@ -94,6 +95,61 @@ func cobraArgs(args []string) []string {
 	}
 
 	return args
+}
+
+// schemaByTitle indexes the --jsonschema=tree output by command title.
+func schemaByTitle(t *testing.T, stdout string) map[string]map[string]any {
+	t.Helper()
+
+	var schemas []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &schemas))
+	require.NotEmpty(t, schemas)
+
+	byTitle := make(map[string]map[string]any, len(schemas))
+	for _, schema := range schemas {
+		title, ok := schema["title"].(string)
+		require.True(t, ok, "schema entry is missing a string title: %#v", schema)
+		byTitle[title] = schema
+	}
+
+	return byTitle
+}
+
+// schemaStrings returns a string slice from a schema array field.
+func schemaStrings(t *testing.T, schema map[string]any, key string) []string {
+	t.Helper()
+
+	values, ok := schema[key].([]any)
+	require.True(t, ok, "schema %q field is not an array", key)
+
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		stringValue, ok := value.(string)
+		require.True(t, ok, "schema %q field contains a non-string value: %#v", key, value)
+		result = append(result, stringValue)
+	}
+
+	return result
+}
+
+// schemaProperties returns the JSON Schema properties map for a command schema.
+func schemaProperties(t *testing.T, schema map[string]any) map[string]any {
+	t.Helper()
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema entry is missing properties: %#v", schema)
+
+	return properties
+}
+
+// schemaProperty returns a single named flag property from a command schema.
+func schemaProperty(t *testing.T, schema map[string]any, name string) map[string]any {
+	t.Helper()
+
+	property, ok := schemaProperties(t, schema)[name].(map[string]any)
+	require.True(t, ok, "schema entry is missing property %q", name)
+
+	return property
 }
 
 // writeTestConfig persists a valid auth config for Before hook tests.
@@ -150,7 +206,7 @@ func TestSkipAuth_HelpTopic(t *testing.T) {
 	var buf bytes.Buffer
 	app := buildAppWithDeps(&buf, commands.RootDeps{})
 	app.SetArgs([]string{"env-vars"})
-	err := app.Execute()
+	_, err := structcli.ExecuteC(app)
 	require.NoError(t, err)
 
 	// Verify output contains help topic content.
@@ -549,7 +605,7 @@ func runMCP(t *testing.T, requests ...string) (string, error) {
 	app.SetOut(&stdout)
 	app.SetArgs([]string{"--mcp"})
 
-	err := app.Execute()
+	_, err := structcli.ExecuteC(app)
 
 	return stdout.String(), err
 }
@@ -565,7 +621,7 @@ func runMCPWithDeps(t *testing.T, deps commands.RootDeps, requests ...string) (s
 	app.SetOut(&stdout)
 	app.SetArgs([]string{"--mcp"})
 
-	err := app.Execute()
+	_, err := structcli.ExecuteC(app)
 
 	return stdout.String(), err
 }

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -180,6 +180,50 @@ func TestBuildApp_AllCommandsPresent(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaTreeIsCanonicalDiscoveryContract(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	stdout, err := runApp(t, "schwab-agent", "--jsonschema=tree")
+	require.NoError(t, err)
+
+	schemas := schemaByTitle(t, stdout)
+	rootSchema := schemas["schwab-agent"]
+	require.NotNil(t, rootSchema)
+
+	assert.Subset(t, schemaStrings(t, rootSchema, "x-structcli-subcommands"), []string{
+		"account",
+		"auth",
+		"chain",
+		"history",
+		"instrument",
+		"market",
+		"order",
+		"position",
+		"quote",
+		"symbol",
+		"ta",
+	})
+	assert.Equal(t, "a", schemaProperty(t, rootSchema, "account")["x-structcli-shorthand"])
+	assert.Equal(t, "v", schemaProperty(t, rootSchema, "verbose")["x-structcli-shorthand"])
+	assert.Contains(t, schemaProperties(t, rootSchema), "config")
+	assert.Contains(t, schemaProperties(t, rootSchema), "token")
+
+	symbolBuildSchema := schemas["schwab-agent symbol build"]
+	require.NotNil(t, symbolBuildSchema)
+	assert.Subset(t, schemaStrings(t, symbolBuildSchema, "required"), []string{"expiration", "strike", "underlying"})
+
+	equitySchema := schemas["schwab-agent order build equity"]
+	require.NotNil(t, equitySchema)
+	assert.Subset(t, schemaStrings(t, equitySchema, "required"), []string{"action", "quantity", "symbol"})
+	assert.Subset(t, schemaStrings(t, schemaProperty(t, equitySchema, "action"), "enum"), []string{"BUY", "SELL"})
+	assert.Subset(t, schemaStrings(t, schemaProperty(t, equitySchema, "type"), "enum"), []string{"LIMIT", "MARKET"})
+
+	taSchema := schemas["schwab-agent ta sma"]
+	require.NotNil(t, taSchema)
+	assert.Equal(t, "daily", schemaProperty(t, taSchema, "interval")["default"])
+	assert.Subset(t, schemaStrings(t, schemaProperty(t, taSchema, "interval"), "enum"), []string{"1min", "daily", "weekly"})
+}
+
 func TestBeforeHook_SkipsAuthForAuthCommand(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 

--- a/internal/client/AGENTS.md
+++ b/internal/client/AGENTS.md
@@ -23,7 +23,7 @@ WithTLSConfig applies a custom TLS configuration to the resty client's transport
 ## Adding a New Endpoint
 
 1. Create `<resource>.go` with methods on `*Client`
-2. Use the appropriate HTTP helper: `doGet`, `doPost`, `doPut`, `doDelete`
+2. Use the appropriate HTTP helper: `doGet`, `doPost`, `doDelete`, or call `doRequest` directly when the endpoint needs a method-specific response header or status-code quirk
 3. Create `<resource>_test.go` with httptest-based tests
 4. Define any new request/response types in `internal/models/`
 
@@ -33,7 +33,6 @@ Core method `doRequest` uses resty v3 internally. It sets the Bearer token via r
 
 - `doGet(ctx, path, params, result)`: GET with query params
 - `doPost(ctx, path, body, result)`: POST with JSON body
-- `doPut(ctx, path, body, result)`: PUT with JSON body
 - `doDelete(ctx, path, result)`: DELETE
 
 Content-Type header is set by resty only when a request body is present (not on GET). Accept: application/json is set globally on the resty client.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -207,11 +207,6 @@ func (c *Client) doPost(ctx context.Context, path string, body, result any) erro
 	return c.doRequest(ctx, http.MethodPost, path, body, result)
 }
 
-// doPut performs a PUT request with JSON body.
-func (c *Client) doPut(ctx context.Context, path string, body, result any) error {
-	return c.doRequest(ctx, http.MethodPut, path, body, result)
-}
-
 // doDelete performs a DELETE request.
 func (c *Client) doDelete(ctx context.Context, path string, result any) error {
 	return c.doRequest(ctx, http.MethodDelete, path, nil, result)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -187,30 +187,6 @@ func TestDoPost_NilBody(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDoPut_JSONBody(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-		assert.Equal(t, http.MethodPut, r.Method)
-
-		var body testRequestBody
-		err := json.NewDecoder(r.Body).Decode(&body)
-		require.NoError(t, err)
-		assert.Equal(t, "MSFT", body.Symbol)
-
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	c := NewClient("tok", WithBaseURL(srv.URL))
-	err := c.doPut(context.Background(), "/orders/123", testRequestBody{
-		Symbol:   "MSFT",
-		Quantity: 5,
-		Price:    300.00,
-	}, nil)
-
-	require.NoError(t, err)
-}
-
 func TestDoDelete(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)

--- a/internal/client/orders.go
+++ b/internal/client/orders.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"net/url"
+	pathpkg "path"
 	"strconv"
 	"strings"
 
@@ -39,6 +41,41 @@ func (p OrderListParams) toQueryParams() map[string]string {
 // PlaceOrderResponse contains the result of a successful order placement.
 type PlaceOrderResponse struct {
 	OrderID int64
+}
+
+// ReplaceOrderResponse contains the best order ID Schwab exposes after a
+// successful replacement. Schwab may return the new replacement order in the
+// Location header; older/proxied responses sometimes omit it, so callers can
+// fall back to the original order ID they asked to replace.
+type ReplaceOrderResponse struct {
+	OrderID int64
+}
+
+// orderIDFromLocation extracts the trailing order ID from a Schwab Location
+// header such as /trader/v1/accounts/{hash}/orders/12345.
+//
+// Schwab usually returns a relative path, but proxies and future API changes may
+// legally produce an absolute URL, query string, or trailing slash. Parse the
+// header as a URL first so a successful mutation is not reported as failed just
+// because the Location format is slightly different.
+func orderIDFromLocation(location string) (int64, error) {
+	parsedURL, err := url.Parse(location)
+	if err != nil {
+		return 0, fmt.Errorf("parse Location header %q: %w", location, err)
+	}
+
+	locationPath := strings.TrimRight(parsedURL.Path, "/")
+	if locationPath == "" {
+		return 0, fmt.Errorf("parse order ID from Location header %q: missing order ID", location)
+	}
+
+	orderIDStr := pathpkg.Base(locationPath)
+	parsedID, err := strconv.ParseInt(orderIDStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse order ID from Location header %q: %w", location, err)
+	}
+
+	return parsedID, nil
 }
 
 // fetchOrders retrieves orders from the given path, fanning out one API call
@@ -167,11 +204,9 @@ func (c *Client) PlaceOrder(ctx context.Context, hashValue string, order *models
 		return &PlaceOrderResponse{}, nil
 	}
 
-	parts := strings.Split(location, "/")
-	orderIDStr := parts[len(parts)-1]
-	parsedID, err := strconv.ParseInt(orderIDStr, 10, 64)
+	parsedID, err := orderIDFromLocation(location)
 	if err != nil {
-		return nil, fmt.Errorf("parse order ID from Location header %q: %w", location, err)
+		return nil, err
 	}
 
 	return &PlaceOrderResponse{OrderID: parsedID}, nil
@@ -188,9 +223,55 @@ func (c *Client) PreviewOrder(ctx context.Context, hashValue string, order *mode
 }
 
 // ReplaceOrder replaces an existing order with a new order specification.
-func (c *Client) ReplaceOrder(ctx context.Context, hashValue string, orderID int64, order *models.OrderRequest) error {
+func (c *Client) ReplaceOrder(ctx context.Context, hashValue string, orderID int64, order *models.OrderRequest) (*ReplaceOrderResponse, error) {
 	path := fmt.Sprintf("/trader/v1/accounts/%s/orders/%d", hashValue, orderID)
-	return c.doPut(ctx, path, order, nil)
+
+	encoded, err := json.Marshal(order)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body: %w", err)
+	}
+
+	c.logger.Debug("http request", "method", http.MethodPut, "path", path)
+
+	resp, err := c.resty.R().
+		SetContext(ctx).
+		SetHeader("Content-Type", "application/json").
+		SetBody(encoded).
+		Execute(http.MethodPut, path)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+
+	respBody := resp.Bytes()
+	if resp.StatusCode() == http.StatusUnauthorized {
+		return nil, apperr.NewAuthExpiredError("authentication expired", nil)
+	}
+	if resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusUnprocessableEntity {
+		return nil, apperr.NewOrderRejectedError(
+			fmt.Sprintf("order rejected: %s", string(respBody)),
+			nil,
+		)
+	}
+	if resp.StatusCode() >= 400 {
+		return nil, apperr.NewHTTPError(
+			fmt.Sprintf("HTTP %d", resp.StatusCode()),
+			resp.StatusCode(),
+			string(respBody),
+			nil,
+		)
+	}
+
+	location := resp.Header().Get("Location")
+	if location == "" {
+		return &ReplaceOrderResponse{OrderID: orderID}, nil
+	}
+
+	replacementID, err := orderIDFromLocation(location)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReplaceOrderResponse{OrderID: replacementID}, nil
 }
 
 // CancelOrder cancels an existing order.

--- a/internal/client/orders_test.go
+++ b/internal/client/orders_test.go
@@ -267,6 +267,51 @@ func TestPlaceOrder_Success(t *testing.T) {
 	assert.Equal(t, int64(67890), result.OrderID)
 }
 
+func TestOrderIDFromLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     int64
+	}{
+		{
+			name:     "relative path",
+			location: "/trader/v1/accounts/abc123/orders/67890",
+			want:     67890,
+		},
+		{
+			name:     "absolute URL",
+			location: "https://api.schwabapi.com/trader/v1/accounts/abc123/orders/67890",
+			want:     67890,
+		},
+		{
+			name:     "trailing slash",
+			location: "/trader/v1/accounts/abc123/orders/67890/",
+			want:     67890,
+		},
+		{
+			name:     "query string",
+			location: "/trader/v1/accounts/abc123/orders/67890?source=proxy",
+			want:     67890,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := orderIDFromLocation(tt.location)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOrderIDFromLocation_MissingOrderID(t *testing.T) {
+	_, err := orderIDFromLocation("https://api.schwabapi.com/")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing order ID")
+}
+
 func TestPlaceOrder_400_ReturnsOrderRejectedError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -361,14 +406,33 @@ func TestReplaceOrder_Success(t *testing.T) {
 		require.Len(t, req.OrderLegCollection, 1)
 		assert.Equal(t, "AAPL", req.OrderLegCollection[0].Instrument.Symbol)
 
+		w.Header().Set("Location", "/trader/v1/accounts/abc123/orders/67890")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
 	c := NewClient("test-token", WithBaseURL(srv.URL))
-	err := c.ReplaceOrder(context.Background(), "abc123", 12345, testOrderRequest())
+	resp, err := c.ReplaceOrder(context.Background(), "abc123", 12345, testOrderRequest())
 
 	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int64(67890), resp.OrderID)
+}
+
+func TestReplaceOrder_NoLocationHeaderFallsBackToOriginalOrderID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		assert.Equal(t, "/trader/v1/accounts/abc123/orders/12345", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient("test-token", WithBaseURL(srv.URL))
+	resp, err := c.ReplaceOrder(context.Background(), "abc123", 12345, testOrderRequest())
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int64(12345), resp.OrderID)
 }
 
 func TestCancelOrder_Success(t *testing.T) {
@@ -515,7 +579,7 @@ func TestReplaceOrder_APIError(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClient("test-token", WithBaseURL(srv.URL))
-	err := c.ReplaceOrder(context.Background(), "abc123", 12345, testOrderRequest())
+	_, err := c.ReplaceOrder(context.Background(), "abc123", 12345, testOrderRequest())
 
 	require.Error(t, err)
 

--- a/internal/commands/AGENTS.md
+++ b/internal/commands/AGENTS.md
@@ -120,7 +120,7 @@ Build tags: `//go:build task16` (auth), `//go:build task17` (account), etc.
 | File | Command | Subcommands |
 |---|---|---|
 | auth.go | auth | login, status, refresh |
-| account.go | account | list, get, numbers, set-default, transaction (list, get) |
+| account.go | account | summary, list, get, numbers, set-default, transaction (list, get) |
 | position.go | position | list (--all-accounts, --account) |
 | quote.go | quote | get |
 | order.go | order | list, get |

--- a/internal/commands/account.go
+++ b/internal/commands/account.go
@@ -27,6 +27,24 @@ type accountNumbersData struct {
 	Accounts []models.AccountNumber `json:"accounts"`
 }
 
+// accountSummaryData wraps a compact account list for agents that need a
+// one-command account picker instead of the full Schwab account payload.
+type accountSummaryData struct {
+	Accounts []accountSummaryEntry `json:"accounts"`
+}
+
+// accountSummaryEntry combines the hash values required by downstream commands
+// with the human-friendly labels stored in Schwab user preferences. Keeping this
+// shape small avoids forcing LLMs to inspect the large balance payload returned
+// by account list just to choose an account.
+type accountSummaryEntry struct {
+	AccountHash    string  `json:"accountHash"`
+	AccountNumber  string  `json:"accountNumber"`
+	NickName       *string `json:"nickName,omitempty"`
+	PrimaryAccount *bool   `json:"primaryAccount,omitempty"`
+	Type           *string `json:"type,omitempty"`
+}
+
 // transactionListData wraps the transaction list response.
 type transactionListData struct {
 	Transactions []models.Transaction `json:"transactions"`
@@ -116,8 +134,42 @@ func enrichAccountsWithPreferences(accounts []models.Account, prefs *models.User
 	}
 }
 
+// summarizeAccounts creates the compact account shape used by account summary.
+// The accountNumbers endpoint is the source of truth for hashes, while
+// userPreference is the only Schwab endpoint that exposes nicknames and primary
+// account flags. They must be joined client-side by plain account number.
+func summarizeAccounts(numbers []models.AccountNumber, prefs *models.UserPreference) []accountSummaryEntry {
+	prefMap := make(map[string]*models.UserPreferenceAccount)
+	if prefs != nil {
+		prefMap = make(map[string]*models.UserPreferenceAccount, len(prefs.Accounts))
+		for i := range prefs.Accounts {
+			if prefs.Accounts[i].AccountNumber != nil {
+				prefMap[*prefs.Accounts[i].AccountNumber] = &prefs.Accounts[i]
+			}
+		}
+	}
+
+	entries := make([]accountSummaryEntry, 0, len(numbers))
+	for _, number := range numbers {
+		entry := accountSummaryEntry{
+			AccountHash:   number.HashValue,
+			AccountNumber: number.AccountNumber,
+		}
+
+		if pref, ok := prefMap[number.AccountNumber]; ok {
+			entry.NickName = pref.NickName
+			entry.PrimaryAccount = pref.PrimaryAccount
+			entry.Type = pref.Type
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
 // NewAccountCmd returns the Cobra parent command for account operations.
-// Subcommands: list, get, numbers, set-default, transaction.
+// Subcommands: summary, list, get, numbers, set-default, transaction.
 // The --account persistent flag overrides the default account hash for all subcommands.
 func NewAccountCmd(c *client.Ref, configPath string, w io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -135,6 +187,7 @@ from the preferences API (best-effort, degrades gracefully).`,
 	cmd.PersistentFlags().String("account", "", "Account hash to use (overrides config default)")
 
 	cmd.AddCommand(
+		newAccountSummaryCmd(c, w),
 		newAccountListCmd(c, w),
 		newAccountGetCmd(c, configPath, w),
 		newAccountNumbersCmd(c, w),
@@ -143,6 +196,43 @@ from the preferences API (best-effort, degrades gracefully).`,
 	)
 
 	return cmd
+}
+
+// newAccountSummaryCmd returns a compact account picker for agents.
+func newAccountSummaryCmd(c *client.Ref, w io.Writer) *cobra.Command {
+	return &cobra.Command{
+		Use:   "summary",
+		Short: "List compact account identifiers for agents",
+		Long: `List linked Schwab accounts in a compact, token-efficient shape for agents.
+Each entry includes the account hash required by other commands, the readable
+account number, and best-effort nickname/primary/type data from user preferences.
+Use account list when you need full balances or account list --positions when
+you need the full Schwab account payload with positions.`,
+		Example: "  schwab-agent account summary",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			numbers, err := c.AccountNumbers(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			var prefs *models.UserPreference
+			if len(numbers) > 0 {
+				// Preferences are best-effort: hashes are enough for the command to be
+				// useful, and failing this auxiliary call should not force the agent
+				// back into running multiple commands.
+				loadedPrefs, prefsErr := c.UserPreference(cmd.Context())
+				if prefsErr == nil {
+					prefs = loadedPrefs
+				}
+			}
+
+			accounts := summarizeAccounts(numbers, prefs)
+			meta := output.NewMetadata()
+			meta.Returned = len(accounts)
+
+			return output.WriteSuccess(w, accountSummaryData{Accounts: accounts}, meta)
+		},
+	}
 }
 
 // newAccountListCmd returns the Cobra subcommand for listing all accounts.
@@ -154,7 +244,9 @@ func newAccountListCmd(c *client.Ref, w io.Writer) *cobra.Command {
 		Long: `List all linked Schwab accounts with nicknames and settings enriched from
 the preferences API. Use --positions to include current positions for each
 account in the response. Nicknames are loaded best-effort and omitted if
-the preferences API is unavailable.`,
+the preferences API is unavailable. Agents that only need account hashes,
+nicknames, and primary account markers should use account summary for a smaller
+one-command account picker.`,
 		Example: `  schwab-agent account list
   schwab-agent account list --positions`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -228,18 +320,18 @@ config. Results are enriched with nicknames from the preferences API. Use
 				return err
 			}
 
-		// Enrich with nickname from user preferences (best-effort).
-		prefs, prefsErr := c.UserPreference(cmd.Context())
-		if prefsErr == nil {
-			accounts := []models.Account{*account}
-			enrichAccountsWithPreferences(accounts, prefs)
-			account = &accounts[0]
-		}
+			// Enrich with nickname from user preferences (best-effort).
+			prefs, prefsErr := c.UserPreference(cmd.Context())
+			if prefsErr == nil {
+				accounts := []models.Account{*account}
+				enrichAccountsWithPreferences(accounts, prefs)
+				account = &accounts[0]
+			}
 
-		meta := output.NewMetadata()
-		meta.Account = hash
+			meta := output.NewMetadata()
+			meta.Account = hash
 
-		return output.WriteSuccess(w, account, meta)
+			return output.WriteSuccess(w, account, meta)
 		},
 	}
 

--- a/internal/commands/account_test.go
+++ b/internal/commands/account_test.go
@@ -274,6 +274,169 @@ func TestNewAccountCmd_Numbers_Success(t *testing.T) {
 	assert.Len(t, accountList, 2)
 }
 
+func TestNewAccountCmd_Summary_Success(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			_, _ = w.Write([]byte(`[
+				{"accountNumber":"12345","hashValue":"HASH_ABC"},
+				{"accountNumber":"67890","hashValue":"HASH_DEF"}
+			]`))
+		case "/trader/v1/userPreference":
+			_, _ = w.Write([]byte(`{"accounts":[
+				{"accountNumber":"12345","nickName":"My IRA","primaryAccount":true,"type":"MARGIN"},
+				{"accountNumber":"67890","nickName":"Joint Taxable","primaryAccount":false,"type":"CASH"}
+			]}`))
+		case "/trader/v1/accounts":
+			t.Errorf("account summary should not fetch the full account payload")
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), "", &buf)
+	_, err := runTestCommand(t, cmd, "summary")
+
+	// Assert
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.NotEmpty(t, env.Metadata.Timestamp)
+	assert.Equal(t, 2, env.Metadata.Returned)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+
+	accountList, ok := dataMap["accounts"].([]any)
+	require.True(t, ok)
+	require.Len(t, accountList, 2)
+
+	first, ok := accountList[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "HASH_ABC", first["accountHash"])
+	assert.Equal(t, "12345", first["accountNumber"])
+	assert.Equal(t, "My IRA", first["nickName"])
+	assert.Equal(t, true, first["primaryAccount"])
+	assert.Equal(t, "MARGIN", first["type"])
+
+	second, ok := accountList[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "HASH_DEF", second["accountHash"])
+	assert.Equal(t, "67890", second["accountNumber"])
+	assert.Equal(t, "Joint Taxable", second["nickName"])
+	assert.Equal(t, false, second["primaryAccount"])
+	assert.Equal(t, "CASH", second["type"])
+}
+
+func TestNewAccountCmd_Summary_PreferencesFailure_StillReturnsHashes(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"accountNumber":"12345","hashValue":"HASH_ABC"}]`))
+		case "/trader/v1/userPreference":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/trader/v1/accounts":
+			t.Errorf("account summary should not fetch the full account payload")
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), "", &buf)
+	_, err := runTestCommand(t, cmd, "summary")
+
+	// Assert
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+
+	accountList, ok := dataMap["accounts"].([]any)
+	require.True(t, ok)
+	require.Len(t, accountList, 1)
+
+	first, ok := accountList[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "HASH_ABC", first["accountHash"])
+	assert.Equal(t, "12345", first["accountNumber"])
+	assert.NotContains(t, first, "nickName")
+	assert.NotContains(t, first, "primaryAccount")
+	assert.NotContains(t, first, "type")
+}
+
+func TestNewAccountCmd_Summary_EmptyAccountsSkipsPreferences(t *testing.T) {
+	// Arrange
+	var preferenceRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		case "/trader/v1/userPreference":
+			preferenceRequests++
+			t.Errorf("empty account summary should not fetch preferences")
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), "", &buf)
+	_, err := runTestCommand(t, cmd, "summary")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 0, preferenceRequests)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, 0, env.Metadata.Returned)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+	accountList, ok := dataMap["accounts"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, accountList)
+}
+
+func TestNewAccountCmd_Summary_AccountNumbersError(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/trader/v1/accounts/accountNumbers", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server error"}`))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), "", &buf)
+	_, err := runTestCommand(t, cmd, "summary")
+
+	// Assert
+	require.Error(t, err)
+	_, ok := errors.AsType[*apperr.HTTPError](err)
+	assert.True(t, ok)
+}
+
 func TestNewAccountCmd_Get_WithPositionsFlag(t *testing.T) {
 	// Arrange
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/commands/order_place.go
+++ b/internal/commands/order_place.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -13,27 +14,24 @@ import (
 	"github.com/major/schwab-agent/internal/output"
 )
 
-// orderPlaceData wraps a successful order placement response.
-type orderPlaceData struct {
-	OrderID int64 `json:"orderId"`
+// orderActionData wraps a successful mutable order response.
+//
+// Schwab's mutation endpoints return little useful body data, so the CLI follows
+// up with a GET and returns the canonical order shape agents already consume
+// from `order get`. OrderID stays in the wrapper as a small convenience and as a
+// fallback for rare Schwab/proxy responses that accept the mutation without an
+// order Location header.
+type orderActionData struct {
+	OrderID  int64         `json:"orderId"`
+	Canceled bool          `json:"canceled,omitempty"`
+	Replaced bool          `json:"replaced,omitempty"`
+	Order    *models.Order `json:"order,omitempty"`
 }
 
 // orderPreviewData wraps an order preview response.
 type orderPreviewData struct {
 	Preview *models.PreviewOrder `json:"preview"`
 	OrderID *int64               `json:"orderId,omitempty"`
-}
-
-// orderCancelData wraps a successful order cancellation response.
-type orderCancelData struct {
-	OrderID  int64 `json:"orderId"`
-	Canceled bool  `json:"canceled"`
-}
-
-// orderReplaceData wraps a successful order replacement response.
-type orderReplaceData struct {
-	OrderID  int64 `json:"orderId"`
-	Replaced bool  `json:"replaced"`
 }
 
 // orderPlaceOpts holds local flags for top-level spec-based order placement.
@@ -67,6 +65,38 @@ type orderReplaceOpts struct {
 
 // Attach implements structcli.Options interface.
 func (o *orderReplaceOpts) Attach(_ *cobra.Command) error { return nil }
+
+// fetchOrderActionData returns the order details after a successful mutable
+// action. The follow-up GET is deliberately best-effort: once Schwab accepts a
+// mutation, the CLI must not turn that successful trade action into a command
+// failure just because the read-after-write lookup is delayed or unavailable.
+func fetchOrderActionData(cmd *cobra.Command, c *client.Ref, account string, orderID int64) (data orderActionData, errs []string) {
+	data = orderActionData{OrderID: orderID}
+	if orderID == 0 {
+		return data, []string{"order details unavailable: Schwab accepted the order action but did not return an order ID"}
+	}
+
+	order, err := c.GetOrder(cmd.Context(), account, orderID)
+	if err != nil {
+		return data, []string{fmt.Sprintf("order details unavailable after successful order action: %v", err)}
+	}
+
+	data.Order = order
+	return data, nil
+}
+
+// writeOrderActionResult emits a normal success envelope when the canonical
+// order lookup succeeds, or a partial envelope when Schwab accepted the mutation
+// but the follow-up details could not be fetched. That distinction lets agents
+// trust the order action occurred while still seeing why `data.order` is absent.
+func writeOrderActionResult(w io.Writer, data orderActionData, errs []string) error {
+	metadata := output.NewMetadata()
+	if len(errs) > 0 {
+		return output.WritePartial(w, data, errs, metadata)
+	}
+
+	return output.WriteSuccess(w, data, metadata)
+}
 
 // newOrderPlaceCmd places new orders from either flags or a JSON spec.
 func newOrderPlaceCmd(c *client.Ref, configPath string, w io.Writer) *cobra.Command {
@@ -125,7 +155,8 @@ order build, preview it with order preview, then place.`,
 				return err
 			}
 
-			return output.WriteSuccess(w, orderPlaceData{OrderID: response.OrderID}, output.NewMetadata())
+			data, errs := fetchOrderActionData(cmd, c, account, response.OrderID)
+			return writeOrderActionResult(w, data, errs)
 		},
 	}
 
@@ -254,7 +285,8 @@ func makeCobraPlaceOrderCommand[O any, P any](
 				return err
 			}
 
-			return output.WriteSuccess(w, orderPlaceData{OrderID: response.OrderID}, output.NewMetadata())
+			data, errs := fetchOrderActionData(cmd, c, account, response.OrderID)
+			return writeOrderActionResult(w, data, errs)
 		},
 	}
 	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
@@ -365,7 +397,9 @@ config flag. The order ID can be passed as a positional argument or with
 				return err
 			}
 
-			return output.WriteSuccess(w, orderCancelData{OrderID: orderID, Canceled: true}, output.NewMetadata())
+			data, errs := fetchOrderActionData(cmd, c, account, orderID)
+			data.Canceled = true
+			return writeOrderActionResult(w, data, errs)
 		},
 	}
 
@@ -438,11 +472,14 @@ original order status becomes REPLACED after the new order is created.`,
 				return err
 			}
 
-			if err := c.ReplaceOrder(cmd.Context(), account, orderID, order); err != nil {
+			response, err := c.ReplaceOrder(cmd.Context(), account, orderID, order)
+			if err != nil {
 				return err
 			}
 
-			return output.WriteSuccess(w, orderReplaceData{OrderID: orderID, Replaced: true}, output.NewMetadata())
+			data, errs := fetchOrderActionData(cmd, c, account, response.OrderID)
+			data.Replaced = true
+			return writeOrderActionResult(w, data, errs)
 		},
 	}
 	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -112,6 +112,28 @@ func mustMarshalJSON(t *testing.T, value any) string {
 	return string(encoded)
 }
 
+// writeTestOrderResponse writes a compact order fixture for action command tests.
+func writeTestOrderResponse(t *testing.T, w http.ResponseWriter, orderID int64, status models.OrderStatus, symbol string) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	response := models.Order{
+		OrderID:           &orderID,
+		Status:            &status,
+		OrderType:         models.OrderTypeLimit,
+		OrderStrategyType: models.OrderStrategyTypeSingle,
+		OrderLegCollection: []models.OrderLegCollection{{
+			Instruction: models.InstructionBuy,
+			Quantity:    10,
+			Instrument: models.OrderInstrument{
+				AssetType: models.AssetTypeEquity,
+				Symbol:    symbol,
+			},
+		}},
+	}
+	require.NoError(t, json.NewEncoder(w).Encode(response))
+}
+
 func TestNewOrderCmdPreviewSpecModes(t *testing.T) {
 	t.Parallel()
 
@@ -224,15 +246,20 @@ func TestNewOrderCmdPlaceEquityPipeline(t *testing.T) {
 
 	var received models.OrderRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/default-hash/orders", r.URL.Path)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/trader/v1/accounts/default-hash/orders":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &received))
 
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &received))
-
-		w.Header().Set("Location", "/trader/v1/accounts/default-hash/orders/67890")
-		w.WriteHeader(http.StatusCreated)
+			w.Header().Set("Location", "/trader/v1/accounts/default-hash/orders/67890")
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/default-hash/orders/67890":
+			writeTestOrderResponse(t, w, 67890, models.OrderStatusQueued, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -266,6 +293,10 @@ func TestNewOrderCmdPlaceEquityPipeline(t *testing.T) {
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(67890), data["orderId"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(67890), order["orderId"])
+	assert.Equal(t, "QUEUED", order["status"])
 	assert.NotEmpty(t, envelope.Metadata.Timestamp)
 }
 
@@ -274,15 +305,20 @@ func TestNewOrderCmdPlaceSpecFromFile(t *testing.T) {
 
 	var received models.OrderRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/hash123/orders", r.URL.Path)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/trader/v1/accounts/hash123/orders":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &received))
 
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &received))
-
-		w.Header().Set("Location", "/trader/v1/accounts/hash123/orders/24680")
-		w.WriteHeader(http.StatusCreated)
+			w.Header().Set("Location", "/trader/v1/accounts/hash123/orders/24680")
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/24680":
+			writeTestOrderResponse(t, w, 24680, models.OrderStatusQueued, "MSFT")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -308,6 +344,52 @@ func TestNewOrderCmdPlaceSpecFromFile(t *testing.T) {
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(24680), data["orderId"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(24680), order["orderId"])
+	assert.Equal(t, "QUEUED", order["status"])
+}
+
+func TestNewOrderCmdPlaceNoLocationReturnsPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	var getRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/trader/v1/accounts/hash123/orders":
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet:
+			getRequests++
+			t.Errorf("unexpected follow-up GET without an order ID: %s", r.URL.Path)
+			http.NotFound(w, r)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfigMutable(t, "hash123")
+	cliClient := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(server.URL))}
+	orderRequest, err := orderbuilder.BuildEquityOrder(&orderbuilder.EquityParams{
+		Symbol:    "MSFT",
+		Action:    models.InstructionBuy,
+		Quantity:  2,
+		OrderType: models.OrderTypeMarket,
+	})
+	require.NoError(t, err)
+
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "place", "--spec", mustMarshalJSON(t, orderRequest))
+	require.NoError(t, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(0), data["orderId"])
+	assert.NotContains(t, data, "order")
+	assert.Equal(t, 0, getRequests)
+	require.Len(t, envelope.Errors, 1)
+	assert.Contains(t, envelope.Errors[0], "did not return an order ID")
 }
 
 func TestNewOrderCmdPlaceUnknownFlagSuggestsSubcommand(t *testing.T) {
@@ -497,15 +579,20 @@ func TestNewOrderCmdPlaceOCOPipeline(t *testing.T) {
 
 	var received models.OrderRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/default-hash/orders", r.URL.Path)
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/trader/v1/accounts/default-hash/orders":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &received))
 
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &received))
-
-		w.Header().Set("Location", "/trader/v1/accounts/default-hash/orders/55555")
-		w.WriteHeader(http.StatusCreated)
+			w.Header().Set("Location", "/trader/v1/accounts/default-hash/orders/55555")
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/default-hash/orders/55555":
+			writeTestOrderResponse(t, w, 55555, models.OrderStatusQueued, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -534,6 +621,9 @@ func TestNewOrderCmdPlaceOCOPipeline(t *testing.T) {
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, float64(55555), data["orderId"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(55555), order["orderId"])
 }
 
 // --- Spread build tests (iron condor, vertical, strangle, straddle, covered call) ---
@@ -1864,9 +1954,15 @@ func TestNewOrderCmdCancelSuccess(t *testing.T) {
 
 	// Arrange
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/hash123/orders/12345", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
+			writeTestOrderResponse(t, w, 12345, models.OrderStatusCanceled, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -1883,6 +1979,10 @@ func TestNewOrderCmdCancelSuccess(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, float64(12345), data["orderId"])
 	assert.Equal(t, true, data["canceled"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(12345), order["orderId"])
+	assert.Equal(t, "CANCELED", order["status"])
 }
 
 func TestNewOrderCmdCancelOrderIDFlagSuccess(t *testing.T) {
@@ -1890,9 +1990,15 @@ func TestNewOrderCmdCancelOrderIDFlagSuccess(t *testing.T) {
 
 	// Arrange
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/trader/v1/accounts/hash123/orders/1234567890":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/1234567890":
+			writeTestOrderResponse(t, w, 1234567890, models.OrderStatusCanceled, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -1909,6 +2015,42 @@ func TestNewOrderCmdCancelOrderIDFlagSuccess(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, float64(1234567890), data["orderId"])
 	assert.Equal(t, true, data["canceled"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1234567890), order["orderId"])
+	assert.Equal(t, "CANCELED", order["status"])
+}
+
+func TestNewOrderCmdCancelGetFailureReturnsPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
+			http.Error(w, "eventual consistency", http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	configPath := writeTestConfigMutable(t, "hash123")
+	cliClient := testClient(t, server)
+
+	stdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "cancel", "12345")
+	require.NoError(t, err)
+
+	envelope := decodeEnvelope(t, stdout)
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(12345), data["orderId"])
+	assert.Equal(t, true, data["canceled"])
+	assert.NotContains(t, data, "order")
+	require.Len(t, envelope.Errors, 1)
+	assert.Contains(t, envelope.Errors[0], "order details unavailable")
 }
 
 func TestNewOrderCmdCancelMutableDisabled(t *testing.T) {
@@ -1959,14 +2101,20 @@ func TestNewOrderCmdReplaceSuccess(t *testing.T) {
 	// Arrange
 	var received models.OrderRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/hash123/orders/12345", r.URL.Path)
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &received))
 
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &received))
-
-		w.WriteHeader(http.StatusOK)
+			w.Header().Set("Location", "/trader/v1/accounts/hash123/orders/67890")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/67890":
+			writeTestOrderResponse(t, w, 67890, models.OrderStatusQueued, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -2001,8 +2149,12 @@ func TestNewOrderCmdReplaceSuccess(t *testing.T) {
 	envelope := decodeEnvelope(t, stdout)
 	data, ok := envelope.Data.(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, float64(12345), data["orderId"])
+	assert.Equal(t, float64(67890), data["orderId"])
 	assert.Equal(t, true, data["replaced"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(67890), order["orderId"])
+	assert.Equal(t, "QUEUED", order["status"])
 }
 
 func TestNewOrderCmdReplaceOrderIDFlagSuccess(t *testing.T) {
@@ -2010,9 +2162,15 @@ func TestNewOrderCmdReplaceOrderIDFlagSuccess(t *testing.T) {
 
 	// Arrange
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPut, r.Method)
-		assert.Equal(t, "/trader/v1/accounts/hash123/orders/1234567890", r.URL.Path)
-		w.WriteHeader(http.StatusOK)
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/trader/v1/accounts/hash123/orders/1234567890":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/1234567890":
+			writeTestOrderResponse(t, w, 1234567890, models.OrderStatusReplaced, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
 	}))
 	defer server.Close()
 
@@ -2043,6 +2201,10 @@ func TestNewOrderCmdReplaceOrderIDFlagSuccess(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, float64(1234567890), data["orderId"])
 	assert.Equal(t, true, data["replaced"])
+	order, ok := data["order"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1234567890), order["orderId"])
+	assert.Equal(t, "REPLACED", order["status"])
 }
 
 func TestNewOrderCmdReplaceMutableDisabled(t *testing.T) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -2,11 +2,16 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
+
+	"github.com/leodido/structcli"
+	"github.com/spf13/cobra"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
@@ -33,17 +38,10 @@ type Envelope struct {
 	Metadata Metadata `json:"metadata"`
 }
 
-// ErrorEnvelope is the standard JSON response wrapper for error responses.
-type ErrorEnvelope struct {
-	Error ErrorDetail `json:"error"`
-}
-
-// ErrorDetail contains error code, message, and optional details.
-type ErrorDetail struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-	Details string `json:"details,omitempty"`
-}
+// ErrorEnvelope is kept as a compatibility alias for tests and callers that
+// decode errors through this package type. Error responses now use structcli's
+// top-level StructuredError contract instead of the legacy nested envelope.
+type ErrorEnvelope = structcli.StructuredError
 
 // WriteSuccess writes a successful response with data and metadata to the writer.
 // The response is formatted as a JSON envelope with data and metadata fields.
@@ -58,38 +56,181 @@ func WriteSuccess(w io.Writer, data any, metadata Metadata) error {
 }
 
 // WriteError writes an error response to the writer.
-// It maps the error type to an appropriate error code string using apperr.ErrorCode().
-// The response is formatted as a JSON envelope with error details.
+// The response uses structcli's top-level StructuredError contract so agents
+// can parse one stable schema for both Schwab-domain and flag/config errors.
 func WriteError(w io.Writer, err error) error {
-	code := apperr.ErrorCode(err)
-	message := err.Error()
+	_, writeErr := WriteCommandError(w, nil, err)
+	return writeErr
+}
 
-	// Extract details from specific error types
-	var details string
-	if schwabErr, ok := errors.AsType[*apperr.SchwabError](err); ok {
-		details = schwabErr.Details()
+// WriteCommandError writes an error response and returns the process exit code
+// that should accompany it. Schwab-domain errors are mapped locally so their
+// existing 1-5 exit-code contract stays intact; Cobra and structcli errors are
+// delegated to structcli.HandleError so flag metadata, command paths, enum
+// values, env var hints, and available commands stay as rich as structcli can
+// make them.
+func WriteCommandError(w io.Writer, cmd *cobra.Command, err error) (int, error) {
+	if err == nil {
+		return 0, nil
 	}
 
-	// Include the upstream response body when available so API errors from
-	// Schwab are visible in the CLI output instead of just "status: NNN".
+	if isSchwabDomainError(err) {
+		se := schwabStructuredError(cmd, err)
+		return se.ExitCode, writeStructuredError(w, &se)
+	}
+
+	if cmd != nil {
+		return writeStructCLIError(w, cmd, err)
+	}
+
+	se := structcli.StructuredError{
+		Error:    "error",
+		ExitCode: 1,
+		Message:  err.Error(),
+	}
+	return se.ExitCode, writeStructuredError(w, &se)
+}
+
+// isSchwabDomainError reports whether err belongs to schwab-agent's typed
+// domain hierarchy. structcli has its own ValidationError type, so checking the
+// shared SchwabError base avoids accidentally stealing structcli validation
+// errors away from structcli.HandleError.
+func isSchwabDomainError(err error) bool {
+	if _, ok := errors.AsType[*apperr.AuthRequiredError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.AuthExpiredError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.AuthCallbackError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.OrderRejectedError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.SymbolNotFoundError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.AccountNotFoundError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.HTTPError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.ValidationError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.OrderBuildError](err); ok {
+		return true
+	}
+	if _, ok := errors.AsType[*apperr.SchwabError](err); ok {
+		return true
+	}
+
+	return false
+}
+
+// schwabStructuredError maps project domain errors onto structcli's stable JSON
+// shape. The old Details field becomes Hint because it is remediation text for
+// agents and humans, not another machine-readable error code.
+func schwabStructuredError(cmd *cobra.Command, err error) structcli.StructuredError {
+	se := structcli.StructuredError{
+		Error:    strings.ToLower(apperr.ErrorCode(err)),
+		ExitCode: apperr.ExitCodeFor(err),
+		Message:  err.Error(),
+		Command:  commandPath(cmd),
+	}
+
+	se.Hint = schwabErrorDetails(err)
+
+	// Preserve upstream HTTP context that used to live in the legacy details
+	// string. `got` carries the observed response, while `expected` tells an
+	// agent what outcome would have avoided this domain error.
 	if httpErr, ok := errors.AsType[*apperr.HTTPError](err); ok {
 		if httpErr.Body != "" {
-			details = fmt.Sprintf("status: %d, body: %s", httpErr.StatusCode, httpErr.Body)
+			se.Got = fmt.Sprintf("status: %d, body: %s", httpErr.StatusCode, httpErr.Body)
 		} else {
-			details = fmt.Sprintf("status: %d", httpErr.StatusCode)
+			se.Got = fmt.Sprintf("status: %d", httpErr.StatusCode)
+		}
+		se.Expected = "2xx response"
+	}
+
+	return se
+}
+
+// schwabErrorDetails extracts remediation details from every concrete domain
+// error. The concrete checks are intentional because embedding SchwabError does
+// not make errors.As match the embedded base type for wrapper errors.
+func schwabErrorDetails(err error) string {
+	if typedErr, ok := errors.AsType[*apperr.AuthRequiredError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.AuthExpiredError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.AuthCallbackError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.OrderRejectedError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.SymbolNotFoundError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.AccountNotFoundError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.HTTPError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.ValidationError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.OrderBuildError](err); ok {
+		return typedErr.Details()
+	}
+	if typedErr, ok := errors.AsType[*apperr.SchwabError](err); ok {
+		return typedErr.Details()
+	}
+
+	return ""
+}
+
+// writeStructCLIError asks structcli to classify the error, then re-encodes the
+// result with this package's JSON encoder settings. This avoids copying
+// structcli's private classifier while still keeping SetEscapeHTML(false)
+// consistent across every JSON writer in schwab-agent.
+func writeStructCLIError(w io.Writer, cmd *cobra.Command, err error) (int, error) {
+	var buf bytes.Buffer
+	exitCode := structcli.HandleError(cmd, err, &buf)
+
+	var se structcli.StructuredError
+	if unmarshalErr := json.Unmarshal(buf.Bytes(), &se); unmarshalErr != nil {
+		se = structcli.StructuredError{
+			Error:    "error",
+			ExitCode: exitCode,
+			Message:  err.Error(),
+			Command:  commandPath(cmd),
 		}
 	}
 
-	errorEnvelope := ErrorEnvelope{
-		Error: ErrorDetail{
-			Code:    code,
-			Message: message,
-			Details: details,
-		},
-	}
+	return exitCode, writeStructuredError(w, &se)
+}
+
+// writeStructuredError writes a top-level structcli StructuredError.
+func writeStructuredError(w io.Writer, se *structcli.StructuredError) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetEscapeHTML(false)
-	return encoder.Encode(errorEnvelope)
+	return encoder.Encode(se)
+}
+
+// commandPath returns the user-facing command path when a command is available.
+func commandPath(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+
+	return cmd.CommandPath()
 }
 
 // WritePartial writes a response with both data and errors (partial success).

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/major/schwab-agent/internal/apperr"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,8 +82,9 @@ func TestWriteErrorAuthRequired(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "AUTH_REQUIRED", errorEnvelope.Error.Code)
-	assert.Equal(t, "authentication required", errorEnvelope.Error.Message)
+	assert.Equal(t, "auth_required", errorEnvelope.Error)
+	assert.Equal(t, "authentication required", errorEnvelope.Message)
+	assert.Equal(t, 3, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorAuthExpired(t *testing.T) {
@@ -96,8 +98,9 @@ func TestWriteErrorAuthExpired(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "AUTH_EXPIRED", errorEnvelope.Error.Code)
-	assert.Equal(t, "auth expired", errorEnvelope.Error.Message)
+	assert.Equal(t, "auth_expired", errorEnvelope.Error)
+	assert.Equal(t, "auth expired", errorEnvelope.Message)
+	assert.Equal(t, 3, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorAuthCallback(t *testing.T) {
@@ -111,8 +114,9 @@ func TestWriteErrorAuthCallback(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "AUTH_CALLBACK", errorEnvelope.Error.Code)
-	assert.Equal(t, "callback failed", errorEnvelope.Error.Message)
+	assert.Equal(t, "auth_callback", errorEnvelope.Error)
+	assert.Equal(t, "callback failed", errorEnvelope.Message)
+	assert.Equal(t, 3, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorOrderRejected(t *testing.T) {
@@ -126,8 +130,9 @@ func TestWriteErrorOrderRejected(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "ORDER_REJECTED", errorEnvelope.Error.Code)
-	assert.Equal(t, "order rejected", errorEnvelope.Error.Message)
+	assert.Equal(t, "order_rejected", errorEnvelope.Error)
+	assert.Equal(t, "order rejected", errorEnvelope.Message)
+	assert.Equal(t, 5, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorSymbolNotFound(t *testing.T) {
@@ -141,8 +146,9 @@ func TestWriteErrorSymbolNotFound(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "SYMBOL_NOT_FOUND", errorEnvelope.Error.Code)
-	assert.Equal(t, "symbol not found", errorEnvelope.Error.Message)
+	assert.Equal(t, "symbol_not_found", errorEnvelope.Error)
+	assert.Equal(t, "symbol not found", errorEnvelope.Message)
+	assert.Equal(t, 2, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorAccountNotFound(t *testing.T) {
@@ -156,8 +162,9 @@ func TestWriteErrorAccountNotFound(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "ACCOUNT_NOT_FOUND", errorEnvelope.Error.Code)
-	assert.Equal(t, "account not found", errorEnvelope.Error.Message)
+	assert.Equal(t, "account_not_found", errorEnvelope.Error)
+	assert.Equal(t, "account not found", errorEnvelope.Message)
+	assert.Equal(t, 2, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorHTTPError(t *testing.T) {
@@ -171,9 +178,11 @@ func TestWriteErrorHTTPError(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "HTTP_ERROR", errorEnvelope.Error.Code)
-	assert.Equal(t, "http error", errorEnvelope.Error.Message)
-	assert.Contains(t, errorEnvelope.Error.Details, "500")
+	assert.Equal(t, "http_error", errorEnvelope.Error)
+	assert.Equal(t, "http error", errorEnvelope.Message)
+	assert.Equal(t, 4, errorEnvelope.ExitCode)
+	assert.Contains(t, errorEnvelope.Got, "500")
+	assert.Equal(t, "2xx response", errorEnvelope.Expected)
 }
 
 func TestWriteErrorValidationError(t *testing.T) {
@@ -187,8 +196,9 @@ func TestWriteErrorValidationError(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "VALIDATION_ERROR", errorEnvelope.Error.Code)
-	assert.Equal(t, "validation failed", errorEnvelope.Error.Message)
+	assert.Equal(t, "validation_error", errorEnvelope.Error)
+	assert.Equal(t, "validation failed", errorEnvelope.Message)
+	assert.Equal(t, 1, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorOrderBuildError(t *testing.T) {
@@ -202,8 +212,9 @@ func TestWriteErrorOrderBuildError(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "ORDER_BUILD_ERROR", errorEnvelope.Error.Code)
-	assert.Equal(t, "order build failed", errorEnvelope.Error.Message)
+	assert.Equal(t, "order_build_error", errorEnvelope.Error)
+	assert.Equal(t, "order build failed", errorEnvelope.Message)
+	assert.Equal(t, 1, errorEnvelope.ExitCode)
 }
 
 func TestWriteErrorGenericError(t *testing.T) {
@@ -217,8 +228,38 @@ func TestWriteErrorGenericError(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "UNKNOWN", errorEnvelope.Error.Code)
-	assert.Equal(t, "unknown error", errorEnvelope.Error.Message)
+	assert.Equal(t, "error", errorEnvelope.Error)
+	assert.Equal(t, "unknown error", errorEnvelope.Message)
+	assert.Equal(t, 1, errorEnvelope.ExitCode)
+}
+
+func TestWriteCommandErrorUnknownFlag(t *testing.T) {
+	buf := &bytes.Buffer{}
+	cmd := &cobra.Command{
+		Use:           "test",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return nil
+		},
+	}
+	cmd.SetArgs([]string{"--bogus"})
+
+	executed, err := cmd.ExecuteC()
+	require.Error(t, err)
+
+	exitCode, writeErr := WriteCommandError(buf, executed, err)
+	require.NoError(t, writeErr)
+
+	var errorEnvelope ErrorEnvelope
+	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
+	require.NoError(t, unmarshalErr)
+
+	assert.Equal(t, "unknown_flag", errorEnvelope.Error)
+	assert.Equal(t, 12, exitCode)
+	assert.Equal(t, 12, errorEnvelope.ExitCode)
+	assert.Equal(t, "bogus", errorEnvelope.Flag)
+	assert.Equal(t, "test", errorEnvelope.Command)
 }
 
 func TestWriteErrorWithDetails(t *testing.T) {
@@ -232,7 +273,7 @@ func TestWriteErrorWithDetails(t *testing.T) {
 	unmarshalErr := json.Unmarshal(buf.Bytes(), &errorEnvelope)
 	require.NoError(t, unmarshalErr)
 
-	assert.Equal(t, "additional context", errorEnvelope.Error.Details)
+	assert.Equal(t, "additional context", errorEnvelope.Hint)
 }
 
 func TestWritePartial(t *testing.T) {
@@ -346,9 +387,8 @@ func TestErrorEnvelopeJSONStructure(t *testing.T) {
 	require.NoError(t, unmarshalErr)
 
 	assert.Contains(t, raw, "error")
-	errorObj := raw["error"].(map[string]any)
-	assert.Contains(t, errorObj, "code")
-	assert.Contains(t, errorObj, "message")
+	assert.Contains(t, raw, "exit_code")
+	assert.Contains(t, raw, "message")
 }
 
 func TestWriteSuccessWithEmptyMetadata(t *testing.T) {

--- a/llms.txt
+++ b/llms.txt
@@ -4,6 +4,14 @@ https://github.com/major/schwab-agent
 
 > CLI tool for AI agents to trade via Schwab APIs
 
+## Discovery
+
+Run `schwab-agent --jsonschema=tree` first when you need to discover commands, flags, enum values, defaults, config keys, or environment variable bindings. Treat that JSON Schema tree as the authoritative shell command contract. Use this file for workflow guidance and static context after choosing the command and flags from the schema.
+
+```bash
+schwab-agent --jsonschema=tree
+```
+
 ## Commands
 
 - [schwab-agent](#schwab-agent): CLI tool for AI agents to trade via Schwab APIs

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,9 @@ schwab-agent --jsonschema=tree
 details, look up account numbers and hash values, set a default account, and
 query transaction history. Account list and get enrich results with nicknames
 from the preferences API (best-effort, degrades gracefully).
+- [schwab-agent account summary](#schwab-agent-account-summary): List compact account identifiers for agents. Returns account hashes from the
+account numbers endpoint and best-effort nickname, primary-account marker, and
+account type from user preferences without fetching balances or positions.
 - [schwab-agent account get](#schwab-agent-account-get): Get details for a single account by hash value. The hash can be passed as a
 positional argument, via --account, or resolved from the default_account
 config. Results are enriched with nicknames from the preferences API. Use
@@ -285,6 +288,16 @@ Manage Schwab trading accounts. List accounts with nicknames, view account
 details, look up account numbers and hash values, set a default account, and
 query transaction history. Account list and get enrich results with nicknames
 from the preferences API (best-effort, degrades gracefully).
+
+## schwab-agent account summary
+
+List compact account identifiers for agents. This is the smallest account picker
+for LLM workflows: it returns accountHash, accountNumber, nickName,
+primaryAccount, and type when preferences are available. It calls accountNumbers
+for hashes, joins optional userPreference fields by account number, and does not
+fetch balances or positions. It has no command-specific flags, enum values,
+config keys, or environment bindings; use root flags like --config and --token
+from the schema tree when needed.
 
 ## schwab-agent account get
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -134,6 +134,7 @@ run_help_test "auth login"        auth login
 run_help_test "auth status"       auth status
 run_help_test "auth refresh"      auth refresh
 run_help_test "account"           account
+run_help_test "account summary"   account summary
 run_help_test "account list"      account list
 run_help_test "account get"       account get
 run_help_test "account numbers"   account numbers
@@ -534,6 +535,7 @@ run_test "auth status" auth status
 
 section "Account"
 
+run_test "account summary" account summary
 run_test "account list" account list
 run_test "account numbers" account numbers
 run_test "account list --positions" account list --positions


### PR DESCRIPTION
## Summary
- Switch CLI validation failures to structcli structured errors and document schema tree discovery.
- Return fetched order details after place/cancel/replace actions, with partial success when the follow-up detail lookup fails.
- Add `account summary` as a compact account picker for agents, joining account hashes with preferences for nickname, primary flag, and type.

## Compatibility notes
- Error output shape changes from the old nested `error` envelope to top-level structcli structured errors for validation failures.
- Order mutations now perform an extra GET when Schwab returns an order ID, so successful mutation output is more useful but may include partial-success errors if Schwab accepts the action and detail lookup fails.

## Verification
- CodeRabbit local review found 2 minor issues. Both fixed and autosquashed.
- Re-ran CodeRabbit with a 20 minute timeout as requested, but the CLI hit an hourly rate limit with a 56 minute wait.
- `make test` passed.
- `make smoke-ci` passed, 136/136 Tier 1 checks.
- `make build` passed.
- `make lint` could not run code analysis locally because `golangci-lint` was built with Go 1.25 while this repo targets Go 1.26.