### PR TITLE
Add compact positions to account summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ schwab-agent quote get AAPL
 # List compact account identifiers for agent workflows
 schwab-agent account summary
 
+# List compact account identifiers and holdings in one response
+schwab-agent account summary --positions
+
 # List full account details and balances
 schwab-agent account list
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -91,13 +91,15 @@ schwab-agent account list
 List linked Schwab accounts in a compact, token-efficient shape for agents.
 Each entry includes the account hash required by other commands, the readable
 account number, and best-effort nickname/primary/type data from user preferences.
-Use account list when you need full balances or account list --positions when
-you need the full Schwab account payload with positions.
+Use --positions to include compact holdings with computed cost basis and P&L in
+the same response. Use account list when you need full balances or account list
+--positions when you need the full Schwab account payload with positions.
 
 **Example:**
 
 ```bash
 schwab-agent account summary
+schwab-agent account summary --positions
 ```
 
 #### `schwab-agent account numbers`
@@ -1471,6 +1473,7 @@ schwab-agent account list
 
 ```bash
 schwab-agent account summary
+schwab-agent account summary --positions
 ```
 
 #### schwab-agent account numbers

--- a/internal/commands/account.go
+++ b/internal/commands/account.go
@@ -2,6 +2,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strconv"
@@ -33,16 +34,35 @@ type accountSummaryData struct {
 	Accounts []accountSummaryEntry `json:"accounts"`
 }
 
+// accountSummaryPosition is the compact position shape used by account summary
+// when agents ask for holdings in the same round trip as account selection.
+// Keep this intentionally smaller than models.Position; account list --positions
+// remains the full Schwab payload for workflows that need every raw field.
+type accountSummaryPosition struct {
+	Symbol           *string  `json:"symbol,omitempty"`
+	AssetType        *string  `json:"assetType,omitempty"`
+	Description      *string  `json:"description,omitempty"`
+	Quantity         *float64 `json:"quantity,omitempty"`
+	LongQuantity     *float64 `json:"longQuantity,omitempty"`
+	ShortQuantity    *float64 `json:"shortQuantity,omitempty"`
+	MarketValue      *float64 `json:"marketValue,omitempty"`
+	AveragePrice     *float64 `json:"averagePrice,omitempty"`
+	TotalCostBasis   *float64 `json:"totalCostBasis,omitempty"`
+	UnrealizedPnL    *float64 `json:"unrealizedPnL,omitempty"`
+	UnrealizedPnLPct *float64 `json:"unrealizedPnLPct,omitempty"`
+}
+
 // accountSummaryEntry combines the hash values required by downstream commands
 // with the human-friendly labels stored in Schwab user preferences. Keeping this
 // shape small avoids forcing LLMs to inspect the large balance payload returned
 // by account list just to choose an account.
 type accountSummaryEntry struct {
-	AccountHash    string  `json:"accountHash"`
-	AccountNumber  string  `json:"accountNumber"`
-	NickName       *string `json:"nickName,omitempty"`
-	PrimaryAccount *bool   `json:"primaryAccount,omitempty"`
-	Type           *string `json:"type,omitempty"`
+	AccountHash    string                    `json:"accountHash"`
+	AccountNumber  string                    `json:"accountNumber"`
+	NickName       *string                   `json:"nickName,omitempty"`
+	PrimaryAccount *bool                     `json:"primaryAccount,omitempty"`
+	Type           *string                   `json:"type,omitempty"`
+	Positions      *[]accountSummaryPosition `json:"positions,omitempty"`
 }
 
 // transactionListData wraps the transaction list response.
@@ -62,6 +82,14 @@ type accountListOpts struct {
 
 // Attach implements structcli.Options interface.
 func (o *accountListOpts) Attach(_ *cobra.Command) error { return nil }
+
+// accountSummaryOpts holds the options for the compact account summary command.
+type accountSummaryOpts struct {
+	Positions bool `flag:"positions" flagdescr:"Include compact current positions for each account"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *accountSummaryOpts) Attach(_ *cobra.Command) error { return nil }
 
 // accountGetOpts holds the options for the account get subcommand.
 type accountGetOpts struct {
@@ -138,7 +166,11 @@ func enrichAccountsWithPreferences(accounts []models.Account, prefs *models.User
 // The accountNumbers endpoint is the source of truth for hashes, while
 // userPreference is the only Schwab endpoint that exposes nicknames and primary
 // account flags. They must be joined client-side by plain account number.
-func summarizeAccounts(numbers []models.AccountNumber, prefs *models.UserPreference) []accountSummaryEntry {
+func summarizeAccounts(
+	numbers []models.AccountNumber,
+	prefs *models.UserPreference,
+	positionsByAccount map[string][]accountSummaryPosition,
+) []accountSummaryEntry {
 	prefMap := make(map[string]*models.UserPreferenceAccount)
 	if prefs != nil {
 		prefMap = make(map[string]*models.UserPreferenceAccount, len(prefs.Accounts))
@@ -162,10 +194,82 @@ func summarizeAccounts(numbers []models.AccountNumber, prefs *models.UserPrefere
 			entry.Type = pref.Type
 		}
 
+		if positionsByAccount != nil {
+			positions := positionsByAccount[number.AccountNumber]
+			if positions == nil {
+				positions = []accountSummaryPosition{}
+			}
+			entry.Positions = &positions
+		}
+
 		entries = append(entries, entry)
 	}
 
 	return entries
+}
+
+// accountSummaryPositions fetches all positions once and groups them by account
+// number so account summary can return account identifiers and compact holdings
+// in one command. The accounts endpoint gives account numbers, while the summary
+// entries already get hashes from accountNumbers.
+func accountSummaryPositions(ctx context.Context, c *client.Ref) (map[string][]accountSummaryPosition, error) {
+	accounts, err := c.Accounts(ctx, "positions")
+	if err != nil {
+		return nil, err
+	}
+
+	positionsByAccount := make(map[string][]accountSummaryPosition, len(accounts))
+	for _, acct := range accounts {
+		if acct.SecuritiesAccount == nil || acct.SecuritiesAccount.AccountNumber == nil {
+			continue
+		}
+
+		accountNumber := *acct.SecuritiesAccount.AccountNumber
+		positions := make([]accountSummaryPosition, 0, len(acct.SecuritiesAccount.Positions))
+		for i := range acct.SecuritiesAccount.Positions {
+			positions = append(positions, newAccountSummaryPosition(&acct.SecuritiesAccount.Positions[i]))
+		}
+
+		positionsByAccount[accountNumber] = positions
+	}
+
+	return positionsByAccount, nil
+}
+
+// newAccountSummaryPosition keeps only the position fields an agent usually
+// needs for account selection and holdings inspection. It reuses the existing
+// computed P&L logic through positionEntry so account summary and position list
+// never drift on derived values.
+func newAccountSummaryPosition(pos *models.Position) accountSummaryPosition {
+	entry := newPositionEntry("", "", "", pos)
+	compact := accountSummaryPosition{
+		LongQuantity:     entry.LongQuantity,
+		ShortQuantity:    entry.ShortQuantity,
+		MarketValue:      entry.MarketValue,
+		AveragePrice:     entry.AveragePrice,
+		TotalCostBasis:   entry.TotalCostBasis,
+		UnrealizedPnL:    entry.UnrealizedPnL,
+		UnrealizedPnLPct: entry.UnrealizedPnLPct,
+	}
+
+	if entry.LongQuantity != nil || entry.ShortQuantity != nil {
+		quantity := 0.0
+		if entry.LongQuantity != nil {
+			quantity += *entry.LongQuantity
+		}
+		if entry.ShortQuantity != nil {
+			quantity += *entry.ShortQuantity
+		}
+		compact.Quantity = &quantity
+	}
+
+	if entry.Instrument != nil {
+		compact.Symbol = entry.Instrument.Symbol
+		compact.AssetType = entry.Instrument.AssetType
+		compact.Description = entry.Instrument.Description
+	}
+
+	return compact
 }
 
 // NewAccountCmd returns the Cobra parent command for account operations.
@@ -200,16 +304,23 @@ from the preferences API (best-effort, degrades gracefully).`,
 
 // newAccountSummaryCmd returns a compact account picker for agents.
 func newAccountSummaryCmd(c *client.Ref, w io.Writer) *cobra.Command {
-	return &cobra.Command{
+	opts := &accountSummaryOpts{}
+	cmd := &cobra.Command{
 		Use:   "summary",
 		Short: "List compact account identifiers for agents",
 		Long: `List linked Schwab accounts in a compact, token-efficient shape for agents.
 Each entry includes the account hash required by other commands, the readable
 account number, and best-effort nickname/primary/type data from user preferences.
-Use account list when you need full balances or account list --positions when
-you need the full Schwab account payload with positions.`,
-		Example: "  schwab-agent account summary",
+Use --positions to include compact holdings with computed cost basis and P&L
+in the same response. Use account list when you need full balances or account
+list --positions when you need the full Schwab account payload with positions.`,
+		Example: `  schwab-agent account summary
+  schwab-agent account summary --positions`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := structcli.Unmarshal(cmd, opts); err != nil {
+				return err
+			}
+
 			numbers, err := c.AccountNumbers(cmd.Context())
 			if err != nil {
 				return err
@@ -226,13 +337,32 @@ you need the full Schwab account payload with positions.`,
 				}
 			}
 
-			accounts := summarizeAccounts(numbers, prefs)
+			var positionsByAccount map[string][]accountSummaryPosition
+			if opts.Positions && len(numbers) > 0 {
+				positionsByAccount, err = accountSummaryPositions(cmd.Context(), c)
+				if err != nil {
+					return err
+				}
+			} else if opts.Positions {
+				positionsByAccount = map[string][]accountSummaryPosition{}
+			}
+
+			accounts := summarizeAccounts(numbers, prefs, positionsByAccount)
 			meta := output.NewMetadata()
 			meta.Returned = len(accounts)
+			if opts.Positions {
+				meta.PositionsIncluded = true
+			}
 
 			return output.WriteSuccess(w, accountSummaryData{Accounts: accounts}, meta)
 		},
 	}
+
+	if err := structcli.Define(cmd, opts); err != nil {
+		panic(err)
+	}
+
+	return cmd
 }
 
 // newAccountListCmd returns the Cobra subcommand for listing all accounts.

--- a/internal/commands/account_test.go
+++ b/internal/commands/account_test.go
@@ -335,6 +335,171 @@ func TestNewAccountCmd_Summary_Success(t *testing.T) {
 	assert.Equal(t, "CASH", second["type"])
 }
 
+func TestNewAccountCmd_Summary_WithPositionsFlag(t *testing.T) {
+	// Arrange
+	configPath := writeAccountTestConfig(t, t.TempDir(), "HASH_ABC")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			_, _ = w.Write([]byte(`[
+				{"accountNumber":"12345","hashValue":"HASH_ABC"},
+				{"accountNumber":"67890","hashValue":"HASH_DEF"}
+			]`))
+		case "/trader/v1/userPreference":
+			_, _ = w.Write([]byte(`{"accounts":[
+				{"accountNumber":"12345","nickName":"My IRA","primaryAccount":true,"type":"MARGIN"},
+				{"accountNumber":"67890","nickName":"Joint Taxable","primaryAccount":false,"type":"CASH"}
+			]}`))
+		case "/trader/v1/accounts":
+			assert.Equal(t, "positions", r.URL.Query().Get("fields"))
+			_, _ = w.Write([]byte(`[{
+				"securitiesAccount": {
+					"accountNumber": "12345",
+					"positions": [{
+						"longQuantity": 10,
+						"averagePrice": 100,
+						"marketValue": 1200,
+						"longOpenProfitLoss": 200,
+						"instrument": {"symbol": "AAPL", "assetType": "EQUITY", "description": "Apple Inc"}
+					}]
+				}
+			}]`))
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), configPath, &buf)
+	_, err := runTestCommand(t, cmd, "summary", "--positions")
+
+	// Assert
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, 2, env.Metadata.Returned)
+	assert.True(t, env.Metadata.PositionsIncluded)
+
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+	accountList, ok := dataMap["accounts"].([]any)
+	require.True(t, ok)
+	require.Len(t, accountList, 2)
+
+	first, ok := accountList[0].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, first, "defaultAccount")
+
+	positions, ok := first["positions"].([]any)
+	require.True(t, ok)
+	require.Len(t, positions, 1)
+	position, ok := positions[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "AAPL", position["symbol"])
+	assert.Equal(t, "EQUITY", position["assetType"])
+	assert.Equal(t, "Apple Inc", position["description"])
+	assert.Equal(t, 10.0, position["quantity"])
+	assert.Equal(t, 1000.0, position["totalCostBasis"])
+	assert.Equal(t, 200.0, position["unrealizedPnL"])
+	assert.Equal(t, 20.0, position["unrealizedPnLPct"])
+
+	second, ok := accountList[1].(map[string]any)
+	require.True(t, ok)
+	emptyPositions, ok := second["positions"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, emptyPositions)
+	assert.NotContains(t, second, "defaultAccount")
+}
+
+func TestNewAccountCmd_Summary_WithPositionsFlag_EmptyAccountsSkipsPositions(t *testing.T) {
+	// Arrange
+	var accountPayloadRequests int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			_, _ = w.Write([]byte(`[]`))
+		case "/trader/v1/accounts":
+			accountPayloadRequests++
+			t.Errorf("empty account summary should not fetch positions")
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), "", &buf)
+	_, err := runTestCommand(t, cmd, "summary", "--positions")
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 0, accountPayloadRequests)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	assert.Equal(t, 0, env.Metadata.Returned)
+	assert.True(t, env.Metadata.PositionsIncluded)
+}
+
+func TestNewAccountCmd_Summary_PreferencesFailure_StillReturnsPositions(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/trader/v1/accounts/accountNumbers":
+			_, _ = w.Write([]byte(`[{"accountNumber":"12345","hashValue":"HASH_ABC"}]`))
+		case "/trader/v1/userPreference":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/trader/v1/accounts":
+			assert.Equal(t, "positions", r.URL.Query().Get("fields"))
+			_, _ = w.Write([]byte(`[{
+				"securitiesAccount": {
+					"accountNumber": "12345",
+					"positions": [{"shortQuantity": 5, "averagePrice": 20, "shortOpenProfitLoss": -10}]
+				}
+			}]`))
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAccountCmd(testClient(t, srv), "", &buf)
+	_, err := runTestCommand(t, cmd, "summary", "--positions")
+
+	// Assert
+	require.NoError(t, err)
+
+	env := decodeAccountEnvelope(t, buf.Bytes())
+	dataMap, ok := env.Data.(map[string]any)
+	require.True(t, ok)
+	accountList, ok := dataMap["accounts"].([]any)
+	require.True(t, ok)
+	require.Len(t, accountList, 1)
+
+	first, ok := accountList[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "HASH_ABC", first["accountHash"])
+	assert.NotContains(t, first, "nickName")
+	positions, ok := first["positions"].([]any)
+	require.True(t, ok)
+	require.Len(t, positions, 1)
+	position, ok := positions[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 5.0, position["quantity"])
+	assert.Equal(t, -10.0, position["unrealizedPnL"])
+}
+
 func TestNewAccountCmd_Summary_PreferencesFailure_StillReturnsHashes(t *testing.T) {
 	// Arrange
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -18,10 +18,11 @@ import (
 
 // Metadata holds the standard metadata fields for response envelopes.
 type Metadata struct {
-	Timestamp string `json:"timestamp"`
-	Account   string `json:"account,omitempty"`
-	Requested int    `json:"requested,omitempty"`
-	Returned  int    `json:"returned,omitempty"`
+	Timestamp         string `json:"timestamp"`
+	Account           string `json:"account,omitempty"`
+	Requested         int    `json:"requested,omitempty"`
+	Returned          int    `json:"returned,omitempty"`
+	PositionsIncluded bool   `json:"positionsIncluded,omitempty"`
 }
 
 // NewMetadata returns metadata pre-populated with the current UTC timestamp.

--- a/llms.txt
+++ b/llms.txt
@@ -295,9 +295,13 @@ List compact account identifiers for agents. This is the smallest account picker
 for LLM workflows: it returns accountHash, accountNumber, nickName,
 primaryAccount, and type when preferences are available. It calls accountNumbers
 for hashes, joins optional userPreference fields by account number, and does not
-fetch balances or positions. It has no command-specific flags, enum values,
-config keys, or environment bindings; use root flags like --config and --token
-from the schema tree when needed.
+fetch balances. Use --positions to fetch
+compact holdings in the same response with symbol, assetType, quantity,
+marketValue, averagePrice, totalCostBasis, unrealizedPnL, and unrealizedPnLPct.
+
+### Flags
+
+- `--positions` (bool, default: false): Include compact current positions for each account
 
 ## schwab-agent account get
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -536,6 +536,7 @@ run_test "auth status" auth status
 section "Account"
 
 run_test "account summary" account summary
+run_test "account summary --positions" account summary --positions
 run_test "account list" account list
 run_test "account numbers" account numbers
 run_test "account list --positions" account list --positions


### PR DESCRIPTION
## Summary
- Add `account summary --positions` for compact account identifiers plus nested holdings in one response.
- Reuse existing position P&L calculations and include `metadata.positionsIncluded` when holdings are requested.
- Update docs, LLM guidance, and smoke coverage for the new flag.

## Verification
- LSP diagnostics clean for `internal/commands/account.go` and `internal/commands/account_test.go`
- `go test ./internal/commands ./internal/output`
- `make test`
- `make build`
- `make smoke-ci`
- `coderabbit review --agent --base main -c .coderabbit.yaml` found 0 findings

## Note
- `make lint` is blocked locally because `golangci-lint` was built with Go 1.25 while this repo targets Go 1.26.