### PR TITLE
Add practical option strategy builders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ CI runs lint (golangci-lint v2.11), test (race detector + coverage + build verif
 
 Shell script at `scripts/smoke-test.sh`. Two tiers:
 
-- **Tier 1** (no auth, CI-safe): help text for all 65 commands/subcommands, symbol build/parse, all 13 order build sub-types with full permutations (136 tests). Runs in CI and locally via `make smoke-ci`.
+- **Tier 1** (no auth, CI-safe): help text for all 70 commands/subcommands, symbol build/parse, all 18 order build sub-types with full permutations (146 tests). Runs in CI and locally via `make smoke-ci`.
 - **Tier 2** (auth required, local only): read-only API commands (account, position, quote, order list, chain, history, instrument, market, all 11 TA indicators). Requires a valid token. Runs locally via `make smoke` (both tiers) or `SMOKE_TIER=2 ./scripts/smoke-test.sh` (tier 2 only).
 
 Each test validates exit code 0, valid JSON output, and the correct envelope structure (`.data` for API commands, raw JSON for order builds). `SMOKE_BIN` env var overrides the binary path.
@@ -90,7 +90,7 @@ spf13/cobra + leodido/structcli. `buildApp()` in main.go constructs the command 
 
 Command flags use structcli struct tags (`flag`, `flagdescr`, `default`, `flagshort`) with `Define()` for registration and `Unmarshal()` in RunE for parsing. Most order commands use `defineAndConstrain[O]()` from helpers.go, which wraps `Define()` + `MarkFlagsMutuallyExclusive`/`MarkFlagsOneRequired` in a single call. Root persistent flags (--account, --verbose, --config, --token) stay as manual Cobra registrations.
 
-11 subcommands: auth (login/status/refresh), account (summary/list/get/numbers/set-default/transaction), position (list with --all-accounts/--account), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), ta (sma/ema/rsi/macd/atr/bbands/stoch/adx/vwap/hv/expected-move). Account summary is the token-efficient account picker for agents: it joins account hashes from account numbers with nicknames/primary/type from user preferences without fetching full balances. Account list/get enrich full results with nicknames from the preferences API (best-effort, degrades gracefully). Position list enriches with nicknames and adds computed cost basis / P&L fields. Order list defaults to non-terminal statuses (use --status all for everything).
+11 subcommands: auth (login/status/refresh), account (summary/list/get/numbers/set-default/transaction), position (list with --all-accounts/--account), quote (get), order (list/get/place/preview/build/cancel/replace; place/build sub-types: equity/option/bracket/oco), chain, history, instrument, market (hours/movers), symbol (build/parse), ta (sma/ema/rsi/macd/atr/bbands/stoch/adx/vwap/hv/expected-move). Account summary is the token-efficient account picker for agents: it joins account hashes from account numbers with nicknames/primary/type from user preferences without fetching full balances. Account list/get enrich full results with nicknames from the preferences API (best-effort, degrades gracefully). Position list enriches with nicknames and adds computed cost basis / P&L fields. Order list defaults to non-terminal statuses (use --status all for everything). Order build supports practical multi-leg strategies including vertical, iron-condor, straddle, strangle, covered-call, collar, calendar, diagonal, butterfly, condor, vertical-roll, back-ratio, and double-diagonal.
 
 ## Config
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: schwab-agent
 description: |
-  CLI tool for AI agents to trade via Schwab APIs. Use when you need to: manage schwab trading accounts. list compact account summaries with hashes and nicknames, view account
+  CLI tool for AI agents to trade via Schwab APIs. Use when you need to: manage schwab trading accounts. list accounts with nicknames, view account
   details, look up account numbers and hash values, set a default account, and
-  query transaction history. account summary is the token-efficient account picker for agents. account list and get enrich results with nicknames
+  query transaction history. account list and get enrich results with nicknames
   from the preferences api (best-effort, degrades gracefully), get details for a single account by hash value. the hash can be passed as a
   positional argument, via --account, or resolved from the default_account
   config. results are enriched with nicknames from the preferences api. use
   --positions to include current positions, list all linked schwab accounts with nicknames and settings enriched from
   the preferences api. use --positions to include current positions for each
   account in the response. nicknames are loaded best-effort and omitted if
-  the preferences api is unavailable, list account numbers and their corresponding hash values. hash values are
-  used as account identifiers in all other commands. use set-def...
+  the preferences api is unavailable. agents that only need account hashes,
+  nicknames, and primary account markers should use account summary for a smaller
+  one-command accoun...
 metadata:
   author: major
   version: dev
@@ -21,14 +22,6 @@ metadata:
 # schwab-agent
 
 ## Instructions
-
-## Agent discovery
-
-Run `schwab-agent --jsonschema=tree` first when you need to discover commands, flags, enum values, defaults, config keys, or environment variable bindings. Treat that JSON Schema tree as the authoritative shell command contract. Use this skill file for workflow guidance and examples after choosing the command and flags from the schema.
-
-```bash
-schwab-agent --jsonschema=tree
-```
 
 ### Available Commands
 
@@ -86,22 +79,6 @@ schwab-agent account list
   schwab-agent account list --positions
 ```
 
-#### `schwab-agent account summary`
-
-List linked Schwab accounts in a compact, token-efficient shape for agents.
-Each entry includes the account hash required by other commands, the readable
-account number, and best-effort nickname/primary/type data from user preferences.
-Use --positions to include compact holdings with computed cost basis and P&L in
-the same response. Use account list when you need full balances or account list
---positions when you need the full Schwab account payload with positions.
-
-**Example:**
-
-```bash
-schwab-agent account summary
-schwab-agent account summary --positions
-```
-
 #### `schwab-agent account numbers`
 
 List account numbers and their corresponding hash values. Hash values are
@@ -124,6 +101,28 @@ numbers to find valid hash values.
 
 ```
 schwab-agent account set-default ABCDEF1234567890
+```
+
+#### `schwab-agent account summary`
+
+List linked Schwab accounts in a compact, token-efficient shape for agents.
+Each entry includes the account hash required by other commands, the readable
+account number, and best-effort nickname/primary/type data from user preferences.
+Use --positions to include compact holdings with computed cost basis and P&L
+in the same response. Use account list when you need full balances or account
+list --positions when you need the full Schwab account payload with positions.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--positions` | bool | false | no | Include compact current positions for each account |
+
+**Example:**
+
+```
+schwab-agent account summary
+  schwab-agent account summary --positions
 ```
 
 #### `schwab-agent account transaction`
@@ -445,6 +444,38 @@ authentication. Output is raw JSON (not envelope-wrapped) that can be piped to
 order preview or order place --spec - for a staged workflow. Supports equity,
 option, bracket, OCO, and multi-leg option strategies.
 
+#### `schwab-agent order build back-ratio`
+
+Build an option back-ratio spread order request JSON. Quantity controls the
+short leg, and --long-ratio controls how many long contracts are bought per
+short contract. Use --debit or --credit because back-ratios can price either way.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--call` | bool | false | no | Call back-ratio |
+| `--close` | bool | false | no | Closing position |
+| `--credit` | bool | false | no | Build as NET_CREDIT |
+| `--debit` | bool | false | no | Build as NET_DEBIT |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--expiration` | string | - | yes | Expiration date (YYYY-MM-DD) |
+| `--long-ratio` | float64 | 2 | no | Long contracts per short contract |
+| `--long-strike` | float64 | 0 | yes | Long option strike |
+| `--open` | bool | false | no | Opening position |
+| `--price` | float64 | 0 | yes | Net debit or credit amount |
+| `--put` | bool | false | no | Put back-ratio |
+| `--quantity` | float64 | 0 | yes | Short-leg contract quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--short-strike` | float64 | 0 | yes | Short option strike |
+| `--underlying` | string | - | yes | Underlying symbol |
+
+**Example:**
+
+```
+schwab-agent order build back-ratio --underlying F --expiration 2026-06-18 --short-strike 12 --long-strike 14 --call --open --quantity 1 --long-ratio 2 --debit --price 0.20
+```
+
 #### `schwab-agent order build bracket`
 
 Build a bracket order request JSON with entry and automatic exit legs. At
@@ -470,6 +501,38 @@ auto-inverted from the entry action.
 ```
 schwab-agent order build bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
   schwab-agent order build bracket --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 180 --stop-loss 170
+```
+
+#### `schwab-agent order build butterfly`
+
+Build a butterfly spread order request JSON. Uses three ordered strikes at
+the same expiration: lower wing, middle body, upper wing. Buying opens a long
+butterfly with long wings and two short body contracts.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--buy` | bool | false | no | Buy a long butterfly |
+| `--call` | bool | false | no | Call butterfly |
+| `--close` | bool | false | no | Closing position |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--expiration` | string | - | yes | Expiration date (YYYY-MM-DD) |
+| `--lower-strike` | float64 | 0 | yes | Lower wing strike |
+| `--middle-strike` | float64 | 0 | yes | Middle body strike |
+| `--open` | bool | false | no | Opening position |
+| `--price` | float64 | 0 | yes | Net debit or credit amount |
+| `--put` | bool | false | no | Put butterfly |
+| `--quantity` | float64 | 0 | yes | Wing contract quantity |
+| `--sell` | bool | false | no | Sell a short butterfly |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--underlying` | string | - | yes | Underlying symbol |
+| `--upper-strike` | float64 | 0 | yes | Upper wing strike |
+
+**Example:**
+
+```
+schwab-agent order build butterfly --underlying F --expiration 2026-06-18 --lower-strike 10 --middle-strike 12 --upper-strike 14 --call --buy --open --quantity 1 --price 0.50
 ```
 
 #### `schwab-agent order build calendar`
@@ -528,6 +591,39 @@ capping upside. Quantity 1 means 100 shares plus 1 put and 1 call contract.
 schwab-agent order build collar --underlying F --put-strike 10 --call-strike 14 --expiration 2026-06-18 --quantity 1 --open --price 12.00
 ```
 
+#### `schwab-agent order build condor`
+
+Build a same-expiration condor spread order request JSON. Uses four ordered
+strikes: lower wing, lower-middle short, upper-middle short, upper wing. Buying
+opens a long condor; selling opens the inverse short condor.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--buy` | bool | false | no | Buy a long condor |
+| `--call` | bool | false | no | Call condor |
+| `--close` | bool | false | no | Closing position |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--expiration` | string | - | yes | Expiration date (YYYY-MM-DD) |
+| `--lower-middle-strike` | float64 | 0 | yes | Lower middle strike |
+| `--lower-strike` | float64 | 0 | yes | Lower wing strike |
+| `--open` | bool | false | no | Opening position |
+| `--price` | float64 | 0 | yes | Net debit or credit amount |
+| `--put` | bool | false | no | Put condor |
+| `--quantity` | float64 | 0 | yes | Contract quantity per strike |
+| `--sell` | bool | false | no | Sell a short condor |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--underlying` | string | - | yes | Underlying symbol |
+| `--upper-middle-strike` | float64 | 0 | yes | Upper middle strike |
+| `--upper-strike` | float64 | 0 | yes | Upper wing strike |
+
+**Example:**
+
+```
+schwab-agent order build condor --underlying F --expiration 2026-06-18 --lower-strike 10 --lower-middle-strike 12 --upper-middle-strike 14 --upper-strike 16 --call --buy --open --quantity 1 --price 0.75
+```
+
 #### `schwab-agent order build covered-call`
 
 Build a covered call order request JSON that atomically buys shares and sells
@@ -581,6 +677,36 @@ contract at a different strike. Combines elements of vertical and calendar sprea
 
 ```
 schwab-agent order build diagonal --underlying F --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50
+```
+
+#### `schwab-agent order build double-diagonal`
+
+Build a double diagonal spread order request JSON with far long put/call legs
+and near short put/call legs. The near expiration must come before the far
+expiration, and strikes must keep the put side below the call side.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--call-far-strike` | float64 | 0 | yes | Far call long strike |
+| `--call-near-strike` | float64 | 0 | yes | Near call short strike |
+| `--close` | bool | false | no | Closing position |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--far-expiration` | string | - | yes | Far expiration for long legs (YYYY-MM-DD) |
+| `--near-expiration` | string | - | yes | Near expiration for short legs (YYYY-MM-DD) |
+| `--open` | bool | false | no | Opening position |
+| `--price` | float64 | 0 | yes | Net debit or credit amount |
+| `--put-far-strike` | float64 | 0 | yes | Far put long strike |
+| `--put-near-strike` | float64 | 0 | yes | Near put short strike |
+| `--quantity` | float64 | 0 | yes | Contract quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--underlying` | string | - | yes | Underlying symbol |
+
+**Example:**
+
+```
+schwab-agent order build double-diagonal --underlying F --near-expiration 2026-06-18 --far-expiration 2026-07-17 --put-far-strike 9 --put-near-strike 10 --call-near-strike 14 --call-far-strike 15 --open --quantity 1 --price 0.80
 ```
 
 #### `schwab-agent order build equity`
@@ -818,6 +944,38 @@ NET_DEBIT or NET_CREDIT is auto-determined from the strike relationship.
   schwab-agent order build vertical --underlying F --expiration 2026-06-18 --long-strike 14 --short-strike 12 --put --open --quantity 1 --price 0.50
 ```
 
+#### `schwab-agent order build vertical-roll`
+
+Build a vertical roll order request JSON that closes one vertical spread and
+opens another in a single order. Use --debit or --credit to state the roll's net
+pricing direction.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--call` | bool | false | no | Call vertical roll |
+| `--close-expiration` | string | - | yes | Expiration of the vertical being closed (YYYY-MM-DD) |
+| `--close-long-strike` | float64 | 0 | yes | Long strike of the vertical being closed |
+| `--close-short-strike` | float64 | 0 | yes | Short strike of the vertical being closed |
+| `--credit` | bool | false | no | Build as NET_CREDIT |
+| `--debit` | bool | false | no | Build as NET_DEBIT |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--open-expiration` | string | - | yes | Expiration of the vertical being opened (YYYY-MM-DD) |
+| `--open-long-strike` | float64 | 0 | yes | Long strike of the vertical being opened |
+| `--open-short-strike` | float64 | 0 | yes | Short strike of the vertical being opened |
+| `--price` | float64 | 0 | yes | Net debit or credit amount |
+| `--put` | bool | false | no | Put vertical roll |
+| `--quantity` | float64 | 0 | yes | Contract quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--underlying` | string | - | yes | Underlying symbol |
+
+**Example:**
+
+```
+schwab-agent order build vertical-roll --underlying F --close-expiration 2026-06-18 --open-expiration 2026-07-17 --close-long-strike 12 --close-short-strike 14 --open-long-strike 13 --open-short-strike 15 --call --debit --quantity 1 --price 0.25
+```
+
 #### `schwab-agent order cancel`
 
 Cancel an existing order by ID. Requires the "i-also-like-to-live-dangerously"
@@ -834,7 +992,7 @@ config flag. The order ID can be passed as a positional argument or with
 
 ```
 schwab-agent order cancel 1234567890
-  schwab-agent order cancel --order-id 1234567890
+   schwab-agent order cancel --order-id 1234567890
 ```
 
 #### `schwab-agent order get`
@@ -885,9 +1043,9 @@ schwab-agent order list
 #### `schwab-agent order place`
 
 Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. The "i-also-like-to-live-dangerously" config flag must be set to
-true in config.json. Recommended workflow: check the price with quote get, build
-the order JSON with order build, preview it with order preview, then place it.
+with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
+Recommended workflow: check the price with quote get, build the order JSON with
+order build, preview it with order preview, then place.
 
 **Flags:**
 
@@ -899,11 +1057,11 @@ the order JSON with order build, preview it with order preview, then place it.
 
 ```
 # Place from a JSON file
-  schwab-agent order place --spec @order.json
-  # Place from stdin (piped from order build)
-  schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
-  # Place from inline JSON
-  schwab-agent order place --spec '{"orderType":"LIMIT",...}'
+   schwab-agent order place --spec @order.json
+   # Place from stdin (piped from order build)
+   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
+   # Place from inline JSON
+   schwab-agent order place --spec '{"orderType":"LIMIT",...}'
 ```
 
 #### `schwab-agent order place bracket`
@@ -942,8 +1100,8 @@ the parent cascades to all child orders.
 
 Place an equity (stock) order. Supports MARKET, LIMIT, STOP, STOP_LIMIT, and
 TRAILING_STOP order types. Default type is MARKET if --type is omitted. Duration
-aliases GTC, FOK, and IOC are accepted alongside their full names. The
-"i-also-like-to-live-dangerously" config flag must be set to true.
+aliases GTC, FOK, and IOC are accepted alongside their full names. Requires
+i-also-like-to-live-dangerously in config for placement.
 
 **Flags:**
 
@@ -1014,8 +1172,8 @@ bracket orders, OCO has no entry leg.
 
 Place a single-leg option order. Requires --underlying, --expiration, --strike,
 and exactly one of --call or --put. Use BUY_TO_OPEN/SELL_TO_CLOSE for new
-positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. The
-"i-also-like-to-live-dangerously" config flag must be set to true.
+positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. Requires
+i-also-like-to-live-dangerously in config for placement.
 
 **Flags:**
 
@@ -1072,8 +1230,8 @@ schwab-agent order preview --spec @order.json
 
 Replace an existing order with a new equity order. The original order is
 canceled and a new one is created with a new ID. Only equity order flags are
-accepted. The "i-also-like-to-live-dangerously" config flag must be set to true.
-The original order status becomes REPLACED after the new order is created.
+accepted. Requires the "i-also-like-to-live-dangerously" config flag. The
+original order status becomes REPLACED after the new order is created.
 
 **Flags:**
 
@@ -1102,7 +1260,7 @@ The original order status becomes REPLACED after the new order is created.
 
 ```
 schwab-agent order replace 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
-  schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
+   schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
 ```
 
 #### `schwab-agent position`
@@ -1120,7 +1278,6 @@ include totalCostBasis, unrealizedPnL, and unrealizedPnLPct.
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
-| `--account` | string | - | no | Account hash (overrides config default) |
 | `--all-accounts` | bool | false | no | Show positions across all linked accounts |
 
 **Example:**
@@ -1469,13 +1626,6 @@ schwab-agent account list
   schwab-agent account list --positions
 ```
 
-#### schwab-agent account summary
-
-```bash
-schwab-agent account summary
-schwab-agent account summary --positions
-```
-
 #### schwab-agent account numbers
 
 ```
@@ -1486,6 +1636,13 @@ schwab-agent account numbers
 
 ```
 schwab-agent account set-default ABCDEF1234567890
+```
+
+#### schwab-agent account summary
+
+```
+schwab-agent account summary
+  schwab-agent account summary --positions
 ```
 
 #### schwab-agent account transaction get
@@ -1576,11 +1733,23 @@ schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
   schwab-agent market movers EQUITY_ALL --sort PERCENT_CHANGE_UP
 ```
 
+#### schwab-agent order build back-ratio
+
+```
+schwab-agent order build back-ratio --underlying F --expiration 2026-06-18 --short-strike 12 --long-strike 14 --call --open --quantity 1 --long-ratio 2 --debit --price 0.20
+```
+
 #### schwab-agent order build bracket
 
 ```
 schwab-agent order build bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
   schwab-agent order build bracket --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 180 --stop-loss 170
+```
+
+#### schwab-agent order build butterfly
+
+```
+schwab-agent order build butterfly --underlying F --expiration 2026-06-18 --lower-strike 10 --middle-strike 12 --upper-strike 14 --call --buy --open --quantity 1 --price 0.50
 ```
 
 #### schwab-agent order build calendar
@@ -1595,6 +1764,12 @@ schwab-agent order build calendar --underlying F --near-expiration 2026-05-16 --
 schwab-agent order build collar --underlying F --put-strike 10 --call-strike 14 --expiration 2026-06-18 --quantity 1 --open --price 12.00
 ```
 
+#### schwab-agent order build condor
+
+```
+schwab-agent order build condor --underlying F --expiration 2026-06-18 --lower-strike 10 --lower-middle-strike 12 --upper-middle-strike 14 --upper-strike 16 --call --buy --open --quantity 1 --price 0.75
+```
+
 #### schwab-agent order build covered-call
 
 ```
@@ -1605,6 +1780,12 @@ schwab-agent order build covered-call --underlying F --expiration 2026-06-18 --s
 
 ```
 schwab-agent order build diagonal --underlying F --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50
+```
+
+#### schwab-agent order build double-diagonal
+
+```
+schwab-agent order build double-diagonal --underlying F --near-expiration 2026-06-18 --far-expiration 2026-07-17 --put-far-strike 9 --put-near-strike 10 --call-near-strike 14 --call-far-strike 15 --open --quantity 1 --price 0.80
 ```
 
 #### schwab-agent order build equity
@@ -1665,11 +1846,17 @@ schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-
   schwab-agent order build vertical --underlying F --expiration 2026-06-18 --long-strike 14 --short-strike 12 --put --open --quantity 1 --price 0.50
 ```
 
+#### schwab-agent order build vertical-roll
+
+```
+schwab-agent order build vertical-roll --underlying F --close-expiration 2026-06-18 --open-expiration 2026-07-17 --close-long-strike 12 --close-short-strike 14 --open-long-strike 13 --open-short-strike 15 --call --debit --quantity 1 --price 0.25
+```
+
 #### schwab-agent order cancel
 
 ```
 schwab-agent order cancel 1234567890
-  schwab-agent order cancel --order-id 1234567890
+   schwab-agent order cancel --order-id 1234567890
 ```
 
 #### schwab-agent order get
@@ -1693,11 +1880,11 @@ schwab-agent order list
 
 ```
 # Place from a JSON file
-  schwab-agent order place --spec @order.json
-  # Place from stdin (piped from order build)
-  schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
-  # Place from inline JSON
-  schwab-agent order place --spec '{"orderType":"LIMIT",...}'
+   schwab-agent order place --spec @order.json
+   # Place from stdin (piped from order build)
+   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
+   # Place from inline JSON
+   schwab-agent order place --spec '{"orderType":"LIMIT",...}'
 ```
 
 #### schwab-agent order place bracket
@@ -1757,7 +1944,7 @@ schwab-agent order preview --spec @order.json
 
 ```
 schwab-agent order replace 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
-  schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
+   schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
 ```
 
 #### schwab-agent position list

--- a/SKILL.md
+++ b/SKILL.md
@@ -51,7 +51,7 @@ config. Results are enriched with nicknames from the preferences API. Use
 
 **Example:**
 
-```
+```bash
 schwab-agent account get
   schwab-agent account get ABCDEF1234567890
   schwab-agent account get --positions
@@ -74,7 +74,7 @@ one-command account picker.
 
 **Example:**
 
-```
+```bash
 schwab-agent account list
   schwab-agent account list --positions
 ```
@@ -87,7 +87,7 @@ a hash as the default account.
 
 **Example:**
 
-```
+```bash
 schwab-agent account numbers
 ```
 
@@ -99,7 +99,7 @@ numbers to find valid hash values.
 
 **Example:**
 
-```
+```bash
 schwab-agent account set-default ABCDEF1234567890
 ```
 
@@ -120,7 +120,7 @@ list --positions when you need the full Schwab account payload with positions.
 
 **Example:**
 
-```
+```bash
 schwab-agent account summary
   schwab-agent account summary --positions
 ```
@@ -137,7 +137,7 @@ Get a specific transaction by ID
 
 **Example:**
 
-```
+```bash
 schwab-agent account transaction get 98765432101
 ```
 
@@ -158,7 +158,7 @@ default account unless --account is specified.
 
 **Example:**
 
-```
+```bash
 schwab-agent account transaction list
   schwab-agent account transaction list --types TRADE --symbol AAPL
   schwab-agent account transaction list --from 2025-01-01T00:00:00Z --to 2025-01-31T23:59:59Z
@@ -186,7 +186,7 @@ it is automatically set as the default.
 
 **Example:**
 
-```
+```bash
 schwab-agent auth login
   schwab-agent auth login --no-browser
 ```
@@ -199,7 +199,7 @@ a valid refresh token (not expired). If the refresh token is stale (older than
 
 **Example:**
 
-```
+```bash
 schwab-agent auth refresh
 ```
 
@@ -211,7 +211,7 @@ this to check whether tokens are still valid before running other commands.
 
 **Example:**
 
-```
+```bash
 schwab-agent auth status
 ```
 
@@ -227,7 +227,7 @@ detailed chain.
 
 **Example:**
 
-```
+```bash
 schwab-agent chain expiration AAPL
 ```
 
@@ -258,7 +258,7 @@ specific moneyness with --strike-range (ITM, NTM, OTM, ALL).
 
 **Example:**
 
-```
+```bash
 schwab-agent chain get AAPL
   schwab-agent chain get AAPL --type CALL --strike-count 5
   schwab-agent chain get AAPL --from-date 2025-06-01 --to-date 2025-07-31 --type PUT
@@ -348,7 +348,7 @@ date ranges via epoch milliseconds. Returns OHLCV candle data.
 
 **Example:**
 
-```
+```bash
 schwab-agent history get AAPL
   schwab-agent history get AAPL --period-type month --period 3 --frequency-type daily --frequency 1
   schwab-agent history get AAPL --period-type day --period 5 --frequency-type minute --frequency 15
@@ -366,7 +366,7 @@ description, exchange, and other metadata for the specified CUSIP.
 
 **Example:**
 
-```
+```bash
 schwab-agent instrument get 037833100
 ```
 
@@ -384,7 +384,7 @@ desc-regex, search, or fundamental.
 
 **Example:**
 
-```
+```bash
 schwab-agent instrument search AAPL
   schwab-agent instrument search "Apple" --projection desc-search
   schwab-agent instrument search AAPL --projection fundamental
@@ -402,7 +402,7 @@ more market names to filter.
 
 **Example:**
 
-```
+```bash
 schwab-agent market hours
   schwab-agent market hours equity
   schwab-agent market hours equity option
@@ -424,7 +424,7 @@ names (e.g. '$SPX').
 
 **Example:**
 
-```
+```bash
 schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
   schwab-agent market movers '$DJI' --sort VOLUME --frequency 5
   schwab-agent market movers EQUITY_ALL --sort PERCENT_CHANGE_UP
@@ -472,7 +472,7 @@ short contract. Use --debit or --credit because back-ratios can price either way
 
 **Example:**
 
-```
+```bash
 schwab-agent order build back-ratio --underlying F --expiration 2026-06-18 --short-strike 12 --long-strike 14 --call --open --quantity 1 --long-ratio 2 --debit --price 0.20
 ```
 
@@ -498,7 +498,7 @@ auto-inverted from the entry action.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
   schwab-agent order build bracket --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 180 --stop-loss 170
 ```
@@ -531,7 +531,7 @@ butterfly with long wings and two short body contracts.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build butterfly --underlying F --expiration 2026-06-18 --lower-strike 10 --middle-strike 12 --upper-strike 14 --call --buy --open --quantity 1 --price 0.50
 ```
 
@@ -560,7 +560,7 @@ contract. Profits from time decay differential between the two legs.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build calendar --underlying F --near-expiration 2026-05-16 --far-expiration 2026-07-17 --strike 12 --call --open --quantity 1 --price 0.50
 ```
 
@@ -587,7 +587,7 @@ capping upside. Quantity 1 means 100 shares plus 1 put and 1 call contract.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build collar --underlying F --put-strike 10 --call-strike 14 --expiration 2026-06-18 --quantity 1 --open --price 12.00
 ```
 
@@ -620,7 +620,7 @@ opens a long condor; selling opens the inverse short condor.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build condor --underlying F --expiration 2026-06-18 --lower-strike 10 --lower-middle-strike 12 --upper-middle-strike 14 --upper-strike 16 --call --buy --open --quantity 1 --price 0.75
 ```
 
@@ -645,7 +645,7 @@ already own, use order place option --action SELL_TO_OPEN instead.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build covered-call --underlying F --expiration 2026-06-18 --strike 14 --quantity 1 --price 12.00
 ```
 
@@ -675,7 +675,7 @@ contract at a different strike. Combines elements of vertical and calendar sprea
 
 **Example:**
 
-```
+```bash
 schwab-agent order build diagonal --underlying F --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50
 ```
 
@@ -705,7 +705,7 @@ expiration, and strikes must keep the put side below the call side.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build double-diagonal --underlying F --near-expiration 2026-06-18 --far-expiration 2026-07-17 --put-far-strike 9 --put-near-strike 10 --call-near-strike 14 --call-far-strike 15 --open --quantity 1 --price 0.80
 ```
 
@@ -739,7 +739,7 @@ or to order preview --spec - to check estimated commissions.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --duration DAY
   schwab-agent order build equity --symbol AAPL --action SELL --quantity 10 --type STOP --stop-price 145
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
@@ -761,7 +761,7 @@ triggered. Both --primary and --secondary accept inline JSON, @file, or
 
 **Example:**
 
-```
+```bash
 schwab-agent order build fts --primary @entry.json --secondary @exit.json
   schwab-agent order build fts --primary '{"orderType":"LIMIT",...}' --secondary '{"orderType":"STOP",...}'
 ```
@@ -791,7 +791,7 @@ generates a NET_CREDIT.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build iron-condor --underlying F --expiration 2026-06-18 --put-long-strike 9 --put-short-strike 10 --call-short-strike 14 --call-long-strike 15 --open --quantity 1 --price 0.50
 ```
 
@@ -815,7 +815,7 @@ one exit fills, the other is canceled. At least one of --take-profit or
 
 **Example:**
 
-```
+```bash
 schwab-agent order build oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
   schwab-agent order build oco --symbol TSLA --action BUY --quantity 10 --stop-loss 250
 ```
@@ -848,7 +848,7 @@ suitable for piping to order place or order preview.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build option --underlying AAPL --expiration 2025-06-20 --strike 190 --put --action SELL_TO_OPEN --quantity 1
 ```
@@ -877,7 +877,7 @@ put at the same strike price and expiration. Use --buy for long straddles
 
 **Example:**
 
-```
+```bash
 schwab-agent order build straddle --underlying F --expiration 2026-06-18 --strike 12 --buy --open --quantity 1 --price 1.50
   schwab-agent order build straddle --underlying F --expiration 2026-06-18 --strike 12 --sell --open --quantity 1 --price 1.50
 ```
@@ -907,7 +907,7 @@ or --sell for short strangles (expecting low volatility).
 
 **Example:**
 
-```
+```bash
 schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-strike 14 --put-strike 10 --buy --open --quantity 1 --price 0.50
   schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-strike 14 --put-strike 10 --sell --open --quantity 1 --price 0.50
 ```
@@ -937,7 +937,7 @@ NET_DEBIT or NET_CREDIT is auto-determined from the strike relationship.
 
 **Example:**
 
-```
+```bash
 # Bull call spread
   schwab-agent order build vertical --underlying F --expiration 2026-06-18 --long-strike 12 --short-strike 14 --call --open --quantity 1 --price 0.50
   # Bear put spread
@@ -972,7 +972,7 @@ pricing direction.
 
 **Example:**
 
-```
+```bash
 schwab-agent order build vertical-roll --underlying F --close-expiration 2026-06-18 --open-expiration 2026-07-17 --close-long-strike 12 --close-short-strike 14 --open-long-strike 13 --open-short-strike 15 --call --debit --quantity 1 --price 0.25
 ```
 
@@ -990,7 +990,7 @@ config flag. The order ID can be passed as a positional argument or with
 
 **Example:**
 
-```
+```bash
 schwab-agent order cancel 1234567890
    schwab-agent order cancel --order-id 1234567890
 ```
@@ -1009,7 +1009,7 @@ priority. Requires a default account or --account flag.
 
 **Example:**
 
-```
+```bash
 schwab-agent order get 1234567890
   schwab-agent order get --order-id 1234567890
 ```
@@ -1032,7 +1032,7 @@ merged, deduplicated results.
 
 **Example:**
 
-```
+```bash
 schwab-agent order list
   schwab-agent order list --status all
   schwab-agent order list --status WORKING --status PENDING_ACTIVATION
@@ -1055,7 +1055,7 @@ order build, preview it with order preview, then place.
 
 **Example:**
 
-```
+```bash
 # Place from a JSON file
    schwab-agent order place --spec @order.json
    # Place from stdin (piped from order build)
@@ -1087,7 +1087,7 @@ the parent cascades to all child orders.
 
 **Example:**
 
-```
+```bash
 # Buy with both take-profit and stop-loss
   schwab-agent order place bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
   # Buy with only a stop-loss safety net
@@ -1127,7 +1127,7 @@ i-also-like-to-live-dangerously in config for placement.
 
 **Example:**
 
-```
+```bash
 # Buy 10 shares at market price
   schwab-agent order place equity --symbol AAPL --action BUY --quantity 10
   # Buy with a limit price, good till cancel
@@ -1159,7 +1159,7 @@ bracket orders, OCO has no entry leg.
 
 **Example:**
 
-```
+```bash
 # Set take-profit and stop-loss for a long position
   schwab-agent order place oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
   # Protect a position with only a stop-loss
@@ -1197,7 +1197,7 @@ i-also-like-to-live-dangerously in config for placement.
 
 **Example:**
 
-```
+```bash
 # Buy a call option to open
   schwab-agent order place option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1
   # Sell a put at a limit price
@@ -1221,7 +1221,7 @@ is actually placed.
 
 **Example:**
 
-```
+```bash
 schwab-agent order preview --spec @order.json
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
 ```
@@ -1258,7 +1258,7 @@ original order status becomes REPLACED after the new order is created.
 
 **Example:**
 
-```
+```bash
 schwab-agent order replace 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
    schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
 ```
@@ -1282,7 +1282,7 @@ include totalCostBasis, unrealizedPnL, and unrealizedPnLPct.
 
 **Example:**
 
-```
+```bash
 schwab-agent position list
   schwab-agent position list --account ABCDEF1234567890
   schwab-agent position list --all-accounts
@@ -1309,7 +1309,7 @@ market cap.
 
 **Example:**
 
-```
+```bash
 schwab-agent quote get AAPL
   schwab-agent quote get AAPL NVDA TSLA
   schwab-agent quote get AAPL --fields quote,fundamental
@@ -1339,7 +1339,7 @@ constructed symbol and its components.
 
 **Example:**
 
-```
+```bash
 schwab-agent symbol build --underlying AAPL --expiration 2025-06-20 --strike 200 --call
   schwab-agent symbol build --underlying TSLA --expiration 2025-12-19 --strike 350.50 --put
 ```
@@ -1351,7 +1351,7 @@ price, and contract type components. No API call or authentication required.
 
 **Example:**
 
-```
+```bash
 schwab-agent symbol parse "AAPL  250620C00200000"
 ```
 
@@ -1378,7 +1378,7 @@ plus_di, and minus_di for directional bias. Default period is 14.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta adx AAPL
   schwab-agent ta adx AAPL --period 14 --interval daily --points 10
 ```
@@ -1399,7 +1399,7 @@ data with Wilder smoothing. Default period is 14.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta atr AAPL
   schwab-agent ta atr AAPL --period 14 --interval daily --points 10
 ```
@@ -1421,7 +1421,7 @@ relatively low. Use --std-dev to widen or narrow the bands (default 2.0).
 
 **Example:**
 
-```
+```bash
 schwab-agent ta bbands AAPL
   schwab-agent ta bbands AAPL --period 20 --std-dev 2.0 --points 10
   schwab-agent ta bbands AAPL --std-dev 1.5 --points 10
@@ -1444,7 +1444,7 @@ analysis).
 
 **Example:**
 
-```
+```bash
 schwab-agent ta ema AAPL
   schwab-agent ta ema AAPL --period 50 --interval daily --points 10
   schwab-agent ta ema AAPL --period 12,26 --points 5
@@ -1465,7 +1465,7 @@ and lower bounds).
 
 **Example:**
 
-```
+```bash
 schwab-agent ta expected-move AAPL
   schwab-agent ta expected-move AAPL --dte 45
 ```
@@ -1486,7 +1486,7 @@ monthly volatility breakdowns.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta hv AAPL
   schwab-agent ta hv AAPL --period 20 --interval daily
 ```
@@ -1510,7 +1510,7 @@ slow=26, signal=9.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta macd AAPL
   schwab-agent ta macd AAPL --fast 12 --slow 26 --signal 9 --points 10
   schwab-agent ta macd NVDA --interval weekly --points 10
@@ -1532,7 +1532,7 @@ can be repeated or comma-separated for multiple lookbacks. Default period is 14.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta rsi AAPL
   schwab-agent ta rsi AAPL --period 14 --interval daily --points 10
   schwab-agent ta rsi AAPL --period 9 --interval 5min --points 20
@@ -1555,7 +1555,7 @@ with keys like sma_21, sma_50, sma_200.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta sma AAPL
   schwab-agent ta sma AAPL --period 50 --interval daily --points 10
   schwab-agent ta sma AAPL --period 21,50,200 --points 1
@@ -1579,7 +1579,7 @@ Configurable via --k-period, --smooth-k, and --d-period.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta stoch AAPL
   schwab-agent ta stoch AAPL --k-period 14 --smooth-k 3 --d-period 3 --points 10
 ```
@@ -1600,7 +1600,7 @@ suggests bearish.
 
 **Example:**
 
-```
+```bash
 schwab-agent ta vwap AAPL
   schwab-agent ta vwap AAPL --interval 5min --points 20
 ```
@@ -1613,7 +1613,7 @@ All environment variables use the `SCHWAB_AGENT_` prefix.
 
 #### schwab-agent account get
 
-```
+```bash
 schwab-agent account get
   schwab-agent account get ABCDEF1234567890
   schwab-agent account get --positions
@@ -1621,39 +1621,39 @@ schwab-agent account get
 
 #### schwab-agent account list
 
-```
+```bash
 schwab-agent account list
   schwab-agent account list --positions
 ```
 
 #### schwab-agent account numbers
 
-```
+```bash
 schwab-agent account numbers
 ```
 
 #### schwab-agent account set-default
 
-```
+```bash
 schwab-agent account set-default ABCDEF1234567890
 ```
 
 #### schwab-agent account summary
 
-```
+```bash
 schwab-agent account summary
   schwab-agent account summary --positions
 ```
 
 #### schwab-agent account transaction get
 
-```
+```bash
 schwab-agent account transaction get 98765432101
 ```
 
 #### schwab-agent account transaction list
 
-```
+```bash
 schwab-agent account transaction list
   schwab-agent account transaction list --types TRADE --symbol AAPL
   schwab-agent account transaction list --from 2025-01-01T00:00:00Z --to 2025-01-31T23:59:59Z
@@ -1661,32 +1661,32 @@ schwab-agent account transaction list
 
 #### schwab-agent auth login
 
-```
+```bash
 schwab-agent auth login
   schwab-agent auth login --no-browser
 ```
 
 #### schwab-agent auth refresh
 
-```
+```bash
 schwab-agent auth refresh
 ```
 
 #### schwab-agent auth status
 
-```
+```bash
 schwab-agent auth status
 ```
 
 #### schwab-agent chain expiration
 
-```
+```bash
 schwab-agent chain expiration AAPL
 ```
 
 #### schwab-agent chain get
 
-```
+```bash
 schwab-agent chain get AAPL
   schwab-agent chain get AAPL --type CALL --strike-count 5
   schwab-agent chain get AAPL --from-date 2025-06-01 --to-date 2025-07-31 --type PUT
@@ -1696,7 +1696,7 @@ schwab-agent chain get AAPL
 
 #### schwab-agent history get
 
-```
+```bash
 schwab-agent history get AAPL
   schwab-agent history get AAPL --period-type month --period 3 --frequency-type daily --frequency 1
   schwab-agent history get AAPL --period-type day --period 5 --frequency-type minute --frequency 15
@@ -1705,13 +1705,13 @@ schwab-agent history get AAPL
 
 #### schwab-agent instrument get
 
-```
+```bash
 schwab-agent instrument get 037833100
 ```
 
 #### schwab-agent instrument search
 
-```
+```bash
 schwab-agent instrument search AAPL
   schwab-agent instrument search "Apple" --projection desc-search
   schwab-agent instrument search AAPL --projection fundamental
@@ -1719,7 +1719,7 @@ schwab-agent instrument search AAPL
 
 #### schwab-agent market hours
 
-```
+```bash
 schwab-agent market hours
   schwab-agent market hours equity
   schwab-agent market hours equity option
@@ -1727,7 +1727,7 @@ schwab-agent market hours
 
 #### schwab-agent market movers
 
-```
+```bash
 schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
   schwab-agent market movers '$DJI' --sort VOLUME --frequency 5
   schwab-agent market movers EQUITY_ALL --sort PERCENT_CHANGE_UP
@@ -1735,62 +1735,62 @@ schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
 
 #### schwab-agent order build back-ratio
 
-```
+```bash
 schwab-agent order build back-ratio --underlying F --expiration 2026-06-18 --short-strike 12 --long-strike 14 --call --open --quantity 1 --long-ratio 2 --debit --price 0.20
 ```
 
 #### schwab-agent order build bracket
 
-```
+```bash
 schwab-agent order build bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
   schwab-agent order build bracket --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 180 --stop-loss 170
 ```
 
 #### schwab-agent order build butterfly
 
-```
+```bash
 schwab-agent order build butterfly --underlying F --expiration 2026-06-18 --lower-strike 10 --middle-strike 12 --upper-strike 14 --call --buy --open --quantity 1 --price 0.50
 ```
 
 #### schwab-agent order build calendar
 
-```
+```bash
 schwab-agent order build calendar --underlying F --near-expiration 2026-05-16 --far-expiration 2026-07-17 --strike 12 --call --open --quantity 1 --price 0.50
 ```
 
 #### schwab-agent order build collar
 
-```
+```bash
 schwab-agent order build collar --underlying F --put-strike 10 --call-strike 14 --expiration 2026-06-18 --quantity 1 --open --price 12.00
 ```
 
 #### schwab-agent order build condor
 
-```
+```bash
 schwab-agent order build condor --underlying F --expiration 2026-06-18 --lower-strike 10 --lower-middle-strike 12 --upper-middle-strike 14 --upper-strike 16 --call --buy --open --quantity 1 --price 0.75
 ```
 
 #### schwab-agent order build covered-call
 
-```
+```bash
 schwab-agent order build covered-call --underlying F --expiration 2026-06-18 --strike 14 --quantity 1 --price 12.00
 ```
 
 #### schwab-agent order build diagonal
 
-```
+```bash
 schwab-agent order build diagonal --underlying F --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50
 ```
 
 #### schwab-agent order build double-diagonal
 
-```
+```bash
 schwab-agent order build double-diagonal --underlying F --near-expiration 2026-06-18 --far-expiration 2026-07-17 --put-far-strike 9 --put-near-strike 10 --call-near-strike 14 --call-far-strike 15 --open --quantity 1 --price 0.80
 ```
 
 #### schwab-agent order build equity
 
-```
+```bash
 schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --duration DAY
   schwab-agent order build equity --symbol AAPL --action SELL --quantity 10 --type STOP --stop-price 145
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
@@ -1798,48 +1798,48 @@ schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type 
 
 #### schwab-agent order build fts
 
-```
+```bash
 schwab-agent order build fts --primary @entry.json --secondary @exit.json
   schwab-agent order build fts --primary '{"orderType":"LIMIT",...}' --secondary '{"orderType":"STOP",...}'
 ```
 
 #### schwab-agent order build iron-condor
 
-```
+```bash
 schwab-agent order build iron-condor --underlying F --expiration 2026-06-18 --put-long-strike 9 --put-short-strike 10 --call-short-strike 14 --call-long-strike 15 --open --quantity 1 --price 0.50
 ```
 
 #### schwab-agent order build oco
 
-```
+```bash
 schwab-agent order build oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
   schwab-agent order build oco --symbol TSLA --action BUY --quantity 10 --stop-loss 250
 ```
 
 #### schwab-agent order build option
 
-```
+```bash
 schwab-agent order build option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build option --underlying AAPL --expiration 2025-06-20 --strike 190 --put --action SELL_TO_OPEN --quantity 1
 ```
 
 #### schwab-agent order build straddle
 
-```
+```bash
 schwab-agent order build straddle --underlying F --expiration 2026-06-18 --strike 12 --buy --open --quantity 1 --price 1.50
   schwab-agent order build straddle --underlying F --expiration 2026-06-18 --strike 12 --sell --open --quantity 1 --price 1.50
 ```
 
 #### schwab-agent order build strangle
 
-```
+```bash
 schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-strike 14 --put-strike 10 --buy --open --quantity 1 --price 0.50
   schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-strike 14 --put-strike 10 --sell --open --quantity 1 --price 0.50
 ```
 
 #### schwab-agent order build vertical
 
-```
+```bash
 # Bull call spread
   schwab-agent order build vertical --underlying F --expiration 2026-06-18 --long-strike 12 --short-strike 14 --call --open --quantity 1 --price 0.50
   # Bear put spread
@@ -1848,27 +1848,27 @@ schwab-agent order build strangle --underlying F --expiration 2026-06-18 --call-
 
 #### schwab-agent order build vertical-roll
 
-```
+```bash
 schwab-agent order build vertical-roll --underlying F --close-expiration 2026-06-18 --open-expiration 2026-07-17 --close-long-strike 12 --close-short-strike 14 --open-long-strike 13 --open-short-strike 15 --call --debit --quantity 1 --price 0.25
 ```
 
 #### schwab-agent order cancel
 
-```
+```bash
 schwab-agent order cancel 1234567890
    schwab-agent order cancel --order-id 1234567890
 ```
 
 #### schwab-agent order get
 
-```
+```bash
 schwab-agent order get 1234567890
   schwab-agent order get --order-id 1234567890
 ```
 
 #### schwab-agent order list
 
-```
+```bash
 schwab-agent order list
   schwab-agent order list --status all
   schwab-agent order list --status WORKING --status PENDING_ACTIVATION
@@ -1878,7 +1878,7 @@ schwab-agent order list
 
 #### schwab-agent order place
 
-```
+```bash
 # Place from a JSON file
    schwab-agent order place --spec @order.json
    # Place from stdin (piped from order build)
@@ -1889,7 +1889,7 @@ schwab-agent order list
 
 #### schwab-agent order place bracket
 
-```
+```bash
 # Buy with both take-profit and stop-loss
   schwab-agent order place bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
   # Buy with only a stop-loss safety net
@@ -1900,7 +1900,7 @@ schwab-agent order list
 
 #### schwab-agent order place equity
 
-```
+```bash
 # Buy 10 shares at market price
   schwab-agent order place equity --symbol AAPL --action BUY --quantity 10
   # Buy with a limit price, good till cancel
@@ -1913,7 +1913,7 @@ schwab-agent order list
 
 #### schwab-agent order place oco
 
-```
+```bash
 # Set take-profit and stop-loss for a long position
   schwab-agent order place oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
   # Protect a position with only a stop-loss
@@ -1924,7 +1924,7 @@ schwab-agent order list
 
 #### schwab-agent order place option
 
-```
+```bash
 # Buy a call option to open
   schwab-agent order place option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1
   # Sell a put at a limit price
@@ -1935,21 +1935,21 @@ schwab-agent order list
 
 #### schwab-agent order preview
 
-```
+```bash
 schwab-agent order preview --spec @order.json
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
 ```
 
 #### schwab-agent order replace
 
-```
+```bash
 schwab-agent order replace 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
    schwab-agent order replace --order-id 1234567890 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 155.00 --duration DAY
 ```
 
 #### schwab-agent position list
 
-```
+```bash
 schwab-agent position list
   schwab-agent position list --account ABCDEF1234567890
   schwab-agent position list --all-accounts
@@ -1957,7 +1957,7 @@ schwab-agent position list
 
 #### schwab-agent quote get
 
-```
+```bash
 schwab-agent quote get AAPL
   schwab-agent quote get AAPL NVDA TSLA
   schwab-agent quote get AAPL --fields quote,fundamental
@@ -1966,34 +1966,34 @@ schwab-agent quote get AAPL
 
 #### schwab-agent symbol build
 
-```
+```bash
 schwab-agent symbol build --underlying AAPL --expiration 2025-06-20 --strike 200 --call
   schwab-agent symbol build --underlying TSLA --expiration 2025-12-19 --strike 350.50 --put
 ```
 
 #### schwab-agent symbol parse
 
-```
+```bash
 schwab-agent symbol parse "AAPL  250620C00200000"
 ```
 
 #### schwab-agent ta adx
 
-```
+```bash
 schwab-agent ta adx AAPL
   schwab-agent ta adx AAPL --period 14 --interval daily --points 10
 ```
 
 #### schwab-agent ta atr
 
-```
+```bash
 schwab-agent ta atr AAPL
   schwab-agent ta atr AAPL --period 14 --interval daily --points 10
 ```
 
 #### schwab-agent ta bbands
 
-```
+```bash
 schwab-agent ta bbands AAPL
   schwab-agent ta bbands AAPL --period 20 --std-dev 2.0 --points 10
   schwab-agent ta bbands AAPL --std-dev 1.5 --points 10
@@ -2001,7 +2001,7 @@ schwab-agent ta bbands AAPL
 
 #### schwab-agent ta ema
 
-```
+```bash
 schwab-agent ta ema AAPL
   schwab-agent ta ema AAPL --period 50 --interval daily --points 10
   schwab-agent ta ema AAPL --period 12,26 --points 5
@@ -2009,21 +2009,21 @@ schwab-agent ta ema AAPL
 
 #### schwab-agent ta expected-move
 
-```
+```bash
 schwab-agent ta expected-move AAPL
   schwab-agent ta expected-move AAPL --dte 45
 ```
 
 #### schwab-agent ta hv
 
-```
+```bash
 schwab-agent ta hv AAPL
   schwab-agent ta hv AAPL --period 20 --interval daily
 ```
 
 #### schwab-agent ta macd
 
-```
+```bash
 schwab-agent ta macd AAPL
   schwab-agent ta macd AAPL --fast 12 --slow 26 --signal 9 --points 10
   schwab-agent ta macd NVDA --interval weekly --points 10
@@ -2031,7 +2031,7 @@ schwab-agent ta macd AAPL
 
 #### schwab-agent ta rsi
 
-```
+```bash
 schwab-agent ta rsi AAPL
   schwab-agent ta rsi AAPL --period 14 --interval daily --points 10
   schwab-agent ta rsi AAPL --period 9 --interval 5min --points 20
@@ -2039,7 +2039,7 @@ schwab-agent ta rsi AAPL
 
 #### schwab-agent ta sma
 
-```
+```bash
 schwab-agent ta sma AAPL
   schwab-agent ta sma AAPL --period 50 --interval daily --points 10
   schwab-agent ta sma AAPL --period 21,50,200 --points 1
@@ -2047,14 +2047,14 @@ schwab-agent ta sma AAPL
 
 #### schwab-agent ta stoch
 
-```
+```bash
 schwab-agent ta stoch AAPL
   schwab-agent ta stoch AAPL --k-period 14 --smooth-k 3 --d-period 3 --points 10
 ```
 
 #### schwab-agent ta vwap
 
-```
+```bash
 schwab-agent ta vwap AAPL
   schwab-agent ta vwap AAPL --interval 5min --points 20
 ```

--- a/internal/commands/AGENTS.md
+++ b/internal/commands/AGENTS.md
@@ -126,7 +126,7 @@ Build tags: `//go:build task16` (auth), `//go:build task17` (account), etc.
 | order.go | order | list, get |
 | order_place.go | order | place (equity/option/bracket/oco), preview, cancel, replace |
 | order_helpers.go | (shared) | opts structs, enum parsing, flag definitions, validation helpers |
-| order_build.go | order build | equity, option, bracket, oco, vertical, iron-condor, straddle, strangle, covered-call |
+| order_build.go | order build | equity, option, bracket, oco, vertical, iron-condor, straddle, strangle, covered-call, collar, calendar, diagonal, butterfly, condor, vertical-roll, back-ratio, double-diagonal, fts |
 | chain.go | chain | get, expiration |
 | history.go | history | get |
 | instrument.go | instrument | search, get |

--- a/internal/commands/order_build.go
+++ b/internal/commands/order_build.go
@@ -180,10 +180,51 @@ expirations: sells the near-term contract at one strike and buys the far-term
 contract at a different strike. Combines elements of vertical and calendar spreads.`
 	diagonalBuild.Example = `  schwab-agent order build diagonal --underlying F --near-strike 12 --far-strike 14 --near-expiration 2026-05-16 --far-expiration 2026-07-17 --call --open --quantity 1 --price 0.50`
 
+	butterflyBuild := makeCobraBuildOrderCommand(w, "butterfly", "Build a butterfly spread order request", func() *butterflyBuildOpts { return &butterflyBuildOpts{} }, func(cmd *cobra.Command, opts *butterflyBuildOpts) {
+		defineAndConstrain(cmd, opts, []string{"call", "put"}, []string{"buy", "sell"}, []string{"open", "close"})
+	}, parseButterflyParams, orderbuilder.ValidateButterflyOrder, orderbuilder.BuildButterflyOrder)
+	butterflyBuild.Long = `Build a butterfly spread order request JSON. Uses three ordered strikes at
+the same expiration: lower wing, middle body, upper wing. Buying opens a long
+butterfly with long wings and two short body contracts.`
+	butterflyBuild.Example = `  schwab-agent order build butterfly --underlying F --expiration 2026-06-18 --lower-strike 10 --middle-strike 12 --upper-strike 14 --call --buy --open --quantity 1 --price 0.50`
+
+	condorBuild := makeCobraBuildOrderCommand(w, "condor", "Build a condor spread order request", func() *condorBuildOpts { return &condorBuildOpts{} }, func(cmd *cobra.Command, opts *condorBuildOpts) {
+		defineAndConstrain(cmd, opts, []string{"call", "put"}, []string{"buy", "sell"}, []string{"open", "close"})
+	}, parseCondorParams, orderbuilder.ValidateCondorOrder, orderbuilder.BuildCondorOrder)
+	condorBuild.Long = `Build a same-expiration condor spread order request JSON. Uses four ordered
+strikes: lower wing, lower-middle short, upper-middle short, upper wing. Buying
+opens a long condor; selling opens the inverse short condor.`
+	condorBuild.Example = `  schwab-agent order build condor --underlying F --expiration 2026-06-18 --lower-strike 10 --lower-middle-strike 12 --upper-middle-strike 14 --upper-strike 16 --call --buy --open --quantity 1 --price 0.75`
+
+	verticalRollBuild := makeCobraBuildOrderCommand(w, "vertical-roll", "Build a vertical roll order request", func() *verticalRollBuildOpts { return &verticalRollBuildOpts{} }, func(cmd *cobra.Command, opts *verticalRollBuildOpts) {
+		defineAndConstrain(cmd, opts, []string{"call", "put"}, []string{"debit", "credit"})
+	}, parseVerticalRollParams, orderbuilder.ValidateVerticalRollOrder, orderbuilder.BuildVerticalRollOrder)
+	verticalRollBuild.Long = `Build a vertical roll order request JSON that closes one vertical spread and
+opens another in a single order. Use --debit or --credit to state the roll's net
+pricing direction.`
+	verticalRollBuild.Example = `  schwab-agent order build vertical-roll --underlying F --close-expiration 2026-06-18 --open-expiration 2026-07-17 --close-long-strike 12 --close-short-strike 14 --open-long-strike 13 --open-short-strike 15 --call --debit --quantity 1 --price 0.25`
+
+	backRatioBuild := makeCobraBuildOrderCommand(w, "back-ratio", "Build a back-ratio spread order request", func() *backRatioBuildOpts { return &backRatioBuildOpts{} }, func(cmd *cobra.Command, opts *backRatioBuildOpts) {
+		defineAndConstrain(cmd, opts, []string{"call", "put"}, []string{"open", "close"}, []string{"debit", "credit"})
+	}, parseBackRatioParams, orderbuilder.ValidateBackRatioOrder, orderbuilder.BuildBackRatioOrder)
+	backRatioBuild.Long = `Build an option back-ratio spread order request JSON. Quantity controls the
+short leg, and --long-ratio controls how many long contracts are bought per
+short contract. Use --debit or --credit because back-ratios can price either way.`
+	backRatioBuild.Example = `  schwab-agent order build back-ratio --underlying F --expiration 2026-06-18 --short-strike 12 --long-strike 14 --call --open --quantity 1 --long-ratio 2 --debit --price 0.20`
+
+	doubleDiagonalBuild := makeCobraBuildOrderCommand(w, "double-diagonal", "Build a double diagonal spread order request", func() *doubleDiagonalBuildOpts { return &doubleDiagonalBuildOpts{} }, func(cmd *cobra.Command, opts *doubleDiagonalBuildOpts) {
+		defineAndConstrain(cmd, opts, []string{"open", "close"})
+	}, parseDoubleDiagonalParams, orderbuilder.ValidateDoubleDiagonalOrder, orderbuilder.BuildDoubleDiagonalOrder)
+	doubleDiagonalBuild.Long = `Build a double diagonal spread order request JSON with far long put/call legs
+and near short put/call legs. The near expiration must come before the far
+expiration, and strikes must keep the put side below the call side.`
+	doubleDiagonalBuild.Example = `  schwab-agent order build double-diagonal --underlying F --near-expiration 2026-06-18 --far-expiration 2026-07-17 --put-far-strike 9 --put-near-strike 10 --call-near-strike 14 --call-far-strike 15 --open --quantity 1 --price 0.80`
+
 	cmd.AddCommand(
 		equityBuild, optionBuild, bracketBuild, ocoBuild,
 		verticalBuild, ironCondorBuild, straddleBuild, strangleBuild,
 		coveredCallBuild, collarBuild, calendarBuild, diagonalBuild,
+		butterflyBuild, condorBuild, verticalRollBuild, backRatioBuild, doubleDiagonalBuild,
 		newBuildFTSCmd(w),
 	)
 

--- a/internal/commands/order_helpers.go
+++ b/internal/commands/order_helpers.go
@@ -241,6 +241,115 @@ type diagonalBuildOpts struct {
 // Attach implements structcli.Options interface.
 func (o *diagonalBuildOpts) Attach(_ *cobra.Command) error { return nil }
 
+// butterflyBuildOpts holds flags for butterfly spread build flows.
+type butterflyBuildOpts struct {
+	Underlying   string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration   string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	LowerStrike  float64         `flag:"lower-strike" flagdescr:"Lower wing strike" flagrequired:"true" flaggroup:"contract"`
+	MiddleStrike float64         `flag:"middle-strike" flagdescr:"Middle body strike" flagrequired:"true" flaggroup:"contract"`
+	UpperStrike  float64         `flag:"upper-strike" flagdescr:"Upper wing strike" flagrequired:"true" flaggroup:"contract"`
+	Call         bool            `flag:"call" flagdescr:"Call butterfly" flaggroup:"contract"`
+	Put          bool            `flag:"put" flagdescr:"Put butterfly" flaggroup:"contract"`
+	Buy          bool            `flag:"buy" flagdescr:"Buy a long butterfly" flaggroup:"execution"`
+	Sell         bool            `flag:"sell" flagdescr:"Sell a short butterfly" flaggroup:"execution"`
+	Open         bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close        bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity     float64         `flag:"quantity" flagdescr:"Wing contract quantity" flagrequired:"true" flaggroup:"execution"`
+	Price        float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration     models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session      models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *butterflyBuildOpts) Attach(_ *cobra.Command) error { return nil }
+
+// condorBuildOpts holds flags for condor spread build flows.
+type condorBuildOpts struct {
+	Underlying        string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration        string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	LowerStrike       float64         `flag:"lower-strike" flagdescr:"Lower wing strike" flagrequired:"true" flaggroup:"contract"`
+	LowerMiddleStrike float64         `flag:"lower-middle-strike" flagdescr:"Lower middle strike" flagrequired:"true" flaggroup:"contract"`
+	UpperMiddleStrike float64         `flag:"upper-middle-strike" flagdescr:"Upper middle strike" flagrequired:"true" flaggroup:"contract"`
+	UpperStrike       float64         `flag:"upper-strike" flagdescr:"Upper wing strike" flagrequired:"true" flaggroup:"contract"`
+	Call              bool            `flag:"call" flagdescr:"Call condor" flaggroup:"contract"`
+	Put               bool            `flag:"put" flagdescr:"Put condor" flaggroup:"contract"`
+	Buy               bool            `flag:"buy" flagdescr:"Buy a long condor" flaggroup:"execution"`
+	Sell              bool            `flag:"sell" flagdescr:"Sell a short condor" flaggroup:"execution"`
+	Open              bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close             bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity          float64         `flag:"quantity" flagdescr:"Contract quantity per strike" flagrequired:"true" flaggroup:"execution"`
+	Price             float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration          models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session           models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *condorBuildOpts) Attach(_ *cobra.Command) error { return nil }
+
+// backRatioBuildOpts holds flags for back-ratio spread build flows.
+type backRatioBuildOpts struct {
+	Underlying  string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	Expiration  string          `flag:"expiration" flagdescr:"Expiration date (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	ShortStrike float64         `flag:"short-strike" flagdescr:"Short option strike" flagrequired:"true" flaggroup:"contract"`
+	LongStrike  float64         `flag:"long-strike" flagdescr:"Long option strike" flagrequired:"true" flaggroup:"contract"`
+	Call        bool            `flag:"call" flagdescr:"Call back-ratio" flaggroup:"contract"`
+	Put         bool            `flag:"put" flagdescr:"Put back-ratio" flaggroup:"contract"`
+	Open        bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close       bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity    float64         `flag:"quantity" flagdescr:"Short-leg contract quantity" flagrequired:"true" flaggroup:"execution"`
+	LongRatio   float64         `flag:"long-ratio" flagdescr:"Long contracts per short contract" default:"2" flaggroup:"execution"`
+	Debit       bool            `flag:"debit" flagdescr:"Build as NET_DEBIT" flaggroup:"pricing"`
+	Credit      bool            `flag:"credit" flagdescr:"Build as NET_CREDIT" flaggroup:"pricing"`
+	Price       float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration    models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session     models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *backRatioBuildOpts) Attach(_ *cobra.Command) error { return nil }
+
+// verticalRollBuildOpts holds flags for vertical roll build flows.
+type verticalRollBuildOpts struct {
+	Underlying       string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	CloseExpiration  string          `flag:"close-expiration" flagdescr:"Expiration of the vertical being closed (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	OpenExpiration   string          `flag:"open-expiration" flagdescr:"Expiration of the vertical being opened (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	CloseLongStrike  float64         `flag:"close-long-strike" flagdescr:"Long strike of the vertical being closed" flagrequired:"true" flaggroup:"contract"`
+	CloseShortStrike float64         `flag:"close-short-strike" flagdescr:"Short strike of the vertical being closed" flagrequired:"true" flaggroup:"contract"`
+	OpenLongStrike   float64         `flag:"open-long-strike" flagdescr:"Long strike of the vertical being opened" flagrequired:"true" flaggroup:"contract"`
+	OpenShortStrike  float64         `flag:"open-short-strike" flagdescr:"Short strike of the vertical being opened" flagrequired:"true" flaggroup:"contract"`
+	Call             bool            `flag:"call" flagdescr:"Call vertical roll" flaggroup:"contract"`
+	Put              bool            `flag:"put" flagdescr:"Put vertical roll" flaggroup:"contract"`
+	Debit            bool            `flag:"debit" flagdescr:"Build as NET_DEBIT" flaggroup:"pricing"`
+	Credit           bool            `flag:"credit" flagdescr:"Build as NET_CREDIT" flaggroup:"pricing"`
+	Quantity         float64         `flag:"quantity" flagdescr:"Contract quantity" flagrequired:"true" flaggroup:"execution"`
+	Price            float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration         models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session          models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *verticalRollBuildOpts) Attach(_ *cobra.Command) error { return nil }
+
+// doubleDiagonalBuildOpts holds flags for double diagonal spread build flows.
+type doubleDiagonalBuildOpts struct {
+	Underlying     string          `flag:"underlying" flagdescr:"Underlying symbol" flagrequired:"true" flaggroup:"contract"`
+	NearExpiration string          `flag:"near-expiration" flagdescr:"Near expiration for short legs (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	FarExpiration  string          `flag:"far-expiration" flagdescr:"Far expiration for long legs (YYYY-MM-DD)" flagrequired:"true" flaggroup:"contract"`
+	PutFarStrike   float64         `flag:"put-far-strike" flagdescr:"Far put long strike" flagrequired:"true" flaggroup:"contract"`
+	PutNearStrike  float64         `flag:"put-near-strike" flagdescr:"Near put short strike" flagrequired:"true" flaggroup:"contract"`
+	CallNearStrike float64         `flag:"call-near-strike" flagdescr:"Near call short strike" flagrequired:"true" flaggroup:"contract"`
+	CallFarStrike  float64         `flag:"call-far-strike" flagdescr:"Far call long strike" flagrequired:"true" flaggroup:"contract"`
+	Open           bool            `flag:"open" flagdescr:"Opening position" flaggroup:"execution"`
+	Close          bool            `flag:"close" flagdescr:"Closing position" flaggroup:"execution"`
+	Quantity       float64         `flag:"quantity" flagdescr:"Contract quantity" flagrequired:"true" flaggroup:"execution"`
+	Price          float64         `flag:"price" flagdescr:"Net debit or credit amount" flagrequired:"true" flaggroup:"pricing"`
+	Duration       models.Duration `flag:"duration" flagdescr:"Order duration" flaggroup:"order"`
+	Session        models.Session  `flag:"session" flagdescr:"Trading session" flaggroup:"order"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *doubleDiagonalBuildOpts) Attach(_ *cobra.Command) error { return nil }
+
 // Valid enum values for CLI flag parsing. Each slice corresponds to one enum
 // type in the models package and is used by the generic parseEnum/requireEnum
 // helpers in helpers.go.
@@ -922,6 +1031,193 @@ func parseDiagonalParams(opts *diagonalBuildOpts, _ []string) (*orderbuilder.Dia
 	}, nil
 }
 
+// parseButterflyParams converts command flags into butterfly builder params.
+func parseButterflyParams(opts *butterflyBuildOpts, _ []string) (*orderbuilder.ButterflyParams, error) {
+	putCall, err := parsePutCall(opts.Call, opts.Put)
+	if err != nil {
+		return nil, err
+	}
+
+	isBuy, err := parseBuySell(opts.Buy, opts.Sell)
+	if err != nil {
+		return nil, err
+	}
+
+	isOpen, err := parseOpenClose(opts.Open, opts.Close)
+	if err != nil {
+		return nil, err
+	}
+
+	expiration, err := parseExpiration(opts.Expiration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &orderbuilder.ButterflyParams{
+		Underlying:   strings.TrimSpace(opts.Underlying),
+		Expiration:   expiration,
+		LowerStrike:  opts.LowerStrike,
+		MiddleStrike: opts.MiddleStrike,
+		UpperStrike:  opts.UpperStrike,
+		PutCall:      putCall,
+		Buy:          isBuy,
+		Open:         isOpen,
+		Quantity:     opts.Quantity,
+		Price:        opts.Price,
+		Duration:     normalizeDuration(opts.Duration),
+		Session:      opts.Session,
+	}, nil
+}
+
+// parseCondorParams converts command flags into condor builder params.
+func parseCondorParams(opts *condorBuildOpts, _ []string) (*orderbuilder.CondorParams, error) {
+	putCall, err := parsePutCall(opts.Call, opts.Put)
+	if err != nil {
+		return nil, err
+	}
+
+	isBuy, err := parseBuySell(opts.Buy, opts.Sell)
+	if err != nil {
+		return nil, err
+	}
+
+	isOpen, err := parseOpenClose(opts.Open, opts.Close)
+	if err != nil {
+		return nil, err
+	}
+
+	expiration, err := parseExpiration(opts.Expiration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &orderbuilder.CondorParams{
+		Underlying:        strings.TrimSpace(opts.Underlying),
+		Expiration:        expiration,
+		LowerStrike:       opts.LowerStrike,
+		LowerMiddleStrike: opts.LowerMiddleStrike,
+		UpperMiddleStrike: opts.UpperMiddleStrike,
+		UpperStrike:       opts.UpperStrike,
+		PutCall:           putCall,
+		Buy:               isBuy,
+		Open:              isOpen,
+		Quantity:          opts.Quantity,
+		Price:             opts.Price,
+		Duration:          normalizeDuration(opts.Duration),
+		Session:           opts.Session,
+	}, nil
+}
+
+// parseBackRatioParams converts command flags into back-ratio builder params.
+func parseBackRatioParams(opts *backRatioBuildOpts, _ []string) (*orderbuilder.BackRatioParams, error) {
+	putCall, err := parsePutCall(opts.Call, opts.Put)
+	if err != nil {
+		return nil, err
+	}
+
+	isOpen, err := parseOpenClose(opts.Open, opts.Close)
+	if err != nil {
+		return nil, err
+	}
+
+	isCredit, err := parseDebitCredit(opts.Debit, opts.Credit)
+	if err != nil {
+		return nil, err
+	}
+
+	expiration, err := parseExpiration(opts.Expiration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &orderbuilder.BackRatioParams{
+		Underlying:  strings.TrimSpace(opts.Underlying),
+		Expiration:  expiration,
+		ShortStrike: opts.ShortStrike,
+		LongStrike:  opts.LongStrike,
+		PutCall:     putCall,
+		Open:        isOpen,
+		Quantity:    opts.Quantity,
+		LongRatio:   opts.LongRatio,
+		Credit:      isCredit,
+		Price:       opts.Price,
+		Duration:    normalizeDuration(opts.Duration),
+		Session:     opts.Session,
+	}, nil
+}
+
+// parseVerticalRollParams converts command flags into vertical roll builder params.
+func parseVerticalRollParams(opts *verticalRollBuildOpts, _ []string) (*orderbuilder.VerticalRollParams, error) {
+	putCall, err := parsePutCall(opts.Call, opts.Put)
+	if err != nil {
+		return nil, err
+	}
+
+	isCredit, err := parseDebitCredit(opts.Debit, opts.Credit)
+	if err != nil {
+		return nil, err
+	}
+
+	closeExpiration, err := parseDateFlag(opts.CloseExpiration, "close-expiration")
+	if err != nil {
+		return nil, err
+	}
+
+	openExpiration, err := parseDateFlag(opts.OpenExpiration, "open-expiration")
+	if err != nil {
+		return nil, err
+	}
+
+	return &orderbuilder.VerticalRollParams{
+		Underlying:       strings.TrimSpace(opts.Underlying),
+		CloseExpiration:  closeExpiration,
+		OpenExpiration:   openExpiration,
+		CloseLongStrike:  opts.CloseLongStrike,
+		CloseShortStrike: opts.CloseShortStrike,
+		OpenLongStrike:   opts.OpenLongStrike,
+		OpenShortStrike:  opts.OpenShortStrike,
+		PutCall:          putCall,
+		Credit:           isCredit,
+		Quantity:         opts.Quantity,
+		Price:            opts.Price,
+		Duration:         normalizeDuration(opts.Duration),
+		Session:          opts.Session,
+	}, nil
+}
+
+// parseDoubleDiagonalParams converts command flags into double diagonal builder params.
+func parseDoubleDiagonalParams(opts *doubleDiagonalBuildOpts, _ []string) (*orderbuilder.DoubleDiagonalParams, error) {
+	isOpen, err := parseOpenClose(opts.Open, opts.Close)
+	if err != nil {
+		return nil, err
+	}
+
+	nearExpiration, err := parseDateFlag(opts.NearExpiration, "near-expiration")
+	if err != nil {
+		return nil, err
+	}
+
+	farExpiration, err := parseDateFlag(opts.FarExpiration, "far-expiration")
+	if err != nil {
+		return nil, err
+	}
+
+	return &orderbuilder.DoubleDiagonalParams{
+		Underlying:     strings.TrimSpace(opts.Underlying),
+		NearExpiration: nearExpiration,
+		FarExpiration:  farExpiration,
+		PutFarStrike:   opts.PutFarStrike,
+		PutNearStrike:  opts.PutNearStrike,
+		CallNearStrike: opts.CallNearStrike,
+		CallFarStrike:  opts.CallFarStrike,
+		Open:           isOpen,
+		Quantity:       opts.Quantity,
+		Price:          opts.Price,
+		Duration:       normalizeDuration(opts.Duration),
+		Session:        opts.Session,
+	}, nil
+}
+
 // parseDateFlag parses a named YYYY-MM-DD flag value into a time.Time.
 // Used by calendar/diagonal spreads which have two expiration flags instead
 // of the single --expiration flag used by other spread types.
@@ -960,6 +1256,15 @@ func parseOpenClose(open, closeLeg bool) (bool, error) {
 	}
 
 	return open, nil
+}
+
+// parseDebitCredit validates mutually exclusive debit/credit flags.
+func parseDebitCredit(debit, credit bool) (bool, error) {
+	if debit == credit {
+		return false, newValidationError("exactly one of --debit or --credit is required")
+	}
+
+	return credit, nil
 }
 
 // parsePutCall validates mutually exclusive put/call flags.

--- a/internal/commands/order_helpers_new_strategies_test.go
+++ b/internal/commands/order_helpers_new_strategies_test.go
@@ -1,0 +1,238 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/major/schwab-agent/internal/models"
+)
+
+// TestNewStrategyAttachMethods verifies the structcli option types satisfy their
+// Attach hooks without side effects. These methods intentionally stay tiny, but
+// exercising them keeps the generated flag option surface covered.
+func TestNewStrategyAttachMethods(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "test"}
+	attachers := []interface{ Attach(*cobra.Command) error }{
+		&butterflyBuildOpts{},
+		&condorBuildOpts{},
+		&backRatioBuildOpts{},
+		&verticalRollBuildOpts{},
+		&doubleDiagonalBuildOpts{},
+	}
+
+	for _, attacher := range attachers {
+		require.NoError(t, attacher.Attach(cmd))
+	}
+}
+
+// TestParseNewOptionStrategyParamsHappyPaths covers parser branches that the
+// end-to-end command tests do not hit, especially sell/close, put, debit, and
+// credit combinations.
+func TestParseNewOptionStrategyParamsHappyPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("butterfly put sell close", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := parseButterflyParams(&butterflyBuildOpts{
+			Underlying: " F ", Expiration: testFutureExpDate,
+			LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14,
+			Put: true, Sell: true, Close: true, Quantity: 1, Price: 0.45,
+			Duration: models.DurationGoodTillCancel, Session: models.SessionPM,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "F", params.Underlying)
+		assert.Equal(t, models.PutCallPut, params.PutCall)
+		assert.False(t, params.Buy)
+		assert.False(t, params.Open)
+		assert.Equal(t, models.DurationGoodTillCancel, params.Duration)
+		assert.Equal(t, models.SessionPM, params.Session)
+	})
+
+	t.Run("condor call buy open", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := parseCondorParams(&condorBuildOpts{
+			Underlying: "F", Expiration: testFutureExpDate,
+			LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16,
+			Call: true, Buy: true, Open: true, Quantity: 2, Price: 0.75,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, models.PutCallCall, params.PutCall)
+		assert.True(t, params.Buy)
+		assert.True(t, params.Open)
+		assert.Equal(t, 2.0, params.Quantity)
+	})
+
+	t.Run("back-ratio put close credit", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := parseBackRatioParams(&backRatioBuildOpts{
+			Underlying: "F", Expiration: testFutureExpDate,
+			ShortStrike: 14, LongStrike: 12,
+			Put: true, Close: true, Credit: true, Quantity: 1, LongRatio: 3, Price: 0.10,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, models.PutCallPut, params.PutCall)
+		assert.False(t, params.Open)
+		assert.True(t, params.Credit)
+		assert.Equal(t, 3.0, params.LongRatio)
+	})
+
+	t.Run("vertical-roll put debit", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := parseVerticalRollParams(&verticalRollBuildOpts{
+			Underlying: "F", CloseExpiration: testFutureExpDate, OpenExpiration: testFutureExpTime.AddDate(0, 1, 0).Format("2006-01-02"),
+			CloseLongStrike: 14, CloseShortStrike: 12, OpenLongStrike: 13, OpenShortStrike: 11,
+			Put: true, Debit: true, Quantity: 1, Price: 0.15,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, models.PutCallPut, params.PutCall)
+		assert.False(t, params.Credit)
+	})
+
+	t.Run("double-diagonal close", func(t *testing.T) {
+		t.Parallel()
+
+		params, err := parseDoubleDiagonalParams(&doubleDiagonalBuildOpts{
+			Underlying: "F", NearExpiration: testFutureExpDate, FarExpiration: testFutureExpTime.AddDate(0, 1, 0).Format("2006-01-02"),
+			PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15,
+			Close: true, Quantity: 1, Price: 0.70,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.False(t, params.Open)
+	})
+}
+
+// TestParseNewOptionStrategyParamsErrors verifies each new parser returns the
+// specific validation errors users see for bad mutually exclusive flags or date
+// formats.
+func TestParseNewOptionStrategyParamsErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		parse   func() error
+		message string
+	}{
+		{
+			name: "butterfly missing call put",
+			parse: func() error {
+				_, err := parseButterflyParams(&butterflyBuildOpts{Buy: true, Open: true, Expiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "exactly one of --call or --put is required",
+		},
+		{
+			name: "butterfly missing buy sell",
+			parse: func() error {
+				_, err := parseButterflyParams(&butterflyBuildOpts{Call: true, Open: true, Expiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "exactly one of --buy or --sell is required",
+		},
+		{
+			name: "condor missing open close",
+			parse: func() error {
+				_, err := parseCondorParams(&condorBuildOpts{Call: true, Buy: true, Expiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "exactly one of --open or --close is required",
+		},
+		{
+			name: "condor invalid expiration",
+			parse: func() error {
+				_, err := parseCondorParams(&condorBuildOpts{Call: true, Buy: true, Open: true, Expiration: "06/18/2026"}, nil)
+				return err
+			},
+			message: "expiration must use YYYY-MM-DD format",
+		},
+		{
+			name: "back-ratio missing debit credit",
+			parse: func() error {
+				_, err := parseBackRatioParams(&backRatioBuildOpts{Call: true, Open: true, Expiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "exactly one of --debit or --credit is required",
+		},
+		{
+			name: "back-ratio invalid expiration",
+			parse: func() error {
+				_, err := parseBackRatioParams(&backRatioBuildOpts{Call: true, Open: true, Debit: true, Expiration: "bad"}, nil)
+				return err
+			},
+			message: "expiration must use YYYY-MM-DD format",
+		},
+		{
+			name: "vertical-roll both debit credit",
+			parse: func() error {
+				_, err := parseVerticalRollParams(&verticalRollBuildOpts{Call: true, Debit: true, Credit: true}, nil)
+				return err
+			},
+			message: "exactly one of --debit or --credit is required",
+		},
+		{
+			name: "vertical-roll invalid close expiration",
+			parse: func() error {
+				_, err := parseVerticalRollParams(&verticalRollBuildOpts{Call: true, Debit: true, CloseExpiration: "bad", OpenExpiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "close-expiration must use YYYY-MM-DD format",
+		},
+		{
+			name: "vertical-roll invalid open expiration",
+			parse: func() error {
+				_, err := parseVerticalRollParams(&verticalRollBuildOpts{Call: true, Debit: true, CloseExpiration: testFutureExpDate, OpenExpiration: "bad"}, nil)
+				return err
+			},
+			message: "open-expiration must use YYYY-MM-DD format",
+		},
+		{
+			name: "double-diagonal missing open close",
+			parse: func() error {
+				_, err := parseDoubleDiagonalParams(&doubleDiagonalBuildOpts{NearExpiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "exactly one of --open or --close is required",
+		},
+		{
+			name: "double-diagonal invalid near expiration",
+			parse: func() error {
+				_, err := parseDoubleDiagonalParams(&doubleDiagonalBuildOpts{Open: true, NearExpiration: "bad", FarExpiration: testFutureExpDate}, nil)
+				return err
+			},
+			message: "near-expiration must use YYYY-MM-DD format",
+		},
+		{
+			name: "double-diagonal invalid far expiration",
+			parse: func() error {
+				_, err := parseDoubleDiagonalParams(&doubleDiagonalBuildOpts{Open: true, NearExpiration: testFutureExpDate, FarExpiration: "bad"}, nil)
+				return err
+			},
+			message: "far-expiration must use YYYY-MM-DD format",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.parse()
+
+			require.Error(t, err)
+			assert.True(t, strings.Contains(err.Error(), testCase.message), "expected %q in %q", testCase.message, err.Error())
+		})
+	}
+}

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -286,6 +286,7 @@ func TestNewOrderCmdBuildNewOptionStrategiesOutputRequestJSON(t *testing.T) {
 			require.NoError(t, err)
 
 			order := decodeOrderRequest(t, stdout)
+			assert.Equal(t, models.OrderStrategyTypeSingle, order.OrderStrategyType)
 			assert.Equal(t, testCase.orderType, order.OrderType)
 			require.NotNil(t, order.ComplexOrderStrategyType)
 			assert.Equal(t, testCase.complexType, *order.ComplexOrderStrategyType)

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -241,6 +241,59 @@ func TestNewOrderCmdBuildEquityOutputsRequestJSON(t *testing.T) {
 	assert.Equal(t, models.InstructionBuy, order.OrderLegCollection[0].Instruction)
 }
 
+func TestNewOrderCmdBuildNewOptionStrategiesOutputRequestJSON(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		args        []string
+		complexType models.ComplexOrderStrategyType
+		orderType   models.OrderType
+		legs        int
+	}{
+		{
+			name:        "butterfly",
+			args:        []string{"order", "build", "butterfly", "--underlying", "F", "--expiration", testFutureExpDate, "--lower-strike", "10", "--middle-strike", "12", "--upper-strike", "14", "--call", "--buy", "--open", "--quantity", "1", "--price", "0.50"},
+			complexType: models.ComplexOrderStrategyTypeButterfly, orderType: models.OrderTypeNetDebit, legs: 3,
+		},
+		{
+			name:        "condor",
+			args:        []string{"order", "build", "condor", "--underlying", "F", "--expiration", testFutureExpDate, "--lower-strike", "10", "--lower-middle-strike", "12", "--upper-middle-strike", "14", "--upper-strike", "16", "--put", "--sell", "--open", "--quantity", "1", "--price", "0.75"},
+			complexType: models.ComplexOrderStrategyTypeCondor, orderType: models.OrderTypeNetCredit, legs: 4,
+		},
+		{
+			name:        "vertical-roll",
+			args:        []string{"order", "build", "vertical-roll", "--underlying", "F", "--close-expiration", testFutureExpDate, "--open-expiration", testFutureExpTime.AddDate(0, 1, 0).Format("2006-01-02"), "--close-long-strike", "12", "--close-short-strike", "14", "--open-long-strike", "13", "--open-short-strike", "15", "--call", "--credit", "--quantity", "1", "--price", "0.25"},
+			complexType: models.ComplexOrderStrategyTypeVerticalRoll, orderType: models.OrderTypeNetCredit, legs: 4,
+		},
+		{
+			name:        "back-ratio",
+			args:        []string{"order", "build", "back-ratio", "--underlying", "F", "--expiration", testFutureExpDate, "--short-strike", "12", "--long-strike", "14", "--call", "--open", "--quantity", "1", "--debit", "--price", "0.20"},
+			complexType: models.ComplexOrderStrategyTypeBackRatio, orderType: models.OrderTypeNetDebit, legs: 2,
+		},
+		{
+			name:        "double-diagonal",
+			args:        []string{"order", "build", "double-diagonal", "--underlying", "F", "--near-expiration", testFutureExpDate, "--far-expiration", testFutureExpTime.AddDate(0, 1, 0).Format("2006-01-02"), "--put-far-strike", "9", "--put-near-strike", "10", "--call-near-strike", "14", "--call-far-strike", "15", "--open", "--quantity", "1", "--price", "0.80"},
+			complexType: models.ComplexOrderStrategyTypeDoubleDiagonal, orderType: models.OrderTypeNetDebit, legs: 4,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, err := runOrderCommand(t, nil, writeTestConfig(t, "hash123"), "", testCase.args...)
+			require.NoError(t, err)
+
+			order := decodeOrderRequest(t, stdout)
+			assert.Equal(t, testCase.orderType, order.OrderType)
+			require.NotNil(t, order.ComplexOrderStrategyType)
+			assert.Equal(t, testCase.complexType, *order.ComplexOrderStrategyType)
+			require.Len(t, order.OrderLegCollection, testCase.legs)
+		})
+	}
+}
+
 func TestNewOrderCmdPlaceEquityPipeline(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orderbuilder/spread.go
+++ b/internal/orderbuilder/spread.go
@@ -163,6 +163,305 @@ func BuildIronCondorOrder(params *IronCondorParams) (*models.OrderRequest, error
 	return order, nil
 }
 
+// ButterflyParams holds parameters for building a same-expiration butterfly.
+// A long butterfly buys the two wings and sells two contracts at the body strike.
+type ButterflyParams struct {
+	Underlying   string
+	Expiration   time.Time
+	LowerStrike  float64
+	MiddleStrike float64
+	UpperStrike  float64
+	PutCall      models.PutCall
+	Buy          bool // true = long butterfly, false = short butterfly
+	Open         bool // true = opening position, false = closing
+	Quantity     float64
+	Price        float64
+	Duration     models.Duration
+	Session      models.Session
+}
+
+// BuildButterflyOrder constructs an OrderRequest for a three-strike butterfly.
+func BuildButterflyOrder(params *ButterflyParams) (*models.OrderRequest, error) {
+	wingInstruction, bodyInstruction := directionalSpreadInstructions(params.Buy, params.Open)
+	complexType := models.ComplexOrderStrategyTypeButterfly
+
+	order := &models.OrderRequest{
+		Session:                  cmp.Or(params.Session, models.SessionNormal),
+		Duration:                 cmp.Or(params.Duration, models.DurationDay),
+		OrderType:                directionalSpreadOrderType(params.Buy, params.Open),
+		ComplexOrderStrategyType: &complexType,
+		OrderStrategyType:        models.OrderStrategyTypeSingle,
+		Price:                    new(params.Price),
+		OrderLegCollection: []models.OrderLegCollection{
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.LowerStrike, PutCall: params.PutCall,
+				Instruction: wingInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.MiddleStrike, PutCall: params.PutCall,
+				Instruction: bodyInstruction, Quantity: params.Quantity * 2,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.UpperStrike, PutCall: params.PutCall,
+				Instruction: wingInstruction, Quantity: params.Quantity,
+			}),
+		},
+	}
+
+	return order, nil
+}
+
+// CondorParams holds parameters for building a same-expiration condor.
+// A long condor buys the outside wings and sells the two middle strikes.
+type CondorParams struct {
+	Underlying        string
+	Expiration        time.Time
+	LowerStrike       float64
+	LowerMiddleStrike float64
+	UpperMiddleStrike float64
+	UpperStrike       float64
+	PutCall           models.PutCall
+	Buy               bool // true = long condor, false = short condor
+	Open              bool // true = opening position, false = closing
+	Quantity          float64
+	Price             float64
+	Duration          models.Duration
+	Session           models.Session
+}
+
+// BuildCondorOrder constructs an OrderRequest for a four-strike condor.
+func BuildCondorOrder(params *CondorParams) (*models.OrderRequest, error) {
+	wingInstruction, middleInstruction := directionalSpreadInstructions(params.Buy, params.Open)
+	complexType := models.ComplexOrderStrategyTypeCondor
+
+	order := &models.OrderRequest{
+		Session:                  cmp.Or(params.Session, models.SessionNormal),
+		Duration:                 cmp.Or(params.Duration, models.DurationDay),
+		OrderType:                directionalSpreadOrderType(params.Buy, params.Open),
+		ComplexOrderStrategyType: &complexType,
+		OrderStrategyType:        models.OrderStrategyTypeSingle,
+		Price:                    new(params.Price),
+		OrderLegCollection: []models.OrderLegCollection{
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.LowerStrike, PutCall: params.PutCall,
+				Instruction: wingInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.LowerMiddleStrike, PutCall: params.PutCall,
+				Instruction: middleInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.UpperMiddleStrike, PutCall: params.PutCall,
+				Instruction: middleInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.UpperStrike, PutCall: params.PutCall,
+				Instruction: wingInstruction, Quantity: params.Quantity,
+			}),
+		},
+	}
+
+	return order, nil
+}
+
+// BackRatioParams holds parameters for building an option back-ratio spread.
+// Quantity is the short-leg size; LongRatio controls long contracts per short.
+type BackRatioParams struct {
+	Underlying  string
+	Expiration  time.Time
+	ShortStrike float64
+	LongStrike  float64
+	PutCall     models.PutCall
+	Open        bool
+	Quantity    float64
+	LongRatio   float64
+	Credit      bool
+	Price       float64
+	Duration    models.Duration
+	Session     models.Session
+}
+
+// BuildBackRatioOrder constructs an OrderRequest for a back-ratio spread.
+func BuildBackRatioOrder(params *BackRatioParams) (*models.OrderRequest, error) {
+	longInstruction, shortInstruction := spreadInstructions(params.Open)
+	complexType := models.ComplexOrderStrategyTypeBackRatio
+
+	orderType := models.OrderTypeNetDebit
+	if params.Credit {
+		orderType = models.OrderTypeNetCredit
+	}
+
+	order := &models.OrderRequest{
+		Session:                  cmp.Or(params.Session, models.SessionNormal),
+		Duration:                 cmp.Or(params.Duration, models.DurationDay),
+		OrderType:                orderType,
+		ComplexOrderStrategyType: &complexType,
+		OrderStrategyType:        models.OrderStrategyTypeSingle,
+		Price:                    new(params.Price),
+		OrderLegCollection: []models.OrderLegCollection{
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.ShortStrike, PutCall: params.PutCall,
+				Instruction: shortInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.Expiration,
+				Strike: params.LongStrike, PutCall: params.PutCall,
+				Instruction: longInstruction, Quantity: params.Quantity * params.LongRatio,
+			}),
+		},
+	}
+
+	return order, nil
+}
+
+// VerticalRollParams holds parameters for closing one vertical and opening another.
+type VerticalRollParams struct {
+	Underlying       string
+	CloseExpiration  time.Time
+	OpenExpiration   time.Time
+	CloseLongStrike  float64
+	CloseShortStrike float64
+	OpenLongStrike   float64
+	OpenShortStrike  float64
+	PutCall          models.PutCall
+	Credit           bool
+	Quantity         float64
+	Price            float64
+	Duration         models.Duration
+	Session          models.Session
+}
+
+// BuildVerticalRollOrder constructs an OrderRequest that closes and opens vertical spreads.
+func BuildVerticalRollOrder(params *VerticalRollParams) (*models.OrderRequest, error) {
+	complexType := models.ComplexOrderStrategyTypeVerticalRoll
+
+	orderType := models.OrderTypeNetDebit
+	if params.Credit {
+		orderType = models.OrderTypeNetCredit
+	}
+
+	order := &models.OrderRequest{
+		Session:                  cmp.Or(params.Session, models.SessionNormal),
+		Duration:                 cmp.Or(params.Duration, models.DurationDay),
+		OrderType:                orderType,
+		ComplexOrderStrategyType: &complexType,
+		OrderStrategyType:        models.OrderStrategyTypeSingle,
+		Price:                    new(params.Price),
+		OrderLegCollection: []models.OrderLegCollection{
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.CloseExpiration,
+				Strike: params.CloseLongStrike, PutCall: params.PutCall,
+				Instruction: models.InstructionSellToClose, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.CloseExpiration,
+				Strike: params.CloseShortStrike, PutCall: params.PutCall,
+				Instruction: models.InstructionBuyToClose, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.OpenExpiration,
+				Strike: params.OpenLongStrike, PutCall: params.PutCall,
+				Instruction: models.InstructionBuyToOpen, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.OpenExpiration,
+				Strike: params.OpenShortStrike, PutCall: params.PutCall,
+				Instruction: models.InstructionSellToOpen, Quantity: params.Quantity,
+			}),
+		},
+	}
+
+	return order, nil
+}
+
+// DoubleDiagonalParams holds parameters for building a double diagonal spread.
+type DoubleDiagonalParams struct {
+	Underlying     string
+	NearExpiration time.Time
+	FarExpiration  time.Time
+	PutFarStrike   float64
+	PutNearStrike  float64
+	CallNearStrike float64
+	CallFarStrike  float64
+	Open           bool
+	Quantity       float64
+	Price          float64
+	Duration       models.Duration
+	Session        models.Session
+}
+
+// BuildDoubleDiagonalOrder constructs an OrderRequest for a put and call diagonal pair.
+func BuildDoubleDiagonalOrder(params *DoubleDiagonalParams) (*models.OrderRequest, error) {
+	longInstruction, shortInstruction := spreadInstructions(params.Open)
+	complexType := models.ComplexOrderStrategyTypeDoubleDiagonal
+
+	orderType := models.OrderTypeNetDebit
+	if !params.Open {
+		orderType = models.OrderTypeNetCredit
+	}
+
+	order := &models.OrderRequest{
+		Session:                  cmp.Or(params.Session, models.SessionNormal),
+		Duration:                 cmp.Or(params.Duration, models.DurationDay),
+		OrderType:                orderType,
+		ComplexOrderStrategyType: &complexType,
+		OrderStrategyType:        models.OrderStrategyTypeSingle,
+		Price:                    new(params.Price),
+		OrderLegCollection: []models.OrderLegCollection{
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.FarExpiration,
+				Strike: params.PutFarStrike, PutCall: models.PutCallPut,
+				Instruction: longInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.NearExpiration,
+				Strike: params.PutNearStrike, PutCall: models.PutCallPut,
+				Instruction: shortInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.NearExpiration,
+				Strike: params.CallNearStrike, PutCall: models.PutCallCall,
+				Instruction: shortInstruction, Quantity: params.Quantity,
+			}),
+			buildOptionLeg(&optionLegParams{
+				Underlying: params.Underlying, Expiration: params.FarExpiration,
+				Strike: params.CallFarStrike, PutCall: models.PutCallCall,
+				Instruction: longInstruction, Quantity: params.Quantity,
+			}),
+		},
+	}
+
+	return order, nil
+}
+
+// directionalSpreadInstructions returns outside and inside leg instructions for
+// strategies whose structure can be bought or sold, then opened or closed.
+func directionalSpreadInstructions(isBuy, isOpen bool) (outerInstruction, innerInstruction models.Instruction) {
+	if isBuy {
+		return spreadInstructions(isOpen)
+	}
+
+	innerInstruction, outerInstruction = spreadInstructions(isOpen)
+	return outerInstruction, innerInstruction
+}
+
+// directionalSpreadOrderType maps buy/sell plus open/close into net debit/credit.
+func directionalSpreadOrderType(isBuy, isOpen bool) models.OrderType {
+	if isBuy == isOpen {
+		return models.OrderTypeNetDebit
+	}
+
+	return models.OrderTypeNetCredit
+}
+
 // StraddleParams holds parameters for building a straddle order.
 // A straddle buys (or sells) both a call and a put at the same strike.
 type StraddleParams struct {

--- a/internal/orderbuilder/spread_test.go
+++ b/internal/orderbuilder/spread_test.go
@@ -173,6 +173,49 @@ func TestBuildDoubleDiagonalOrderOpen(t *testing.T) {
 	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[3].Instruction)
 }
 
+// TestBuildButterflyOrderShortOpen verifies short butterflies use credit order
+// semantics and the inverse leg directions from long butterflies.
+func TestBuildButterflyOrderShortOpen(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildButterflyOrder(&ButterflyParams{
+		Underlying: "F", Expiration: expiration, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14,
+		PutCall: models.PutCallPut, Buy: false, Open: true, Quantity: 1, Price: 0.45,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetCredit, order.OrderType)
+	require.Len(t, order.OrderLegCollection, 3)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[2].Instruction)
+}
+
+// TestBuildDoubleDiagonalOrderClose verifies close-side order semantics for the
+// strategy that defaults to debit on open and credit on close.
+func TestBuildDoubleDiagonalOrderClose(t *testing.T) {
+	t.Parallel()
+
+	nearExpiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+	farExpiration := time.Date(2026, time.July, 17, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildDoubleDiagonalOrder(&DoubleDiagonalParams{
+		Underlying: "F", NearExpiration: nearExpiration, FarExpiration: farExpiration,
+		PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15,
+		Open: false, Quantity: 1, Price: 0.70,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetCredit, order.OrderType)
+	require.Len(t, order.OrderLegCollection, 4)
+	assert.Equal(t, models.InstructionSellToClose, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionBuyToClose, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, models.InstructionBuyToClose, order.OrderLegCollection[2].Instruction)
+	assert.Equal(t, models.InstructionSellToClose, order.OrderLegCollection[3].Instruction)
+}
+
 // TestBuildVerticalOrderBearCallOpen verifies a bear call spread (credit to open).
 // BUY higher strike call + SELL lower strike call = NET_CREDIT.
 func TestBuildVerticalOrderBearCallOpen(t *testing.T) {

--- a/internal/orderbuilder/spread_test.go
+++ b/internal/orderbuilder/spread_test.go
@@ -60,6 +60,119 @@ func TestBuildVerticalOrderBullCallOpen(t *testing.T) {
 	assert.Equal(t, 14.0, *shortLeg.Instrument.OptionStrikePrice)
 }
 
+// TestBuildButterflyOrderLongOpen verifies a long butterfly uses long wings and a short body.
+func TestBuildButterflyOrderLongOpen(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildButterflyOrder(&ButterflyParams{
+		Underlying: "F", Expiration: expiration, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14,
+		PutCall: models.PutCallCall, Buy: true, Open: true, Quantity: 1, Price: 0.50,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetDebit, order.OrderType)
+	require.NotNil(t, order.ComplexOrderStrategyType)
+	assert.Equal(t, models.ComplexOrderStrategyTypeButterfly, *order.ComplexOrderStrategyType)
+	require.Len(t, order.OrderLegCollection, 3)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, 2.0, order.OrderLegCollection[1].Quantity)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[2].Instruction)
+}
+
+// TestBuildCondorOrderShortClose verifies a short condor close buys the wings back.
+func TestBuildCondorOrderShortClose(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildCondorOrder(&CondorParams{
+		Underlying: "F", Expiration: expiration, LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16,
+		PutCall: models.PutCallPut, Buy: false, Open: false, Quantity: 1, Price: 0.75,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetDebit, order.OrderType)
+	require.NotNil(t, order.ComplexOrderStrategyType)
+	assert.Equal(t, models.ComplexOrderStrategyTypeCondor, *order.ComplexOrderStrategyType)
+	require.Len(t, order.OrderLegCollection, 4)
+	assert.Equal(t, models.InstructionBuyToClose, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionSellToClose, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, models.InstructionSellToClose, order.OrderLegCollection[2].Instruction)
+	assert.Equal(t, models.InstructionBuyToClose, order.OrderLegCollection[3].Instruction)
+}
+
+// TestBuildBackRatioOrderOpen verifies a one-by-two back-ratio spread.
+func TestBuildBackRatioOrderOpen(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildBackRatioOrder(&BackRatioParams{
+		Underlying: "F", Expiration: expiration, ShortStrike: 12, LongStrike: 14,
+		PutCall: models.PutCallCall, Open: true, Quantity: 1, LongRatio: 2, Credit: false, Price: 0.20,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetDebit, order.OrderType)
+	require.NotNil(t, order.ComplexOrderStrategyType)
+	assert.Equal(t, models.ComplexOrderStrategyTypeBackRatio, *order.ComplexOrderStrategyType)
+	require.Len(t, order.OrderLegCollection, 2)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, 2.0, order.OrderLegCollection[1].Quantity)
+}
+
+// TestBuildVerticalRollOrder verifies closing and opening vertical legs are ordered clearly.
+func TestBuildVerticalRollOrder(t *testing.T) {
+	t.Parallel()
+
+	closeExpiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+	openExpiration := time.Date(2026, time.July, 17, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildVerticalRollOrder(&VerticalRollParams{
+		Underlying: "F", CloseExpiration: closeExpiration, OpenExpiration: openExpiration,
+		CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15,
+		PutCall: models.PutCallCall, Credit: true, Quantity: 1, Price: 0.25,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetCredit, order.OrderType)
+	require.NotNil(t, order.ComplexOrderStrategyType)
+	assert.Equal(t, models.ComplexOrderStrategyTypeVerticalRoll, *order.ComplexOrderStrategyType)
+	require.Len(t, order.OrderLegCollection, 4)
+	assert.Equal(t, models.InstructionSellToClose, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionBuyToClose, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[2].Instruction)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[3].Instruction)
+}
+
+// TestBuildDoubleDiagonalOrderOpen verifies long far legs and short near legs.
+func TestBuildDoubleDiagonalOrderOpen(t *testing.T) {
+	t.Parallel()
+
+	nearExpiration := time.Date(2026, time.June, 18, 0, 0, 0, 0, time.UTC)
+	farExpiration := time.Date(2026, time.July, 17, 0, 0, 0, 0, time.UTC)
+
+	order, err := BuildDoubleDiagonalOrder(&DoubleDiagonalParams{
+		Underlying: "F", NearExpiration: nearExpiration, FarExpiration: farExpiration,
+		PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15,
+		Open: true, Quantity: 1, Price: 0.80,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.OrderTypeNetDebit, order.OrderType)
+	require.NotNil(t, order.ComplexOrderStrategyType)
+	assert.Equal(t, models.ComplexOrderStrategyTypeDoubleDiagonal, *order.ComplexOrderStrategyType)
+	require.Len(t, order.OrderLegCollection, 4)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[0].Instruction)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[1].Instruction)
+	assert.Equal(t, models.InstructionSellToOpen, order.OrderLegCollection[2].Instruction)
+	assert.Equal(t, models.InstructionBuyToOpen, order.OrderLegCollection[3].Instruction)
+}
+
 // TestBuildVerticalOrderBearCallOpen verifies a bear call spread (credit to open).
 // BUY higher strike call + SELL lower strike call = NET_CREDIT.
 func TestBuildVerticalOrderBearCallOpen(t *testing.T) {

--- a/internal/orderbuilder/validate.go
+++ b/internal/orderbuilder/validate.go
@@ -2,6 +2,7 @@
 package orderbuilder
 
 import (
+	"math"
 	"strings"
 	"time"
 
@@ -321,6 +322,229 @@ func ValidateIronCondorOrder(params *IronCondorParams) error {
 	return validateSpreadPrice(params.Price, "iron condors")
 }
 
+// ValidateButterflyOrder validates butterfly spread parameters.
+func ValidateButterflyOrder(params *ButterflyParams) error {
+	if err := validateUnderlying(params.Underlying); err != nil {
+		return err
+	}
+
+	if err := validateQuantity(params.Quantity); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.Expiration); err != nil {
+		return err
+	}
+
+	if err := validatePositiveStrikes([]namedStrike{
+		{params.LowerStrike, "lower-strike"},
+		{params.MiddleStrike, "middle-strike"},
+		{params.UpperStrike, "upper-strike"},
+	}); err != nil {
+		return err
+	}
+
+	if params.LowerStrike >= params.MiddleStrike || params.MiddleStrike >= params.UpperStrike {
+		return validationError("butterfly strikes must be ordered lower < middle < upper", "Use three increasing strikes with `--lower-strike`, `--middle-strike`, and `--upper-strike`")
+	}
+
+	if !sameStrikeWidth(params.MiddleStrike-params.LowerStrike, params.UpperStrike-params.MiddleStrike) {
+		return validationError(
+			"butterfly wings must be balanced",
+			"Use equal distances from `--middle-strike` to `--lower-strike` and `--upper-strike`; unbalanced butterflies are a separate strategy type",
+		)
+	}
+
+	if params.PutCall == "" {
+		return validationError("option type (call or put) is required", "Add `--call` or `--put`")
+	}
+
+	return validateSpreadPrice(params.Price, "butterflies")
+}
+
+// ValidateCondorOrder validates condor spread parameters.
+func ValidateCondorOrder(params *CondorParams) error {
+	if err := validateUnderlying(params.Underlying); err != nil {
+		return err
+	}
+
+	if err := validateQuantity(params.Quantity); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.Expiration); err != nil {
+		return err
+	}
+
+	if err := validatePositiveStrikes([]namedStrike{
+		{params.LowerStrike, "lower-strike"},
+		{params.LowerMiddleStrike, "lower-middle-strike"},
+		{params.UpperMiddleStrike, "upper-middle-strike"},
+		{params.UpperStrike, "upper-strike"},
+	}); err != nil {
+		return err
+	}
+
+	if params.LowerStrike >= params.LowerMiddleStrike || params.LowerMiddleStrike >= params.UpperMiddleStrike || params.UpperMiddleStrike >= params.UpperStrike {
+		return validationError("condor strikes must be ordered lower < lower-middle < upper-middle < upper", "Use four increasing strikes for the condor wings and middle strikes")
+	}
+
+	if !sameStrikeWidth(params.LowerMiddleStrike-params.LowerStrike, params.UpperStrike-params.UpperMiddleStrike) {
+		return validationError(
+			"condor wings must be balanced",
+			"Use equal wing widths between lower/lower-middle and upper-middle/upper; unbalanced condors are a separate strategy type",
+		)
+	}
+
+	if params.PutCall == "" {
+		return validationError("option type (call or put) is required", "Add `--call` or `--put`")
+	}
+
+	return validateSpreadPrice(params.Price, "condors")
+}
+
+// ValidateBackRatioOrder validates back-ratio spread parameters.
+func ValidateBackRatioOrder(params *BackRatioParams) error {
+	if err := validateUnderlying(params.Underlying); err != nil {
+		return err
+	}
+
+	if err := validateQuantity(params.Quantity); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.Expiration); err != nil {
+		return err
+	}
+
+	if err := validatePositiveStrikes([]namedStrike{
+		{params.ShortStrike, "short-strike"},
+		{params.LongStrike, "long-strike"},
+	}); err != nil {
+		return err
+	}
+
+	if params.ShortStrike == params.LongStrike {
+		return validationError("short and long strikes must be different", "Use different values for `--short-strike` and `--long-strike`")
+	}
+
+	if params.PutCall == models.PutCallCall && params.LongStrike <= params.ShortStrike {
+		return validationError("call back-ratio long strike must be above short strike", "For call back-ratios, sell the lower strike and buy more contracts at the higher strike")
+	}
+
+	if params.PutCall == models.PutCallPut && params.LongStrike >= params.ShortStrike {
+		return validationError("put back-ratio long strike must be below short strike", "For put back-ratios, sell the higher strike and buy more contracts at the lower strike")
+	}
+
+	if params.LongRatio <= 1 {
+		return validationError("long ratio must be greater than one", "Use `--long-ratio 2` for the standard one-by-two back-ratio")
+	}
+
+	if params.PutCall == "" {
+		return validationError("option type (call or put) is required", "Add `--call` or `--put`")
+	}
+
+	return validateSpreadPrice(params.Price, "back-ratios")
+}
+
+// ValidateVerticalRollOrder validates vertical roll parameters.
+func ValidateVerticalRollOrder(params *VerticalRollParams) error {
+	if err := validateUnderlying(params.Underlying); err != nil {
+		return err
+	}
+
+	if err := validateQuantity(params.Quantity); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.CloseExpiration); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.OpenExpiration); err != nil {
+		return err
+	}
+
+	if params.OpenExpiration.Before(params.CloseExpiration) {
+		return validationError("open expiration must not be before close expiration", "Use `--open-expiration` on or after `--close-expiration`")
+	}
+
+	if err := validatePositiveStrikes([]namedStrike{
+		{params.CloseLongStrike, "close-long-strike"},
+		{params.CloseShortStrike, "close-short-strike"},
+		{params.OpenLongStrike, "open-long-strike"},
+		{params.OpenShortStrike, "open-short-strike"},
+	}); err != nil {
+		return err
+	}
+
+	if params.CloseLongStrike == params.CloseShortStrike {
+		return validationError("close long and short strikes must be different", "Use different values for `--close-long-strike` and `--close-short-strike`")
+	}
+
+	if params.OpenLongStrike == params.OpenShortStrike {
+		return validationError("open long and short strikes must be different", "Use different values for `--open-long-strike` and `--open-short-strike`")
+	}
+
+	if !sameStrikeWidth(spreadWidth(params.CloseLongStrike, params.CloseShortStrike), spreadWidth(params.OpenLongStrike, params.OpenShortStrike)) {
+		return validationError(
+			"vertical roll widths must match",
+			"Use equal close and open spread widths for `VERTICAL_ROLL`; unequal widths are a separate unbalanced strategy type",
+		)
+	}
+
+	if params.CloseExpiration.Equal(params.OpenExpiration) && params.CloseLongStrike == params.OpenLongStrike && params.CloseShortStrike == params.OpenShortStrike {
+		return validationError(
+			"vertical roll must change strikes or expiration",
+			"Use different open strikes or a later `--open-expiration` so the roll changes the position",
+		)
+	}
+
+	if params.PutCall == "" {
+		return validationError("option type (call or put) is required", "Add `--call` or `--put`")
+	}
+
+	return validateSpreadPrice(params.Price, "vertical rolls")
+}
+
+// ValidateDoubleDiagonalOrder validates double diagonal spread parameters.
+func ValidateDoubleDiagonalOrder(params *DoubleDiagonalParams) error {
+	if err := validateUnderlying(params.Underlying); err != nil {
+		return err
+	}
+
+	if err := validateQuantity(params.Quantity); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.NearExpiration); err != nil {
+		return err
+	}
+
+	if err := validateExpiration(params.FarExpiration); err != nil {
+		return err
+	}
+
+	if params.NearExpiration.Equal(params.FarExpiration) || params.NearExpiration.After(params.FarExpiration) {
+		return validationError("near expiration must be before far expiration", "Use `--near-expiration` before `--far-expiration`")
+	}
+
+	if err := validatePositiveStrikes([]namedStrike{
+		{params.PutFarStrike, "put-far-strike"},
+		{params.PutNearStrike, "put-near-strike"},
+		{params.CallNearStrike, "call-near-strike"},
+		{params.CallFarStrike, "call-far-strike"},
+	}); err != nil {
+		return err
+	}
+
+	if params.PutFarStrike >= params.PutNearStrike || params.PutNearStrike >= params.CallNearStrike || params.CallNearStrike >= params.CallFarStrike {
+		return validationError("double diagonal strikes must be ordered put-far < put-near < call-near < call-far", "Keep put strikes below call strikes so the near short legs do not overlap")
+	}
+
+	return validateSpreadPrice(params.Price, "double diagonals")
+}
+
 // ValidateStrangleOrder validates strangle parameters.
 func ValidateStrangleOrder(params *StrangleParams) error {
 	if err := validateUnderlying(params.Underlying); err != nil {
@@ -564,6 +788,39 @@ func validateSpreadPrice(price float64, strategy string) error {
 	}
 
 	return nil
+}
+
+// namedStrike pairs a strike value with its CLI flag name for validation errors.
+type namedStrike struct {
+	value float64
+	name  string
+}
+
+// validatePositiveStrikes checks a set of strike flags for positive values.
+func validatePositiveStrikes(strikes []namedStrike) error {
+	for _, strike := range strikes {
+		if strike.value <= 0 {
+			return validationError(strike.name+" must be greater than zero", "Add `--"+strike.name+" <price>` with a positive value")
+		}
+	}
+
+	return nil
+}
+
+// spreadWidth returns the absolute distance between two strikes. Vertical spreads
+// can be entered with the long leg above or below the short leg, so validation
+// compares widths rather than relying on strike ordering.
+func spreadWidth(firstStrike, secondStrike float64) float64 {
+	return math.Abs(firstStrike - secondStrike)
+}
+
+// sameStrikeWidth compares option strike distances with a small tolerance. Strike
+// flags are decimal values, and direct float64 equality can reject valid spreads
+// when equivalent decimal widths have slightly different binary representations.
+func sameStrikeWidth(left, right float64) bool {
+	const strikeWidthTolerance = 1e-9
+
+	return math.Abs(left-right) <= strikeWidthTolerance
 }
 
 // validatePriceLinkPair checks that price-link-basis and price-link-type are

--- a/internal/orderbuilder/validate.go
+++ b/internal/orderbuilder/validate.go
@@ -440,6 +440,10 @@ func ValidateBackRatioOrder(params *BackRatioParams) error {
 		return validationError("long ratio must be greater than one", "Use `--long-ratio 2` for the standard one-by-two back-ratio")
 	}
 
+	if math.Trunc(params.LongRatio) != params.LongRatio {
+		return validationError("long ratio must be a whole number", "Use an integer value like `--long-ratio 2`")
+	}
+
 	if params.PutCall == "" {
 		return validationError("option type (call or put) is required", "Add `--call` or `--put`")
 	}

--- a/internal/orderbuilder/validate_test.go
+++ b/internal/orderbuilder/validate_test.go
@@ -262,6 +262,190 @@ func TestValidateVerticalOrderRequiresUnderlying(t *testing.T) {
 	assertValidationError(t, err, "underlying symbol is required", "Add `--underlying <TICKER>` to specify the underlying stock")
 }
 
+// TestValidateButterflyOrderRejectsUnorderedStrikes verifies butterfly strike ordering.
+func TestValidateButterflyOrderRejectsUnorderedStrikes(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateButterflyOrder(&ButterflyParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		LowerStrike: 12, MiddleStrike: 10, UpperStrike: 14, PutCall: models.PutCallCall,
+		Buy: true, Open: true, Quantity: 1, Price: 0.50,
+	})
+
+	assertValidationError(t, err, "butterfly strikes must be ordered lower < middle < upper", "Use three increasing strikes with `--lower-strike`, `--middle-strike`, and `--upper-strike`")
+}
+
+// TestValidateButterflyOrderRejectsUnbalancedWings keeps the balanced strategy
+// from accepting shapes that Schwab represents with UNBALANCED_BUTTERFLY.
+func TestValidateButterflyOrderRejectsUnbalancedWings(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateButterflyOrder(&ButterflyParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		LowerStrike: 10, MiddleStrike: 12, UpperStrike: 15, PutCall: models.PutCallCall,
+		Buy: true, Open: true, Quantity: 1, Price: 0.50,
+	})
+
+	assertValidationError(t, err, "butterfly wings must be balanced", "Use equal distances from `--middle-strike` to `--lower-strike` and `--upper-strike`; unbalanced butterflies are a separate strategy type")
+}
+
+// TestValidateCondorOrderRejectsUnorderedStrikes verifies condor strike ordering.
+func TestValidateCondorOrderRejectsUnorderedStrikes(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateCondorOrder(&CondorParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		LowerStrike: 10, LowerMiddleStrike: 14, UpperMiddleStrike: 12, UpperStrike: 16, PutCall: models.PutCallPut,
+		Buy: true, Open: true, Quantity: 1, Price: 0.50,
+	})
+
+	assertValidationError(t, err, "condor strikes must be ordered lower < lower-middle < upper-middle < upper", "Use four increasing strikes for the condor wings and middle strikes")
+}
+
+// TestValidateCondorOrderRejectsUnbalancedWings keeps the balanced strategy
+// distinct from Schwab's UNBALANCED_CONDOR enum value.
+func TestValidateCondorOrderRejectsUnbalancedWings(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateCondorOrder(&CondorParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 17, PutCall: models.PutCallPut,
+		Buy: true, Open: true, Quantity: 1, Price: 0.50,
+	})
+
+	assertValidationError(t, err, "condor wings must be balanced", "Use equal wing widths between lower/lower-middle and upper-middle/upper; unbalanced condors are a separate strategy type")
+}
+
+// TestValidateBackRatioOrderRejectsInvalidRatio verifies back-ratio quantity relationship.
+func TestValidateBackRatioOrderRejectsInvalidRatio(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateBackRatioOrder(&BackRatioParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallCall,
+		Open: true, Quantity: 1, LongRatio: 1, Price: 0.20,
+	})
+
+	assertValidationError(t, err, "long ratio must be greater than one", "Use `--long-ratio 2` for the standard one-by-two back-ratio")
+}
+
+// TestValidateBackRatioOrderRejectsWrongCallDirection verifies the conventional
+// call back-ratio shape: sell the lower strike and buy more contracts higher.
+func TestValidateBackRatioOrderRejectsWrongCallDirection(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateBackRatioOrder(&BackRatioParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		ShortStrike: 14, LongStrike: 12, PutCall: models.PutCallCall,
+		Open: true, Quantity: 1, LongRatio: 2, Price: 0.20,
+	})
+
+	assertValidationError(t, err, "call back-ratio long strike must be above short strike", "For call back-ratios, sell the lower strike and buy more contracts at the higher strike")
+}
+
+// TestValidateBackRatioOrderRejectsWrongPutDirection verifies the conventional
+// put back-ratio shape: sell the higher strike and buy more contracts lower.
+func TestValidateBackRatioOrderRejectsWrongPutDirection(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateBackRatioOrder(&BackRatioParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallPut,
+		Open: true, Quantity: 1, LongRatio: 2, Price: 0.20,
+	})
+
+	assertValidationError(t, err, "put back-ratio long strike must be below short strike", "For put back-ratios, sell the higher strike and buy more contracts at the lower strike")
+}
+
+// TestValidateVerticalRollOrderRejectsEqualOpenStrikes verifies rolled verticals remain spreads.
+func TestValidateVerticalRollOrderRejectsEqualOpenStrikes(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateVerticalRollOrder(&VerticalRollParams{
+		Underlying: "F", CloseExpiration: time.Now().UTC().Add(30 * 24 * time.Hour), OpenExpiration: time.Now().UTC().Add(60 * 24 * time.Hour),
+		CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 15, OpenShortStrike: 15,
+		PutCall: models.PutCallCall, Quantity: 1, Price: 0.25,
+	})
+
+	assertValidationError(t, err, "open long and short strikes must be different", "Use different values for `--open-long-strike` and `--open-short-strike`")
+}
+
+// TestValidateVerticalRollOrderAcceptsSameExpirationStrikeRoll verifies users can
+// roll a vertical up or down within the same expiration cycle.
+func TestValidateVerticalRollOrderAcceptsSameExpirationStrikeRoll(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Now().UTC().Add(30 * 24 * time.Hour)
+
+	err := ValidateVerticalRollOrder(&VerticalRollParams{
+		Underlying: "F", CloseExpiration: expiration, OpenExpiration: expiration,
+		CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15,
+		PutCall: models.PutCallCall, Quantity: 1, Price: 0.25,
+	})
+
+	require.NoError(t, err)
+}
+
+// TestValidateVerticalRollOrderRejectsEarlierOpenExpiration verifies rolls never
+// open a new spread before the spread being closed.
+func TestValidateVerticalRollOrderRejectsEarlierOpenExpiration(t *testing.T) {
+	t.Parallel()
+
+	closeExpiration := time.Now().UTC().Add(60 * 24 * time.Hour)
+	openExpiration := time.Now().UTC().Add(30 * 24 * time.Hour)
+
+	err := ValidateVerticalRollOrder(&VerticalRollParams{
+		Underlying: "F", CloseExpiration: closeExpiration, OpenExpiration: openExpiration,
+		CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15,
+		PutCall: models.PutCallCall, Quantity: 1, Price: 0.25,
+	})
+
+	assertValidationError(t, err, "open expiration must not be before close expiration", "Use `--open-expiration` on or after `--close-expiration`")
+}
+
+// TestValidateVerticalRollOrderRejectsUnequalWidths preserves the distinction
+// between balanced VERTICAL_ROLL and Schwab's UNBALANCED_VERTICAL_ROLL enum.
+func TestValidateVerticalRollOrderRejectsUnequalWidths(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateVerticalRollOrder(&VerticalRollParams{
+		Underlying: "F", CloseExpiration: time.Now().UTC().Add(30 * 24 * time.Hour), OpenExpiration: time.Now().UTC().Add(60 * 24 * time.Hour),
+		CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 16,
+		PutCall: models.PutCallCall, Quantity: 1, Price: 0.25,
+	})
+
+	assertValidationError(t, err, "vertical roll widths must match", "Use equal close and open spread widths for `VERTICAL_ROLL`; unequal widths are a separate unbalanced strategy type")
+}
+
+// TestValidateVerticalRollOrderRejectsNoopRoll catches close/open legs that would
+// close and reopen the same vertical without changing strikes or expiration.
+func TestValidateVerticalRollOrderRejectsNoopRoll(t *testing.T) {
+	t.Parallel()
+
+	expiration := time.Now().UTC().Add(30 * 24 * time.Hour)
+
+	err := ValidateVerticalRollOrder(&VerticalRollParams{
+		Underlying: "F", CloseExpiration: expiration, OpenExpiration: expiration,
+		CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 12, OpenShortStrike: 14,
+		PutCall: models.PutCallCall, Quantity: 1, Price: 0.25,
+	})
+
+	assertValidationError(t, err, "vertical roll must change strikes or expiration", "Use different open strikes or a later `--open-expiration` so the roll changes the position")
+}
+
+// TestValidateDoubleDiagonalOrderRejectsOverlappingStrikes verifies put/call sides do not overlap.
+func TestValidateDoubleDiagonalOrderRejectsOverlappingStrikes(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{
+		Underlying: "F", NearExpiration: time.Now().UTC().Add(30 * 24 * time.Hour), FarExpiration: time.Now().UTC().Add(60 * 24 * time.Hour),
+		PutFarStrike: 9, PutNearStrike: 15, CallNearStrike: 14, CallFarStrike: 16,
+		Open: true, Quantity: 1, Price: 0.80,
+	})
+
+	assertValidationError(t, err, "double diagonal strikes must be ordered put-far < put-near < call-near < call-far", "Keep put strikes below call strikes so the near short legs do not overlap")
+}
+
 // TestValidateVerticalOrderRejectsEqualStrikes verifies same-strike rejection.
 func TestValidateVerticalOrderRejectsEqualStrikes(t *testing.T) {
 	t.Parallel()

--- a/internal/orderbuilder/validate_test.go
+++ b/internal/orderbuilder/validate_test.go
@@ -1,7 +1,6 @@
 package orderbuilder
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -327,6 +326,19 @@ func TestValidateBackRatioOrderRejectsInvalidRatio(t *testing.T) {
 	})
 
 	assertValidationError(t, err, "long ratio must be greater than one", "Use `--long-ratio 2` for the standard one-by-two back-ratio")
+}
+
+// TestValidateBackRatioOrderRejectsFractionalRatio prevents fractional option legs.
+func TestValidateBackRatioOrderRejectsFractionalRatio(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateBackRatioOrder(&BackRatioParams{
+		Underlying: "F", Expiration: time.Now().UTC().Add(30 * 24 * time.Hour),
+		ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallCall,
+		Open: true, Quantity: 1, LongRatio: 1.5, Price: 0.20,
+	})
+
+	assertValidationError(t, err, "long ratio must be a whole number", "Use an integer value like `--long-ratio 2`")
 }
 
 // TestValidateBackRatioOrderRejectsWrongCallDirection verifies the conventional
@@ -695,7 +707,7 @@ func TestValidateNewOptionStrategiesCommonFailures(t *testing.T) {
 			err := testCase.check()
 
 			var validationErr *apperr.ValidationError
-			require.True(t, errors.As(err, &validationErr), "expected ValidationError, got %T: %v", err, err)
+			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, testCase.message, validationErr.Message)
 		})
 	}
@@ -2125,8 +2137,8 @@ func TestValidateVerticalOrderRemainingBranches(t *testing.T) {
 			err := ValidateVerticalOrder(&tt.params)
 
 			require.Error(t, err)
-			validationErr, ok := errors.AsType[*apperr.ValidationError](err)
-			require.True(t, ok)
+			var validationErr *apperr.ValidationError
+			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, tt.wantMsg, validationErr.Message)
 		})
 	}
@@ -2220,8 +2232,8 @@ func TestValidateIronCondorRemainingBranches(t *testing.T) {
 			err := ValidateIronCondorOrder(&tt.params)
 
 			require.Error(t, err)
-			validationErr, ok := errors.AsType[*apperr.ValidationError](err)
-			require.True(t, ok)
+			var validationErr *apperr.ValidationError
+			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, tt.wantMsg, validationErr.Message)
 		})
 	}
@@ -2292,8 +2304,8 @@ func TestValidateStrangleRemainingBranches(t *testing.T) {
 			err := ValidateStrangleOrder(&tt.params)
 
 			require.Error(t, err)
-			validationErr, ok := errors.AsType[*apperr.ValidationError](err)
-			require.True(t, ok)
+			var validationErr *apperr.ValidationError
+			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, tt.wantMsg, validationErr.Message)
 		})
 	}
@@ -2338,8 +2350,8 @@ func TestValidateStraddleRemainingBranches(t *testing.T) {
 			err := ValidateStraddleOrder(&tt.params)
 
 			require.Error(t, err)
-			validationErr, ok := errors.AsType[*apperr.ValidationError](err)
-			require.True(t, ok)
+			var validationErr *apperr.ValidationError
+			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, tt.wantMsg, validationErr.Message)
 		})
 	}
@@ -2384,8 +2396,8 @@ func TestValidateCoveredCallRemainingBranches(t *testing.T) {
 			err := ValidateCoveredCallOrder(&tt.params)
 
 			require.Error(t, err)
-			validationErr, ok := errors.AsType[*apperr.ValidationError](err)
-			require.True(t, ok)
+			var validationErr *apperr.ValidationError
+			require.ErrorAs(t, err, &validationErr)
 			assert.Equal(t, tt.wantMsg, validationErr.Message)
 		})
 	}
@@ -2486,8 +2498,8 @@ func assertValidationError(t *testing.T, err error, expectedMessage, expectedDet
 
 	require.Error(t, err)
 
-	validationErr, ok := errors.AsType[*apperr.ValidationError](err)
-	require.True(t, ok)
+	var validationErr *apperr.ValidationError
+	require.ErrorAs(t, err, &validationErr)
 	assert.Equal(t, expectedMessage, validationErr.Message)
 	assert.Equal(t, expectedDetails, validationErr.Details())
 }

--- a/internal/orderbuilder/validate_test.go
+++ b/internal/orderbuilder/validate_test.go
@@ -446,6 +446,261 @@ func TestValidateDoubleDiagonalOrderRejectsOverlappingStrikes(t *testing.T) {
 	assertValidationError(t, err, "double diagonal strikes must be ordered put-far < put-near < call-near < call-far", "Keep put strikes below call strikes so the near short legs do not overlap")
 }
 
+// TestValidateNewOptionStrategiesCommonFailures covers validation branches that
+// are shared by the new strategy builders. These are user-facing errors, not
+// coverage-only paths, because every builder can receive malformed direct API
+// input even when CLI flag constraints catch many cases earlier.
+func TestValidateNewOptionStrategiesCommonFailures(t *testing.T) {
+	t.Parallel()
+
+	future := time.Now().UTC().Add(30 * 24 * time.Hour)
+	later := future.Add(30 * 24 * time.Hour)
+	past := time.Now().UTC().Add(-24 * time.Hour)
+
+	testCases := []struct {
+		name    string
+		check   func() error
+		message string
+	}{
+		{
+			name: "butterfly missing underlying",
+			check: func() error {
+				return ValidateButterflyOrder(&ButterflyParams{Expiration: future, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14, PutCall: models.PutCallCall, Quantity: 1, Price: 0.50})
+			},
+			message: "underlying symbol is required",
+		},
+		{
+			name: "butterfly zero quantity",
+			check: func() error {
+				return ValidateButterflyOrder(&ButterflyParams{Underlying: "F", Expiration: future, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14, PutCall: models.PutCallCall, Price: 0.50})
+			},
+			message: "quantity must be greater than zero",
+		},
+		{
+			name: "butterfly past expiration",
+			check: func() error {
+				return ValidateButterflyOrder(&ButterflyParams{Underlying: "F", Expiration: past, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14, PutCall: models.PutCallCall, Quantity: 1, Price: 0.50})
+			},
+			message: "option expiration date is in the past",
+		},
+		{
+			name: "butterfly negative strike",
+			check: func() error {
+				return ValidateButterflyOrder(&ButterflyParams{Underlying: "F", Expiration: future, LowerStrike: -10, MiddleStrike: 12, UpperStrike: 14, PutCall: models.PutCallCall, Quantity: 1, Price: 0.50})
+			},
+			message: "lower-strike must be greater than zero",
+		},
+		{
+			name: "butterfly missing option type",
+			check: func() error {
+				return ValidateButterflyOrder(&ButterflyParams{Underlying: "F", Expiration: future, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14, Quantity: 1, Price: 0.50})
+			},
+			message: "option type (call or put) is required",
+		},
+		{
+			name: "butterfly missing price",
+			check: func() error {
+				return ValidateButterflyOrder(&ButterflyParams{Underlying: "F", Expiration: future, LowerStrike: 10, MiddleStrike: 12, UpperStrike: 14, PutCall: models.PutCallCall, Quantity: 1})
+			},
+			message: "price is required for butterflies",
+		},
+		{
+			name: "condor missing option type",
+			check: func() error {
+				return ValidateCondorOrder(&CondorParams{Underlying: "F", Expiration: future, LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16, Quantity: 1, Price: 0.50})
+			},
+			message: "option type (call or put) is required",
+		},
+		{
+			name: "condor missing underlying",
+			check: func() error {
+				return ValidateCondorOrder(&CondorParams{Expiration: future, LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16, PutCall: models.PutCallPut, Quantity: 1, Price: 0.50})
+			},
+			message: "underlying symbol is required",
+		},
+		{
+			name: "condor zero quantity",
+			check: func() error {
+				return ValidateCondorOrder(&CondorParams{Underlying: "F", Expiration: future, LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16, PutCall: models.PutCallPut, Price: 0.50})
+			},
+			message: "quantity must be greater than zero",
+		},
+		{
+			name: "condor past expiration",
+			check: func() error {
+				return ValidateCondorOrder(&CondorParams{Underlying: "F", Expiration: past, LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16, PutCall: models.PutCallPut, Quantity: 1, Price: 0.50})
+			},
+			message: "option expiration date is in the past",
+		},
+		{
+			name: "condor negative strike",
+			check: func() error {
+				return ValidateCondorOrder(&CondorParams{Underlying: "F", Expiration: future, LowerStrike: 10, LowerMiddleStrike: -12, UpperMiddleStrike: 14, UpperStrike: 16, PutCall: models.PutCallPut, Quantity: 1, Price: 0.50})
+			},
+			message: "lower-middle-strike must be greater than zero",
+		},
+		{
+			name: "condor missing price",
+			check: func() error {
+				return ValidateCondorOrder(&CondorParams{Underlying: "F", Expiration: future, LowerStrike: 10, LowerMiddleStrike: 12, UpperMiddleStrike: 14, UpperStrike: 16, PutCall: models.PutCallPut, Quantity: 1})
+			},
+			message: "price is required for condors",
+		},
+		{
+			name: "back-ratio equal strikes",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Underlying: "F", Expiration: future, ShortStrike: 12, LongStrike: 12, PutCall: models.PutCallCall, Quantity: 1, LongRatio: 2, Price: 0.20})
+			},
+			message: "short and long strikes must be different",
+		},
+		{
+			name: "back-ratio missing underlying",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Expiration: future, ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallCall, Quantity: 1, LongRatio: 2, Price: 0.20})
+			},
+			message: "underlying symbol is required",
+		},
+		{
+			name: "back-ratio zero quantity",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Underlying: "F", Expiration: future, ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallCall, LongRatio: 2, Price: 0.20})
+			},
+			message: "quantity must be greater than zero",
+		},
+		{
+			name: "back-ratio past expiration",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Underlying: "F", Expiration: past, ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallCall, Quantity: 1, LongRatio: 2, Price: 0.20})
+			},
+			message: "option expiration date is in the past",
+		},
+		{
+			name: "back-ratio negative strike",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Underlying: "F", Expiration: future, ShortStrike: -12, LongStrike: 14, PutCall: models.PutCallCall, Quantity: 1, LongRatio: 2, Price: 0.20})
+			},
+			message: "short-strike must be greater than zero",
+		},
+		{
+			name: "back-ratio missing option type",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Underlying: "F", Expiration: future, ShortStrike: 12, LongStrike: 14, Quantity: 1, LongRatio: 2, Price: 0.20})
+			},
+			message: "option type (call or put) is required",
+		},
+		{
+			name: "back-ratio missing price",
+			check: func() error {
+				return ValidateBackRatioOrder(&BackRatioParams{Underlying: "F", Expiration: future, ShortStrike: 12, LongStrike: 14, PutCall: models.PutCallCall, Quantity: 1, LongRatio: 2})
+			},
+			message: "price is required for back-ratios",
+		},
+		{
+			name: "vertical-roll equal close strikes",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{Underlying: "F", CloseExpiration: future, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 12, OpenLongStrike: 13, OpenShortStrike: 15, PutCall: models.PutCallCall, Quantity: 1, Price: 0.25})
+			},
+			message: "close long and short strikes must be different",
+		},
+		{
+			name: "vertical-roll missing underlying",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{CloseExpiration: future, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15, PutCall: models.PutCallCall, Quantity: 1, Price: 0.25})
+			},
+			message: "underlying symbol is required",
+		},
+		{
+			name: "vertical-roll zero quantity",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{Underlying: "F", CloseExpiration: future, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15, PutCall: models.PutCallCall, Price: 0.25})
+			},
+			message: "quantity must be greater than zero",
+		},
+		{
+			name: "vertical-roll past close expiration",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{Underlying: "F", CloseExpiration: past, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15, PutCall: models.PutCallCall, Quantity: 1, Price: 0.25})
+			},
+			message: "option expiration date is in the past",
+		},
+		{
+			name: "vertical-roll negative strike",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{Underlying: "F", CloseExpiration: future, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: -13, OpenShortStrike: 15, PutCall: models.PutCallCall, Quantity: 1, Price: 0.25})
+			},
+			message: "open-long-strike must be greater than zero",
+		},
+		{
+			name: "vertical-roll missing option type",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{Underlying: "F", CloseExpiration: future, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15, Quantity: 1, Price: 0.25})
+			},
+			message: "option type (call or put) is required",
+		},
+		{
+			name: "vertical-roll missing price",
+			check: func() error {
+				return ValidateVerticalRollOrder(&VerticalRollParams{Underlying: "F", CloseExpiration: future, OpenExpiration: later, CloseLongStrike: 12, CloseShortStrike: 14, OpenLongStrike: 13, OpenShortStrike: 15, PutCall: models.PutCallCall, Quantity: 1})
+			},
+			message: "price is required for vertical rolls",
+		},
+		{
+			name: "double-diagonal missing underlying",
+			check: func() error {
+				return ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{NearExpiration: future, FarExpiration: later, PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15, Quantity: 1, Price: 0.80})
+			},
+			message: "underlying symbol is required",
+		},
+		{
+			name: "double-diagonal zero quantity",
+			check: func() error {
+				return ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{Underlying: "F", NearExpiration: future, FarExpiration: later, PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15, Price: 0.80})
+			},
+			message: "quantity must be greater than zero",
+		},
+		{
+			name: "double-diagonal past near expiration",
+			check: func() error {
+				return ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{Underlying: "F", NearExpiration: past, FarExpiration: later, PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15, Quantity: 1, Price: 0.80})
+			},
+			message: "option expiration date is in the past",
+		},
+		{
+			name: "double-diagonal near not before far",
+			check: func() error {
+				return ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{Underlying: "F", NearExpiration: later, FarExpiration: future, PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15, Quantity: 1, Price: 0.80})
+			},
+			message: "near expiration must be before far expiration",
+		},
+		{
+			name: "double-diagonal negative strike",
+			check: func() error {
+				return ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{Underlying: "F", NearExpiration: future, FarExpiration: later, PutFarStrike: -9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15, Quantity: 1, Price: 0.80})
+			},
+			message: "put-far-strike must be greater than zero",
+		},
+		{
+			name: "double-diagonal missing price",
+			check: func() error {
+				return ValidateDoubleDiagonalOrder(&DoubleDiagonalParams{Underlying: "F", NearExpiration: future, FarExpiration: later, PutFarStrike: 9, PutNearStrike: 10, CallNearStrike: 14, CallFarStrike: 15, Quantity: 1})
+			},
+			message: "price is required for double diagonals",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.check()
+
+			var validationErr *apperr.ValidationError
+			require.True(t, errors.As(err, &validationErr), "expected ValidationError, got %T: %v", err, err)
+			assert.Equal(t, testCase.message, validationErr.Message)
+		})
+	}
+}
+
 // TestValidateVerticalOrderRejectsEqualStrikes verifies same-strike rejection.
 func TestValidateVerticalOrderRejectsEqualStrikes(t *testing.T) {
 	t.Parallel()

--- a/llms.txt
+++ b/llms.txt
@@ -4,14 +4,6 @@ https://github.com/major/schwab-agent
 
 > CLI tool for AI agents to trade via Schwab APIs
 
-## Discovery
-
-Run `schwab-agent --jsonschema=tree` first when you need to discover commands, flags, enum values, defaults, config keys, or environment variable bindings. Treat that JSON Schema tree as the authoritative shell command contract. Use this file for workflow guidance and static context after choosing the command and flags from the schema.
-
-```bash
-schwab-agent --jsonschema=tree
-```
-
 ## Commands
 
 - [schwab-agent](#schwab-agent): CLI tool for AI agents to trade via Schwab APIs
@@ -19,9 +11,6 @@ schwab-agent --jsonschema=tree
 details, look up account numbers and hash values, set a default account, and
 query transaction history. Account list and get enrich results with nicknames
 from the preferences API (best-effort, degrades gracefully).
-- [schwab-agent account summary](#schwab-agent-account-summary): List compact account identifiers for agents. Returns account hashes from the
-account numbers endpoint and best-effort nickname, primary-account marker, and
-account type from user preferences without fetching balances or positions.
 - [schwab-agent account get](#schwab-agent-account-get): Get details for a single account by hash value. The hash can be passed as a
 positional argument, via --account, or resolved from the default_account
 config. Results are enriched with nicknames from the preferences API. Use
@@ -29,13 +18,21 @@ config. Results are enriched with nicknames from the preferences API. Use
 - [schwab-agent account list](#schwab-agent-account-list): List all linked Schwab accounts with nicknames and settings enriched from
 the preferences API. Use --positions to include current positions for each
 account in the response. Nicknames are loaded best-effort and omitted if
-the preferences API is unavailable.
+the preferences API is unavailable. Agents that only need account hashes,
+nicknames, and primary account markers should use account summary for a smaller
+one-command account picker.
 - [schwab-agent account numbers](#schwab-agent-account-numbers): List account numbers and their corresponding hash values. Hash values are
 used as account identifiers in all other commands. Use set-default to store
 a hash as the default account.
 - [schwab-agent account set-default](#schwab-agent-account-set-default): Set the default account hash in the config file. Commands that require an
 account will use this value when --account is not specified. Run account
 numbers to find valid hash values.
+- [schwab-agent account summary](#schwab-agent-account-summary): List linked Schwab accounts in a compact, token-efficient shape for agents.
+Each entry includes the account hash required by other commands, the readable
+account number, and best-effort nickname/primary/type data from user preferences.
+Use --positions to include compact holdings with computed cost basis and P&L
+in the same response. Use account list when you need full balances or account
+list --positions when you need the full Schwab account payload with positions.
 - [schwab-agent account transaction](#schwab-agent-account-transaction): Query transaction history for an account. Transactions are account-scoped and
 inherit the --account flag from the parent command. Filter by type, date range,
 and symbol.
@@ -129,21 +126,30 @@ magnitude (0, 1, 5, 10, 30, 60). Quote shell-special characters in index
 names (e.g. '$SPX').
 - [schwab-agent order](#schwab-agent-order): Manage orders across your Schwab accounts. Supports listing, viewing, placing,
 previewing, building, canceling, and replacing orders. Placing, canceling, and
-replacing orders require both the "i-also-like-to-live-dangerously" config flag
-and --confirm on each command. Duration aliases GTC, FOK, and IOC are accepted.
+replacing orders require the "i-also-like-to-live-dangerously" config flag.
+Duration aliases GTC, FOK, and IOC are accepted.
 - [schwab-agent order build](#schwab-agent-order-build): Build order request JSON locally without calling the API or requiring
 authentication. Output is raw JSON (not envelope-wrapped) that can be piped to
 order preview or order place --spec - for a staged workflow. Supports equity,
 option, bracket, OCO, and multi-leg option strategies.
+- [schwab-agent order build back-ratio](#schwab-agent-order-build-back-ratio): Build an option back-ratio spread order request JSON. Quantity controls the
+short leg, and --long-ratio controls how many long contracts are bought per
+short contract. Use --debit or --credit because back-ratios can price either way.
 - [schwab-agent order build bracket](#schwab-agent-order-build-bracket): Build a bracket order request JSON with entry and automatic exit legs. At
 least one of --take-profit or --stop-loss is required. Exit instructions are
 auto-inverted from the entry action.
+- [schwab-agent order build butterfly](#schwab-agent-order-build-butterfly): Build a butterfly spread order request JSON. Uses three ordered strikes at
+the same expiration: lower wing, middle body, upper wing. Buying opens a long
+butterfly with long wings and two short body contracts.
 - [schwab-agent order build calendar](#schwab-agent-order-build-calendar): Build a calendar spread order request JSON. Same strike price across two
 different expirations: sells the near-term contract and buys the far-term
 contract. Profits from time decay differential between the two legs.
 - [schwab-agent order build collar](#schwab-agent-order-build-collar): Build a collar-with-stock order request JSON. Combines long stock, a
 protective long put, and a covered short call. Limits downside risk while
 capping upside. Quantity 1 means 100 shares plus 1 put and 1 call contract.
+- [schwab-agent order build condor](#schwab-agent-order-build-condor): Build a same-expiration condor spread order request JSON. Uses four ordered
+strikes: lower wing, lower-middle short, upper-middle short, upper wing. Buying
+opens a long condor; selling opens the inverse short condor.
 - [schwab-agent order build covered-call](#schwab-agent-order-build-covered-call): Build a covered call order request JSON that atomically buys shares and sells
 a call. Quantity 1 means 100 shares plus 1 call contract. The --price is the
 net debit per share after call premium. To sell calls against shares you
@@ -151,8 +157,11 @@ already own, use order place option --action SELL_TO_OPEN instead.
 - [schwab-agent order build diagonal](#schwab-agent-order-build-diagonal): Build a diagonal spread order request JSON. Different strikes AND different
 expirations: sells the near-term contract at one strike and buys the far-term
 contract at a different strike. Combines elements of vertical and calendar spreads.
+- [schwab-agent order build double-diagonal](#schwab-agent-order-build-double-diagonal): Build a double diagonal spread order request JSON with far long put/call legs
+and near short put/call legs. The near expiration must come before the far
+expiration, and strikes must keep the put side below the call side.
 - [schwab-agent order build equity](#schwab-agent-order-build-equity): Build an equity order request JSON. Validates flags and outputs the order
-payload without placing it. Pipe to order place --spec - --confirm to execute,
+payload without placing it. Pipe to order place --spec - to execute,
 or to order preview --spec - to check estimated commissions.
 - [schwab-agent order build fts](#schwab-agent-order-build-fts): Build a first-triggers-second order from two JSON order specs. The primary
 order executes first; when it fills, the secondary order is automatically
@@ -176,9 +185,12 @@ or --sell for short strangles (expecting low volatility).
 - [schwab-agent order build vertical](#schwab-agent-order-build-vertical): Build a vertical spread (bull/bear call or put spread) order request JSON.
 Use --long-strike for the strike bought and --short-strike for the strike sold.
 NET_DEBIT or NET_CREDIT is auto-determined from the strike relationship.
-- [schwab-agent order cancel](#schwab-agent-order-cancel): Cancel an existing order by ID. Requires both safety guards: the
-"i-also-like-to-live-dangerously" config flag and --confirm. The order ID can
-be passed as a positional argument or with --order-id (flag takes priority).
+- [schwab-agent order build vertical-roll](#schwab-agent-order-build-vertical-roll): Build a vertical roll order request JSON that closes one vertical spread and
+opens another in a single order. Use --debit or --credit to state the roll's net
+pricing direction.
+- [schwab-agent order cancel](#schwab-agent-order-cancel): Cancel an existing order by ID. Requires the "i-also-like-to-live-dangerously"
+config flag. The order ID can be passed as a positional argument or with
+--order-id (flag takes priority).
 - [schwab-agent order get](#schwab-agent-order-get): Retrieve a single order by its ID. The order ID can be passed as a positional
 argument or with the --order-id flag. When both are provided, the flag takes
 priority. Requires a default account or --account flag.
@@ -188,34 +200,33 @@ are filtered out to show only actionable orders. Use --status all to see
 everything. Multiple --status values fan out into separate API calls with
 merged, deduplicated results.
 - [schwab-agent order place](#schwab-agent-order-place): Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. Both safety guards are required: set "i-also-like-to-live-dangerously"
-to true in config.json, and pass --confirm on every placement. Recommended workflow:
-check the price with quote get, build the order JSON with order build, preview it
-with order preview, then place with --confirm.
+with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
+Recommended workflow: check the price with quote get, build the order JSON with
+order build, preview it with order preview, then place.
 - [schwab-agent order place bracket](#schwab-agent-order-place-bracket): Place a bracket order that combines an entry trade with automatic exit orders.
 At least one of --take-profit or --stop-loss is required. Exit instructions are
 auto-inverted from the entry action (BUY entry creates SELL exits). Canceling
 the parent cascades to all child orders.
 - [schwab-agent order place equity](#schwab-agent-order-place-equity): Place an equity (stock) order. Supports MARKET, LIMIT, STOP, STOP_LIMIT, and
 TRAILING_STOP order types. Default type is MARKET if --type is omitted. Duration
-aliases GTC, FOK, and IOC are accepted alongside their full names. Both safety
-guards are required for placement.
+aliases GTC, FOK, and IOC are accepted alongside their full names. Requires
+i-also-like-to-live-dangerously in config for placement.
 - [schwab-agent order place oco](#schwab-agent-order-place-oco): Place a one-cancels-other order for an existing position. When one exit fills,
 the other is automatically canceled. At least one of --take-profit or --stop-loss
 is required. For long positions use SELL; for short positions use BUY. Unlike
 bracket orders, OCO has no entry leg.
 - [schwab-agent order place option](#schwab-agent-order-place-option): Place a single-leg option order. Requires --underlying, --expiration, --strike,
 and exactly one of --call or --put. Use BUY_TO_OPEN/SELL_TO_CLOSE for new
-positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. Both safety guards
-are required for placement.
+positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. Requires
+i-also-like-to-live-dangerously in config for placement.
 - [schwab-agent order preview](#schwab-agent-order-preview): Preview an order from a JSON spec without placing it. Returns estimated
 commissions, fees, and order details. Pipe output from order build for a
 build-then-preview workflow. Does not require safety guards since no order
 is actually placed.
 - [schwab-agent order replace](#schwab-agent-order-replace): Replace an existing order with a new equity order. The original order is
 canceled and a new one is created with a new ID. Only equity order flags are
-accepted. Requires both safety guards. The original order status becomes
-REPLACED after the new order is created.
+accepted. Requires the "i-also-like-to-live-dangerously" config flag. The
+original order status becomes REPLACED after the new order is created.
 - [schwab-agent position](#schwab-agent-position): View positions across accounts
 - [schwab-agent position list](#schwab-agent-position-list): List positions as a flat list with account identifiers and computed cost basis
 and P&L fields that Schwab's API does not provide directly. Uses the default
@@ -289,20 +300,6 @@ details, look up account numbers and hash values, set a default account, and
 query transaction history. Account list and get enrich results with nicknames
 from the preferences API (best-effort, degrades gracefully).
 
-## schwab-agent account summary
-
-List compact account identifiers for agents. This is the smallest account picker
-for LLM workflows: it returns accountHash, accountNumber, nickName,
-primaryAccount, and type when preferences are available. It calls accountNumbers
-for hashes, joins optional userPreference fields by account number, and does not
-fetch balances. Use --positions to fetch
-compact holdings in the same response with symbol, assetType, quantity,
-marketValue, averagePrice, totalCostBasis, unrealizedPnL, and unrealizedPnLPct.
-
-### Flags
-
-- `--positions` (bool, default: false): Include compact current positions for each account
-
 ## schwab-agent account get
 
 Get details for a single account by hash value. The hash can be passed as a
@@ -319,7 +316,9 @@ config. Results are enriched with nicknames from the preferences API. Use
 List all linked Schwab accounts with nicknames and settings enriched from
 the preferences API. Use --positions to include current positions for each
 account in the response. Nicknames are loaded best-effort and omitted if
-the preferences API is unavailable.
+the preferences API is unavailable. Agents that only need account hashes,
+nicknames, and primary account markers should use account summary for a smaller
+one-command account picker.
 
 ### Flags
 
@@ -336,6 +335,19 @@ a hash as the default account.
 Set the default account hash in the config file. Commands that require an
 account will use this value when --account is not specified. Run account
 numbers to find valid hash values.
+
+## schwab-agent account summary
+
+List linked Schwab accounts in a compact, token-efficient shape for agents.
+Each entry includes the account hash required by other commands, the readable
+account number, and best-effort nickname/primary/type data from user preferences.
+Use --positions to include compact holdings with computed cost basis and P&L
+in the same response. Use account list when you need full balances or account
+list --positions when you need the full Schwab account payload with positions.
+
+### Flags
+
+- `--positions` (bool, default: false): Include compact current positions for each account
 
 ## schwab-agent account transaction
 
@@ -546,8 +558,8 @@ names (e.g. '$SPX').
 
 Manage orders across your Schwab accounts. Supports listing, viewing, placing,
 previewing, building, canceling, and replacing orders. Placing, canceling, and
-replacing orders require both the "i-also-like-to-live-dangerously" config flag
-and --confirm on each command. Duration aliases GTC, FOK, and IOC are accepted.
+replacing orders require the "i-also-like-to-live-dangerously" config flag.
+Duration aliases GTC, FOK, and IOC are accepted.
 
 ## schwab-agent order build
 
@@ -555,6 +567,30 @@ Build order request JSON locally without calling the API or requiring
 authentication. Output is raw JSON (not envelope-wrapped) that can be piped to
 order preview or order place --spec - for a staged workflow. Supports equity,
 option, bracket, OCO, and multi-leg option strategies.
+
+## schwab-agent order build back-ratio
+
+Build an option back-ratio spread order request JSON. Quantity controls the
+short leg, and --long-ratio controls how many long contracts are bought per
+short contract. Use --debit or --credit because back-ratios can price either way.
+
+### Flags
+
+- `--call` (bool, default: false): Call back-ratio
+- `--close` (bool, default: false): Closing position
+- `--credit` (bool, default: false): Build as NET_CREDIT
+- `--debit` (bool, default: false): Build as NET_DEBIT
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--expiration` (string, required): Expiration date (YYYY-MM-DD)
+- `--long-ratio` (float64, default: 2): Long contracts per short contract
+- `--long-strike` (float64, default: 0, required): Long option strike
+- `--open` (bool, default: false): Opening position
+- `--price` (float64, default: 0, required): Net debit or credit amount
+- `--put` (bool, default: false): Put back-ratio
+- `--quantity` (float64, default: 0, required): Short-leg contract quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--short-strike` (float64, default: 0, required): Short option strike
+- `--underlying` (string, required): Underlying symbol
 
 ## schwab-agent order build bracket
 
@@ -573,6 +609,30 @@ auto-inverted from the entry action.
 - `--symbol` (string, required): Equity symbol
 - `--take-profit` (float64, default: 0): Take-profit exit price
 - `--type` (string): Entry order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT}
+
+## schwab-agent order build butterfly
+
+Build a butterfly spread order request JSON. Uses three ordered strikes at
+the same expiration: lower wing, middle body, upper wing. Buying opens a long
+butterfly with long wings and two short body contracts.
+
+### Flags
+
+- `--buy` (bool, default: false): Buy a long butterfly
+- `--call` (bool, default: false): Call butterfly
+- `--close` (bool, default: false): Closing position
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--expiration` (string, required): Expiration date (YYYY-MM-DD)
+- `--lower-strike` (float64, default: 0, required): Lower wing strike
+- `--middle-strike` (float64, default: 0, required): Middle body strike
+- `--open` (bool, default: false): Opening position
+- `--price` (float64, default: 0, required): Net debit or credit amount
+- `--put` (bool, default: false): Put butterfly
+- `--quantity` (float64, default: 0, required): Wing contract quantity
+- `--sell` (bool, default: false): Sell a short butterfly
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--underlying` (string, required): Underlying symbol
+- `--upper-strike` (float64, default: 0, required): Upper wing strike
 
 ## schwab-agent order build calendar
 
@@ -614,6 +674,31 @@ capping upside. Quantity 1 means 100 shares plus 1 put and 1 call contract.
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
 - `--underlying` (string, required): Underlying symbol
 
+## schwab-agent order build condor
+
+Build a same-expiration condor spread order request JSON. Uses four ordered
+strikes: lower wing, lower-middle short, upper-middle short, upper wing. Buying
+opens a long condor; selling opens the inverse short condor.
+
+### Flags
+
+- `--buy` (bool, default: false): Buy a long condor
+- `--call` (bool, default: false): Call condor
+- `--close` (bool, default: false): Closing position
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--expiration` (string, required): Expiration date (YYYY-MM-DD)
+- `--lower-middle-strike` (float64, default: 0, required): Lower middle strike
+- `--lower-strike` (float64, default: 0, required): Lower wing strike
+- `--open` (bool, default: false): Opening position
+- `--price` (float64, default: 0, required): Net debit or credit amount
+- `--put` (bool, default: false): Put condor
+- `--quantity` (float64, default: 0, required): Contract quantity per strike
+- `--sell` (bool, default: false): Sell a short condor
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--underlying` (string, required): Underlying symbol
+- `--upper-middle-strike` (float64, default: 0, required): Upper middle strike
+- `--upper-strike` (float64, default: 0, required): Upper wing strike
+
 ## schwab-agent order build covered-call
 
 Build a covered call order request JSON that atomically buys shares and sells
@@ -653,10 +738,32 @@ contract at a different strike. Combines elements of vertical and calendar sprea
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
 - `--underlying` (string, required): Underlying symbol
 
+## schwab-agent order build double-diagonal
+
+Build a double diagonal spread order request JSON with far long put/call legs
+and near short put/call legs. The near expiration must come before the far
+expiration, and strikes must keep the put side below the call side.
+
+### Flags
+
+- `--call-far-strike` (float64, default: 0, required): Far call long strike
+- `--call-near-strike` (float64, default: 0, required): Near call short strike
+- `--close` (bool, default: false): Closing position
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--far-expiration` (string, required): Far expiration for long legs (YYYY-MM-DD)
+- `--near-expiration` (string, required): Near expiration for short legs (YYYY-MM-DD)
+- `--open` (bool, default: false): Opening position
+- `--price` (float64, default: 0, required): Net debit or credit amount
+- `--put-far-strike` (float64, default: 0, required): Far put long strike
+- `--put-near-strike` (float64, default: 0, required): Near put short strike
+- `--quantity` (float64, default: 0, required): Contract quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--underlying` (string, required): Underlying symbol
+
 ## schwab-agent order build equity
 
 Build an equity order request JSON. Validates flags and outputs the order
-payload without placing it. Pipe to order place --spec - --confirm to execute,
+payload without placing it. Pipe to order place --spec - to execute,
 or to order preview --spec - to check estimated commissions.
 
 ### Flags
@@ -814,15 +921,38 @@ NET_DEBIT or NET_CREDIT is auto-determined from the strike relationship.
 - `--short-strike` (float64, default: 0, required): Strike price of the option being sold
 - `--underlying` (string, required): Underlying symbol
 
-## schwab-agent order cancel
+## schwab-agent order build vertical-roll
 
-Cancel an existing order by ID. Requires both safety guards: the
-"i-also-like-to-live-dangerously" config flag and --confirm. The order ID can
-be passed as a positional argument or with --order-id (flag takes priority).
+Build a vertical roll order request JSON that closes one vertical spread and
+opens another in a single order. Use --debit or --credit to state the roll's net
+pricing direction.
 
 ### Flags
 
-- `--confirm` (bool, default: false): Confirm cancellation
+- `--call` (bool, default: false): Call vertical roll
+- `--close-expiration` (string, required): Expiration of the vertical being closed (YYYY-MM-DD)
+- `--close-long-strike` (float64, default: 0, required): Long strike of the vertical being closed
+- `--close-short-strike` (float64, default: 0, required): Short strike of the vertical being closed
+- `--credit` (bool, default: false): Build as NET_CREDIT
+- `--debit` (bool, default: false): Build as NET_DEBIT
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--open-expiration` (string, required): Expiration of the vertical being opened (YYYY-MM-DD)
+- `--open-long-strike` (float64, default: 0, required): Long strike of the vertical being opened
+- `--open-short-strike` (float64, default: 0, required): Short strike of the vertical being opened
+- `--price` (float64, default: 0, required): Net debit or credit amount
+- `--put` (bool, default: false): Put vertical roll
+- `--quantity` (float64, default: 0, required): Contract quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--underlying` (string, required): Underlying symbol
+
+## schwab-agent order cancel
+
+Cancel an existing order by ID. Requires the "i-also-like-to-live-dangerously"
+config flag. The order ID can be passed as a positional argument or with
+--order-id (flag takes priority).
+
+### Flags
+
 - `--order-id` (string): Order ID
 
 ## schwab-agent order get
@@ -852,14 +982,12 @@ merged, deduplicated results.
 ## schwab-agent order place
 
 Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. Both safety guards are required: set "i-also-like-to-live-dangerously"
-to true in config.json, and pass --confirm on every placement. Recommended workflow:
-check the price with quote get, build the order JSON with order build, preview it
-with order preview, then place with --confirm.
+with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
+Recommended workflow: check the price with quote get, build the order JSON with
+order build, preview it with order preview, then place.
 
 ### Flags
 
-- `--confirm` (bool, default: false): Confirm order placement
 - `--spec` (string, required): Inline JSON, @file, or - for stdin
 
 ## schwab-agent order place bracket
@@ -872,7 +1000,6 @@ the parent cascades to all child orders.
 ### Flags
 
 - `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
-- `--confirm` (bool, default: false): Confirm order placement
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--price` (float64, default: 0): Entry price
 - `--quantity` (float64, default: 0, required): Share quantity
@@ -886,14 +1013,13 @@ the parent cascades to all child orders.
 
 Place an equity (stock) order. Supports MARKET, LIMIT, STOP, STOP_LIMIT, and
 TRAILING_STOP order types. Default type is MARKET if --type is omitted. Duration
-aliases GTC, FOK, and IOC are accepted alongside their full names. Both safety
-guards are required for placement.
+aliases GTC, FOK, and IOC are accepted alongside their full names. Requires
+i-also-like-to-live-dangerously in config for placement.
 
 ### Flags
 
 - `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
 - `--activation-price` (float64, default: 0): Price that activates the trailing stop
-- `--confirm` (bool, default: false): Confirm order placement
 - `--destination` (string): Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX}
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--price` (float64, default: 0): Limit price
@@ -920,7 +1046,6 @@ bracket orders, OCO has no entry leg.
 ### Flags
 
 - `--action` (string, required): Exit action (SELL to close long, BUY to close short) {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
-- `--confirm` (bool, default: false): Confirm order placement
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--quantity` (float64, default: 0, required): Share quantity
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
@@ -932,14 +1057,13 @@ bracket orders, OCO has no entry leg.
 
 Place a single-leg option order. Requires --underlying, --expiration, --strike,
 and exactly one of --call or --put. Use BUY_TO_OPEN/SELL_TO_CLOSE for new
-positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. Both safety guards
-are required for placement.
+positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. Requires
+i-also-like-to-live-dangerously in config for placement.
 
 ### Flags
 
 - `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
 - `--call` (bool, default: false): Call option
-- `--confirm` (bool, default: false): Confirm order placement
 - `--destination` (string): Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX}
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--expiration` (string, required): Expiration date (YYYY-MM-DD)
@@ -969,14 +1093,13 @@ is actually placed.
 
 Replace an existing order with a new equity order. The original order is
 canceled and a new one is created with a new ID. Only equity order flags are
-accepted. Requires both safety guards. The original order status becomes
-REPLACED after the new order is created.
+accepted. Requires the "i-also-like-to-live-dangerously" config flag. The
+original order status becomes REPLACED after the new order is created.
 
 ### Flags
 
 - `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
 - `--activation-price` (float64, default: 0): Price that activates the trailing stop
-- `--confirm` (bool, default: false): Confirm replacement
 - `--destination` (string): Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX}
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--order-id` (string): Order ID
@@ -1007,7 +1130,6 @@ include totalCostBasis, unrealizedPnL, and unrealizedPnLPct.
 
 ### Flags
 
-- `--account` (string): Account hash (overrides config default)
 - `--all-accounts` (bool, default: false): Show positions across all linked accounts
 
 ## schwab-agent quote

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -166,6 +166,11 @@ run_help_test "order build covered-call" order build covered-call
 run_help_test "order build collar"       order build collar
 run_help_test "order build calendar"     order build calendar
 run_help_test "order build diagonal"     order build diagonal
+run_help_test "order build butterfly"    order build butterfly
+run_help_test "order build condor"       order build condor
+run_help_test "order build vertical-roll" order build vertical-roll
+run_help_test "order build back-ratio"   order build back-ratio
+run_help_test "order build double-diagonal" order build double-diagonal
 run_help_test "order build fts"          order build fts
 run_help_test "chain"             chain
 run_help_test "chain get"         chain get
@@ -489,6 +494,34 @@ run_build_test "diagonal: PUT CLOSE" \
     --near-strike 14 --far-strike 12 \
     --near-expiration 2026-05-15 --far-expiration 2026-07-17 \
     --put --close --quantity 1 --price 0.50
+
+# -------------------------------------------------------------------
+# Order build: Additional option strategies
+# -------------------------------------------------------------------
+
+section "Order Build: Additional Option Strategies"
+
+run_build_test "butterfly: CALL BUY OPEN" \
+    order build butterfly --underlying F --expiration 2026-06-18 \
+    --lower-strike 10 --middle-strike 12 --upper-strike 14 \
+    --call --buy --open --quantity 1 --price 0.50
+run_build_test "condor: PUT SELL OPEN" \
+    order build condor --underlying F --expiration 2026-06-18 \
+    --lower-strike 10 --lower-middle-strike 12 --upper-middle-strike 14 --upper-strike 16 \
+    --put --sell --open --quantity 1 --price 0.75
+run_build_test "vertical-roll: CALL CREDIT" \
+    order build vertical-roll --underlying F \
+    --close-expiration 2026-06-18 --open-expiration 2026-07-17 \
+    --close-long-strike 12 --close-short-strike 14 --open-long-strike 13 --open-short-strike 15 \
+    --call --credit --quantity 1 --price 0.25
+run_build_test "back-ratio: CALL DEBIT" \
+    order build back-ratio --underlying F --expiration 2026-06-18 \
+    --short-strike 12 --long-strike 14 --call --open --quantity 1 --long-ratio 2 --debit --price 0.20
+run_build_test "double-diagonal: OPEN" \
+    order build double-diagonal --underlying F \
+    --near-expiration 2026-06-18 --far-expiration 2026-07-17 \
+    --put-far-strike 9 --put-near-strike 10 --call-near-strike 14 --call-far-strike 15 \
+    --open --quantity 1 --price 0.80
 
 # -------------------------------------------------------------------
 # Order build: FTS (first-triggers-second)


### PR DESCRIPTION
## Summary
- Add order builders and CLI commands for butterfly, condor, vertical-roll, back-ratio, and double-diagonal option strategies.
- Add validation, tests, generated docs, and smoke coverage for the new strategy builders.

## Verification
- /usr/local/go/bin/go test ./internal/orderbuilder ./internal/commands
- make test
- make build
- /usr/local/go/bin/go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0 run ./...
- make smoke-ci