### PR TITLE
feat(ta): add dashboard command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ schwab-agent option ticket get AAPL --expiration <YYYY-MM-DD> --strike 200 --cal
 # Get multiple moving averages in one technical-analysis run
 schwab-agent ta sma AAPL --period 21,50,200 --points 1
 
+# Get a compact technical-analysis dashboard in one history fetch
+schwab-agent ta dashboard AAPL
+
 # Place a limit order (requires safety config)
 schwab-agent order place equity \
   --symbol AAPL \
@@ -156,7 +159,7 @@ schwab-agent order place --spec @order.json
 | `chain` | Option chain data (`get`, `expiration`) |
 | `option` | Option planning tickets that combine quote, chain, and OCC symbol context |
 | `history` | Price history for a symbol |
-| `ta` | Technical analysis (sma, ema, rsi, macd, atr, bbands, stoch, adx, vwap, hv, expected-move) |
+| `ta` | Technical analysis (dashboard, sma, ema, rsi, macd, atr, bbands, stoch, adx, vwap, hv, expected-move) |
 | `market` | Market hours and top movers |
 | `symbol` | Build and parse OCC option symbols (no auth required) |
 | `instrument` | Search instruments |

--- a/SKILL.md
+++ b/SKILL.md
@@ -430,6 +430,39 @@ schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
   schwab-agent market movers EQUITY_ALL --sort PERCENT_CHANGE_UP
 ```
 
+#### `schwab-agent option`
+
+Option planning workflows that combine quote, chain, and symbol context for agents.
+
+#### `schwab-agent option ticket`
+
+Build an option planning ticket from live market data. The ticket combines
+the underlying quote, a narrowly filtered option chain, the matching contract,
+and the OCC symbol in one read-only command. Use order preview option when you
+are ready to turn the ticket into a Schwab preview request.
+
+#### `schwab-agent option ticket get`
+
+Get a compact option ticket for one underlying, expiration, strike, and
+contract side. This collapses the common agent workflow of quote lookup, chain
+lookup, and OCC symbol construction into one read-only CLI call.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--call` | bool | false | no | Select the call contract |
+| `--expiration` | string | - | no | Option expiration date (YYYY-MM-DD) |
+| `--put` | bool | false | no | Select the put contract |
+| `--strike` | float64 | 0 | no | Option strike price |
+
+**Example:**
+
+```bash
+schwab-agent option ticket get AAPL --expiration 2026-01-16 --strike 200 --call
+  schwab-agent option ticket get TSLA --expiration 2026-03-20 --strike 180 --put
+```
+
 #### `schwab-agent order`
 
 Manage orders across your Schwab accounts. Supports listing, viewing, placing,
@@ -1019,14 +1052,17 @@ schwab-agent order get 1234567890
 List orders for the current account, or all accounts when no --account is set.
 By default, terminal statuses (FILLED, CANCELED, REJECTED, EXPIRED, REPLACED)
 are filtered out to show only actionable orders. Use --status all to see
-everything. Multiple --status values fan out into separate API calls with
-merged, deduplicated results.
+everything. Use --recent for an agent-friendly recent activity view that keeps
+terminal statuses and narrows the default lookback to 24 hours. Multiple
+--status values fan out into separate API calls with merged, deduplicated
+results.
 
 **Flags:**
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
 | `--from` | string | - | no | Filter by entered time lower bound |
+| `--recent` | bool | false | no | Show recent order activity, including terminal statuses, from the last 24 hours unless --from is set |
 | `--status` | stringSlice | [] | no | Filter by order status (repeatable, use 'all' for unfiltered): WORKING, PENDING_ACTIVATION, FILLED, EXPIRED, CANCELED, REJECTED, etc. |
 | `--to` | string | - | no | Filter by entered time upper bound |
 
@@ -1034,6 +1070,7 @@ merged, deduplicated results.
 
 ```bash
 schwab-agent order list
+  schwab-agent order list --recent
   schwab-agent order list --status all
   schwab-agent order list --status WORKING --status PENDING_ACTIVATION
   schwab-agent order list --status WORKING,FILLED,EXPIRED
@@ -1208,10 +1245,11 @@ i-also-like-to-live-dangerously in config for placement.
 
 #### `schwab-agent order preview`
 
-Preview an order from a JSON spec without placing it. Returns estimated
-commissions, fees, and order details. Pipe output from order build for a
-build-then-preview workflow. Does not require safety guards since no order
-is actually placed.
+Preview an order from a JSON spec or typed subcommand flags without placing it.
+Typed preview subcommands reuse the same local builders as order place, then
+return both the built order request and Schwab preview response in one envelope.
+This removes the build-then-preview round trip while keeping placement explicit.
+Does not require safety guards since no order is actually placed.
 
 **Flags:**
 
@@ -1223,7 +1261,130 @@ is actually placed.
 
 ```bash
 schwab-agent order preview --spec @order.json
+  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200
+  schwab-agent order preview option --underlying AAPL --expiration 2026-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
+```
+
+#### `schwab-agent order preview bracket`
+
+Preview a bracket order without placing it. At least one of --take-profit or
+--stop-loss is required. The preview response includes the locally built trigger
+order and Schwab's validation, fee, and commission details.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--action` | string | - | yes | Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN} |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--price` | float64 | 0 | no | Entry price |
+| `--quantity` | float64 | 0 | yes | Share quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--stop-loss` | float64 | 0 | no | Stop-loss exit price |
+| `--symbol` | string | - | yes | Equity symbol |
+| `--take-profit` | float64 | 0 | no | Take-profit exit price |
+| `--type` | string | - | no | Entry order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT} |
+
+**Example:**
+
+```bash
+schwab-agent order preview bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
+	  schwab-agent order preview bracket --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 180 --stop-loss 170
+```
+
+#### `schwab-agent order preview equity`
+
+Preview an equity (stock) order without placing it. Supports the same flags
+as order place equity, but skips the mutable-operation safety gate because no
+order is submitted. The response includes the built order request plus Schwab's
+preview details so agents can inspect both in one call.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--action` | string | - | yes | Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN} |
+| `--activation-price` | float64 | 0 | no | Price that activates the trailing stop |
+| `--destination` | string | - | no | Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX} |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--price` | float64 | 0 | no | Limit price |
+| `--price-link-basis` | string | - | no | Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER} |
+| `--price-link-type` | string | - | no | Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE} |
+| `--quantity` | float64 | 0 | yes | Share quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--special-instruction` | string | - | no | Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE} |
+| `--stop-link-basis` | string | - | no | Trailing stop reference price (LAST, BID, ASK, MARK) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER} |
+| `--stop-link-type` | string | - | no | Trailing stop offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE} |
+| `--stop-offset` | float64 | 0 | no | Trailing stop offset amount |
+| `--stop-price` | float64 | 0 | no | Stop price |
+| `--stop-type` | string | - | no | Trailing stop trigger type (STANDARD, BID, ASK, LAST, MARK) {,ASK,BID,LAST,MARK,STANDARD} |
+| `--symbol` | string | - | yes | Equity symbol |
+| `--type` | string | - | no | Order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT} |
+
+**Example:**
+
+```bash
+schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10
+	  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 150 --duration GTC
+```
+
+#### `schwab-agent order preview oco`
+
+Preview a one-cancels-other order for an existing position without placing it.
+When both exits are present, the built order shows the OCO relationship Schwab
+will validate during preview.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--action` | string | - | yes | Exit action (SELL to close long, BUY to close short) {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN} |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--quantity` | float64 | 0 | yes | Share quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--stop-loss` | float64 | 0 | no | Stop-loss exit price (stop order) |
+| `--symbol` | string | - | yes | Equity symbol |
+| `--take-profit` | float64 | 0 | no | Take-profit exit price (limit order) |
+
+**Example:**
+
+```bash
+schwab-agent order preview oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
+	  schwab-agent order preview oco --symbol TSLA --action BUY --quantity 10 --stop-loss 250
+```
+
+#### `schwab-agent order preview option`
+
+Preview a single-leg option order without placing it. Requires --underlying,
+--expiration, --strike, and exactly one of --call or --put. The response includes
+the locally built OCC order request and Schwab's preview response.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--action` | string | - | yes | Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN} |
+| `--call` | bool | false | no | Call option |
+| `--destination` | string | - | no | Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX} |
+| `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
+| `--expiration` | string | - | yes | Expiration date (YYYY-MM-DD) |
+| `--price` | float64 | 0 | no | Limit price |
+| `--price-link-basis` | string | - | no | Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER} |
+| `--price-link-type` | string | - | no | Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE} |
+| `--put` | bool | false | no | Put option |
+| `--quantity` | float64 | 0 | yes | Contract quantity |
+| `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
+| `--special-instruction` | string | - | no | Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE} |
+| `--strike` | float64 | 0 | yes | Strike price |
+| `--type` | string | - | no | Order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT} |
+| `--underlying` | string | - | yes | Underlying symbol |
+
+**Example:**
+
+```bash
+schwab-agent order preview option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1
+	  schwab-agent order preview option --underlying AAPL --expiration 2025-06-20 --strike 190 --put --action SELL_TO_OPEN --quantity 1 --type LIMIT --price 3.50
 ```
 
 #### `schwab-agent order replace`
@@ -1425,6 +1586,28 @@ relatively low. Use --std-dev to widen or narrow the bands (default 2.0).
 schwab-agent ta bbands AAPL
   schwab-agent ta bbands AAPL --period 20 --std-dev 2.0 --points 10
   schwab-agent ta bbands AAPL --std-dev 1.5 --points 10
+```
+
+#### `schwab-agent ta dashboard`
+
+Compute an opinionated technical-analysis dashboard for a symbol with one
+price-history fetch. The dashboard includes SMA 21/50/200 trend context, RSI 14,
+MACD 12/26/9, ATR 14, Bollinger Bands 20/2, volume context, and 20/252-candle
+high-low ranges. Signals are neutral factual labels for agents, not trading advice.
+
+**Flags:**
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--interval` | string | daily | no | Data interval (daily, weekly, 1min, 5min, 15min, 30min) |
+| `--points` | int | 1 | no | Number of output points (0 = all) |
+
+**Example:**
+
+```bash
+schwab-agent ta dashboard AAPL
+  schwab-agent ta dashboard AAPL --points 5
+  schwab-agent ta dashboard NVDA --interval weekly --points 10
 ```
 
 #### `schwab-agent ta ema`
@@ -1733,6 +1916,13 @@ schwab-agent market movers '$SPX' --sort PERCENT_CHANGE_UP
   schwab-agent market movers EQUITY_ALL --sort PERCENT_CHANGE_UP
 ```
 
+#### schwab-agent option ticket get
+
+```bash
+schwab-agent option ticket get AAPL --expiration 2026-01-16 --strike 200 --call
+  schwab-agent option ticket get TSLA --expiration 2026-03-20 --strike 180 --put
+```
+
 #### schwab-agent order build back-ratio
 
 ```bash
@@ -1870,6 +2060,7 @@ schwab-agent order get 1234567890
 
 ```bash
 schwab-agent order list
+  schwab-agent order list --recent
   schwab-agent order list --status all
   schwab-agent order list --status WORKING --status PENDING_ACTIVATION
   schwab-agent order list --status WORKING,FILLED,EXPIRED
@@ -1937,7 +2128,37 @@ schwab-agent order list
 
 ```bash
 schwab-agent order preview --spec @order.json
+  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200
+  schwab-agent order preview option --underlying AAPL --expiration 2026-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
+```
+
+#### schwab-agent order preview bracket
+
+```bash
+schwab-agent order preview bracket --symbol NVDA --action BUY --quantity 10 --type MARKET --take-profit 150 --stop-loss 120
+	  schwab-agent order preview bracket --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 180 --stop-loss 170
+```
+
+#### schwab-agent order preview equity
+
+```bash
+schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10
+	  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 150 --duration GTC
+```
+
+#### schwab-agent order preview oco
+
+```bash
+schwab-agent order preview oco --symbol AAPL --action SELL --quantity 100 --take-profit 160 --stop-loss 140
+	  schwab-agent order preview oco --symbol TSLA --action BUY --quantity 10 --stop-loss 250
+```
+
+#### schwab-agent order preview option
+
+```bash
+schwab-agent order preview option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1
+	  schwab-agent order preview option --underlying AAPL --expiration 2025-06-20 --strike 190 --put --action SELL_TO_OPEN --quantity 1 --type LIMIT --price 3.50
 ```
 
 #### schwab-agent order replace
@@ -1997,6 +2218,14 @@ schwab-agent ta atr AAPL
 schwab-agent ta bbands AAPL
   schwab-agent ta bbands AAPL --period 20 --std-dev 2.0 --points 10
   schwab-agent ta bbands AAPL --std-dev 1.5 --points 10
+```
+
+#### schwab-agent ta dashboard
+
+```bash
+schwab-agent ta dashboard AAPL
+  schwab-agent ta dashboard AAPL --points 5
+  schwab-agent ta dashboard NVDA --interval weekly --points 10
 ```
 
 #### schwab-agent ta ema

--- a/cmd/generate-docs/main.go
+++ b/cmd/generate-docs/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/leodido/structcli"
 	"github.com/leodido/structcli/generate"
@@ -69,6 +70,8 @@ func run() error {
 		return fmt.Errorf("generating SKILL.md: %w", err)
 	}
 
+	skill = labelSkillCodeFences(skill)
+
 	//nolint:gosec // G306: public documentation files should be world-readable
 	if err := os.WriteFile(filepath.Join(outDir, "SKILL.md"), skill, 0o644); err != nil {
 		return fmt.Errorf("writing SKILL.md: %w", err)
@@ -94,6 +97,29 @@ func run() error {
 	fmt.Fprintf(os.Stderr, "wrote %s\n", filepath.Join(outDir, "llms.txt"))
 
 	return nil
+}
+
+func labelSkillCodeFences(content []byte) []byte {
+	lines := strings.Split(string(content), "\n")
+	inFence := false
+	for i, line := range lines {
+		if line != "```" {
+			continue
+		}
+
+		if inFence {
+			inFence = false
+			continue
+		}
+
+		// structcli generates shell examples in SKILL.md with bare opening
+		// fences. Add a language tag here so generated docs satisfy markdownlint
+		// without forking or post-editing the generated file by hand.
+		lines[i] = "```bash"
+		inFence = true
+	}
+
+	return []byte(strings.Join(lines, "\n"))
 }
 
 // projectRoot returns the repository root by walking up from this source

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"strconv"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/leodido/structcli"
 	"github.com/spf13/cobra"
 
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/output"
@@ -115,6 +117,30 @@ type expectedMoveOutput struct {
 	Lower1x         float64 `json:"lower_1x"`
 	Upper2x         float64 `json:"upper_2x"`
 	Lower2x         float64 `json:"lower_2x"`
+}
+
+type dashboardParameters struct {
+	SMAPeriods   []int   `json:"sma_periods"`
+	RSIPeriod    int     `json:"rsi_period"`
+	MACDFast     int     `json:"macd_fast"`
+	MACDSlow     int     `json:"macd_slow"`
+	MACDSignal   int     `json:"macd_signal"`
+	ATRPeriod    int     `json:"atr_period"`
+	BBandsPeriod int     `json:"bbands_period"`
+	BBandsStdDev float64 `json:"bbands_std_dev"`
+	VolumePeriod int     `json:"volume_period"`
+	RangePeriod  int     `json:"range_period"`
+	LongRange    int     `json:"long_range"`
+}
+
+type dashboardOutput struct {
+	Indicator  string              `json:"indicator"`
+	Symbol     string              `json:"symbol"`
+	Interval   string              `json:"interval"`
+	Parameters dashboardParameters `json:"parameters"`
+	Latest     map[string]any      `json:"latest"`
+	Signals    map[string]any      `json:"signals"`
+	Values     []map[string]any    `json:"values"`
 }
 
 // taOutput is the common envelope for single-value time series indicators (SMA, EMA, RSI, etc.).
@@ -288,6 +314,15 @@ type expectedMoveOpts struct {
 // Attach implements structcli.Options interface.
 func (o *expectedMoveOpts) Attach(_ *cobra.Command) error { return nil }
 
+// dashboardOpts holds CLI flags for the opinionated TA dashboard command.
+type dashboardOpts struct {
+	Interval taInterval `flag:"interval" flagdescr:"Data interval (daily, weekly, 1min, 5min, 15min, 30min)" default:"daily" flaggroup:"data"`
+	Points   int        `flag:"points" flagdescr:"Number of output points (0 = all)" default:"1" flaggroup:"data"`
+}
+
+// Attach implements structcli.Options interface.
+func (o *dashboardOpts) Attach(_ *cobra.Command) error { return nil }
+
 // NewTACmd returns the Cobra command for technical analysis indicators.
 func NewTACmd(c *client.Ref, w io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -303,6 +338,7 @@ output to the N most recent values.`,
 	cmd.SetFlagErrorFunc(suggestSubcommands)
 
 	cmd.AddCommand(
+		cobraTADashboardCommand(c, w),
 		makeCobraSimpleTACommand(&simpleTAConfig{
 			name:  "sma",
 			usage: "Simple Moving Average",
@@ -424,6 +460,357 @@ func makeCobraSimpleTACommand(cfg *simpleTAConfig, c *client.Ref, w io.Writer) *
 	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
 
 	return cmd
+}
+
+func cobraTADashboardCommand(c *client.Ref, w io.Writer) *cobra.Command {
+	opts := &dashboardOpts{}
+	cmd := &cobra.Command{
+		Use:   "dashboard SYMBOL",
+		Short: "Opinionated TA dashboard for agent trade analysis",
+		Long: `Compute an opinionated technical-analysis dashboard for a symbol with one
+price-history fetch. The dashboard includes SMA 21/50/200 trend context, RSI 14,
+MACD 12/26/9, ATR 14, Bollinger Bands 20/2, volume context, and 20/252-candle
+high-low ranges. Signals are neutral factual labels for agents, not trading advice.`,
+		Example: `  schwab-agent ta dashboard AAPL
+  schwab-agent ta dashboard AAPL --points 5
+  schwab-agent ta dashboard NVDA --interval weekly --points 10`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := structcli.Unmarshal(cmd, opts); err != nil {
+				return err
+			}
+
+			return writeTADashboard(cmd.Context(), c, w, args[0], string(opts.Interval), opts.Points)
+		},
+	}
+
+	if err := structcli.Define(cmd, opts); err != nil {
+		panic(err)
+	}
+	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
+
+	return cmd
+}
+
+func writeTADashboard(ctx context.Context, c *client.Ref, w io.Writer, symbol, interval string, points int) error {
+	const (
+		smaFastPeriod    = 21
+		smaMediumPeriod  = 50
+		smaLongPeriod    = 200
+		rsiPeriod        = 14
+		macdFastPeriod   = 12
+		macdSlowPeriod   = 26
+		macdSignalPeriod = 9
+		atrPeriod        = 14
+		bbandsPeriod     = 20
+		bbandsStdDev     = 2.0
+		volumePeriod     = 20
+		rangePeriod      = 20
+		longRangePeriod  = 252
+	)
+
+	requestedRows := 1
+	if points > 0 {
+		requestedRows = points
+	}
+	dashboardMinCandles := longRangePeriod + requestedRows - 1
+
+	candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, dashboardMinCandles, "dashboard")
+	if err != nil {
+		return err
+	}
+
+	opens, err := ta.ExtractOpen(candles)
+	if err != nil {
+		return err
+	}
+	highs, err := ta.ExtractHigh(candles)
+	if err != nil {
+		return err
+	}
+	lows, err := ta.ExtractLow(candles)
+	if err != nil {
+		return err
+	}
+	closes, err := ta.ExtractClose(candles)
+	if err != nil {
+		return err
+	}
+	volumes, err := ta.ExtractVolume(candles)
+	if err != nil {
+		return err
+	}
+
+	sma21, err := ta.SMA(closes, smaFastPeriod)
+	if err != nil {
+		return err
+	}
+	sma50, err := ta.SMA(closes, smaMediumPeriod)
+	if err != nil {
+		return err
+	}
+	sma200, err := ta.SMA(closes, smaLongPeriod)
+	if err != nil {
+		return err
+	}
+	rsi14, err := ta.RSI(closes, rsiPeriod)
+	if err != nil {
+		return err
+	}
+	macdVals, macdSignalVals, macdHistVals, err := ta.MACD(closes, macdFastPeriod, macdSlowPeriod, macdSignalPeriod)
+	if err != nil {
+		return err
+	}
+	atr14, err := ta.ATR(highs, lows, closes, atrPeriod)
+	if err != nil {
+		return err
+	}
+	bbandsUpper, bbandsMiddle, bbandsLower, err := ta.BBands(closes, bbandsPeriod, bbandsStdDev)
+	if err != nil {
+		return err
+	}
+	avgVolume20, err := ta.SMA(volumes, volumePeriod)
+	if err != nil {
+		return err
+	}
+
+	// The series begins where the 252-candle range is complete. SMA 200 becomes
+	// available earlier, but labeling partial windows as range_252_* would mislead
+	// agents about long-range highs and lows.
+	baseStart := longRangePeriod - 1
+	rowCount := len(candles) - baseStart
+	rows := make([]map[string]any, rowCount)
+	for i := range rowCount {
+		candleIndex := baseStart + i
+		rows[i] = map[string]any{
+			"datetime": timestamps[candleIndex],
+			"open":     opens[candleIndex],
+			"high":     highs[candleIndex],
+			"low":      lows[candleIndex],
+			"close":    closes[candleIndex],
+			"volume":   volumes[candleIndex],
+		}
+	}
+
+	for key, values := range map[string][]float64{
+		"sma_21":         sma21,
+		"sma_50":         sma50,
+		"sma_200":        sma200,
+		"rsi_14":         rsi14,
+		"macd":           macdVals,
+		"macd_signal":    macdSignalVals,
+		"macd_histogram": macdHistVals,
+		"atr_14":         atr14,
+		"bbands_upper":   bbandsUpper,
+		"bbands_middle":  bbandsMiddle,
+		"bbands_lower":   bbandsLower,
+		"avg_volume_20":  avgVolume20,
+	} {
+		if err := addTailAlignedFloat(rows, key, values); err != nil {
+			return err
+		}
+	}
+
+	for i := range rows {
+		closePrice := rows[i]["close"].(float64)
+		atrValue := rows[i]["atr_14"].(float64)
+		avgVolume := rows[i]["avg_volume_20"].(float64)
+		volume := rows[i]["volume"].(float64)
+		candleIndex := baseStart + i
+		rangeHigh20, rangeLow20 := highLowWindow(highs, lows, candleIndex, rangePeriod)
+		rangeHigh252, rangeLow252 := highLowWindow(highs, lows, candleIndex, longRangePeriod)
+
+		rows[i]["atr_percent"] = percentOf(atrValue, closePrice)
+		rows[i]["relative_volume"] = ratio(volume, avgVolume)
+		rows[i]["range_20_high"] = rangeHigh20
+		rows[i]["range_20_low"] = rangeLow20
+		rows[i]["range_252_high"] = rangeHigh252
+		rows[i]["range_252_low"] = rangeLow252
+		rows[i]["distance_from_sma_21_percent"] = percentChange(closePrice, rows[i]["sma_21"].(float64))
+		rows[i]["distance_from_sma_50_percent"] = percentChange(closePrice, rows[i]["sma_50"].(float64))
+		rows[i]["distance_from_sma_200_percent"] = percentChange(closePrice, rows[i]["sma_200"].(float64))
+		rows[i]["distance_from_range_20_high_percent"] = percentChange(closePrice, rangeHigh20)
+		rows[i]["distance_from_range_252_high_percent"] = percentChange(closePrice, rangeHigh252)
+	}
+
+	latest := cloneDashboardRow(rows[len(rows)-1])
+	data := dashboardOutput{
+		Indicator: "dashboard",
+		Symbol:    symbol,
+		Interval:  interval,
+		Parameters: dashboardParameters{
+			SMAPeriods:   []int{smaFastPeriod, smaMediumPeriod, smaLongPeriod},
+			RSIPeriod:    rsiPeriod,
+			MACDFast:     macdFastPeriod,
+			MACDSlow:     macdSlowPeriod,
+			MACDSignal:   macdSignalPeriod,
+			ATRPeriod:    atrPeriod,
+			BBandsPeriod: bbandsPeriod,
+			BBandsStdDev: bbandsStdDev,
+			VolumePeriod: volumePeriod,
+			RangePeriod:  rangePeriod,
+			LongRange:    longRangePeriod,
+		},
+		Latest:  latest,
+		Signals: dashboardSignals(latest),
+		Values:  limitDashboardRows(rows, points),
+	}
+
+	return output.WriteSuccess(w, data, output.NewMetadata())
+}
+
+func addTailAlignedFloat(rows []map[string]any, key string, values []float64) error {
+	// TA-Lib returns leading zero placeholders before an indicator warms up. The
+	// ta package strips those placeholders, but an all-zero valid series, such as
+	// flat-price MACD or ATR, becomes empty. Treat an empty indicator result as a
+	// valid zero-valued tail so a quiet market produces JSON instead of a panic.
+	if len(values) == 0 {
+		for i := range rows {
+			rows[i][key] = 0.0
+		}
+		return nil
+	}
+
+	if len(values) < len(rows) {
+		return apperr.NewValidationError(
+			fmt.Sprintf("dashboard %s series has %d values for %d output rows", key, len(values), len(rows)),
+			nil,
+		)
+	}
+
+	start := len(values) - len(rows)
+	for i := range rows {
+		rows[i][key] = values[start+i]
+	}
+	return nil
+}
+
+func limitDashboardRows(rows []map[string]any, points int) []map[string]any {
+	if points > 0 && points < len(rows) {
+		rows = rows[len(rows)-points:]
+	}
+
+	out := make([]map[string]any, len(rows))
+	for i, row := range rows {
+		out[i] = cloneDashboardRow(row)
+	}
+	return out
+}
+
+func cloneDashboardRow(row map[string]any) map[string]any {
+	clone := make(map[string]any, len(row))
+	maps.Copy(clone, row)
+	return clone
+}
+
+func highLowWindow(highs, lows []float64, endIndex, window int) (highest, lowest float64) {
+	start := max(0, endIndex-window+1)
+	highest = highs[start]
+	lowest = lows[start]
+	for i := start + 1; i <= endIndex; i++ {
+		if highs[i] > highest {
+			highest = highs[i]
+		}
+		if lows[i] < lowest {
+			lowest = lows[i]
+		}
+	}
+	return highest, lowest
+}
+
+func percentOf(value, base float64) float64 {
+	if base == 0 {
+		return 0
+	}
+	return value / base * 100
+}
+
+func percentChange(value, base float64) float64 {
+	if base == 0 {
+		return 0
+	}
+	return (value - base) / base * 100
+}
+
+func ratio(value, base float64) float64 {
+	if base == 0 {
+		return 0
+	}
+	return value / base
+}
+
+func dashboardSignals(latest map[string]any) map[string]any {
+	closePrice := latest["close"].(float64)
+	sma21 := latest["sma_21"].(float64)
+	sma50 := latest["sma_50"].(float64)
+	sma200 := latest["sma_200"].(float64)
+	rsi14 := latest["rsi_14"].(float64)
+	macdHist := latest["macd_histogram"].(float64)
+	atrPercent := latest["atr_percent"].(float64)
+	relativeVolume := latest["relative_volume"].(float64)
+
+	return map[string]any{
+		"trend":                   trendSignal(closePrice, sma21, sma50, sma200),
+		"momentum":                momentumSignal(rsi14, macdHist),
+		"volatility":              volatilitySignal(atrPercent),
+		"volume":                  volumeSignal(relativeVolume),
+		"close_above_sma_21":      closePrice > sma21,
+		"close_above_sma_50":      closePrice > sma50,
+		"close_above_sma_200":     closePrice > sma200,
+		"sma_21_above_sma_50":     sma21 > sma50,
+		"sma_50_above_sma_200":    sma50 > sma200,
+		"rsi_overbought":          rsi14 >= 70,
+		"rsi_oversold":            rsi14 <= 30,
+		"macd_histogram_positive": macdHist > 0,
+	}
+}
+
+func trendSignal(closePrice, sma21, sma50, sma200 float64) string {
+	switch {
+	case closePrice > sma21 && sma21 > sma50 && sma50 > sma200:
+		return "bullish"
+	case closePrice < sma21 && sma21 < sma50 && sma50 < sma200:
+		return "bearish"
+	default:
+		return "mixed"
+	}
+}
+
+func momentumSignal(rsi14, macdHistogram float64) string {
+	switch {
+	case rsi14 >= 70:
+		return "overbought"
+	case rsi14 <= 30:
+		return "oversold"
+	case macdHistogram > 0:
+		return "bullish"
+	case macdHistogram < 0:
+		return "bearish"
+	default:
+		return "neutral"
+	}
+}
+
+func volatilitySignal(atrPercent float64) string {
+	switch {
+	case atrPercent >= 5:
+		return "elevated"
+	case atrPercent <= 2:
+		return "compressed"
+	default:
+		return "normal"
+	}
+}
+
+func volumeSignal(relativeVolume float64) string {
+	switch {
+	case relativeVolume >= 1.5:
+		return "elevated"
+	case relativeVolume <= 0.75:
+		return "light"
+	default:
+		return "normal"
+	}
 }
 
 func cobraTAMACDCommand(c *client.Ref, w io.Writer) *cobra.Command {

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -35,6 +35,22 @@ func mockCandleListJSON(symbol string, n int) string {
 	return fmt.Sprintf(`{"symbol":%q,"empty":false,"candles":[%s]}`, symbol, strings.Join(candles, ","))
 }
 
+// mockFlatCandleListJSON builds candles with no price movement. Flat histories
+// produce valid all-zero MACD/ATR-style outputs after warm-up, which guards the
+// dashboard against confusing "all zeros" with "no indicator data".
+func mockFlatCandleListJSON(symbol string, n int) string {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	candles := make([]string, n)
+	for i := range n {
+		dt := base.AddDate(0, 0, i).Format(time.RFC3339)
+		candles[i] = fmt.Sprintf(
+			`{"open":100.0,"high":100.0,"low":100.0,"close":100.0,"volume":1000000,"datetimeISO8601":%q}`,
+			dt,
+		)
+	}
+	return fmt.Sprintf(`{"symbol":%q,"empty":false,"candles":[%s]}`, symbol, strings.Join(candles, ","))
+}
+
 // decodeTAEnvelope unmarshals the output buffer into an Envelope and extracts the data map.
 func decodeTAEnvelope(t *testing.T, buf *bytes.Buffer) (envelope output.Envelope, data map[string]any) {
 	t.Helper()
@@ -173,6 +189,146 @@ func optionChainHandler(t *testing.T, body string) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	})
+}
+
+func TestTADashboard_ValidEnvelope(t *testing.T) {
+	// Arrange: dashboard needs 252 candles for its long-range price context and
+	// SMA 200 while still making only one price-history request.
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
+		assert.Equal(t, "1", r.URL.Query().Get("period"), "252 daily candles should fit in one year")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockCandleListJSON("AAPL", 252)))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClient(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "AAPL")
+	require.NoError(t, err)
+
+	// Assert
+	envelope, data := decodeTAEnvelope(t, &buf)
+	assert.NotEmpty(t, envelope.Metadata.Timestamp)
+	assert.Equal(t, 1, requestCount, "dashboard should fetch price history once")
+	assert.Equal(t, "dashboard", data["indicator"])
+	assert.Equal(t, "AAPL", data["symbol"])
+	assert.Equal(t, "daily", data["interval"])
+
+	parameters, ok := data["parameters"].(map[string]any)
+	require.True(t, ok, "parameters should be an object")
+	assert.Equal(t, []any{float64(21), float64(50), float64(200)}, parameters["sma_periods"])
+	assert.InDelta(t, 14, parameters["rsi_period"], 0.1)
+	assert.InDelta(t, 12, parameters["macd_fast"], 0.1)
+	assert.InDelta(t, 26, parameters["macd_slow"], 0.1)
+	assert.InDelta(t, 9, parameters["macd_signal"], 0.1)
+	assert.InDelta(t, 20, parameters["bbands_period"], 0.1)
+	assert.InDelta(t, 252, parameters["long_range"], 0.1)
+
+	latest, ok := data["latest"].(map[string]any)
+	require.True(t, ok, "latest should be an object")
+	for _, key := range []string{
+		"datetime", "open", "high", "low", "close", "volume",
+		"sma_21", "sma_50", "sma_200", "rsi_14", "macd", "macd_signal", "macd_histogram",
+		"atr_14", "atr_percent", "bbands_upper", "bbands_middle", "bbands_lower",
+		"avg_volume_20", "relative_volume", "range_20_high", "range_20_low", "range_252_high", "range_252_low",
+		"distance_from_sma_21_percent", "distance_from_sma_50_percent", "distance_from_sma_200_percent",
+	} {
+		assert.Contains(t, latest, key)
+	}
+
+	signals, ok := data["signals"].(map[string]any)
+	require.True(t, ok, "signals should be an object")
+	assert.Contains(t, signals, "trend")
+	assert.Contains(t, signals, "momentum")
+	assert.Contains(t, signals, "volatility")
+	assert.Contains(t, signals, "volume")
+	assert.Contains(t, signals, "close_above_sma_200")
+	assert.Contains(t, signals, "macd_histogram_positive")
+
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 1, "dashboard defaults to the latest point")
+	assert.Equal(t, latest, values[0].(map[string]any), "default values row should match latest")
+}
+
+func TestTADashboard_PointsFlag(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(priceHistoryHandler(t, "MSFT", 254))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClient(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "--points", "3", "MSFT")
+	require.NoError(t, err)
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	assert.Equal(t, "dashboard", data["indicator"])
+	assert.Equal(t, "MSFT", data["symbol"])
+
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 3, "--points 3 should return three dashboard rows")
+
+	latest, ok := data["latest"].(map[string]any)
+	require.True(t, ok, "latest should be an object")
+	assert.Equal(t, latest, values[2].(map[string]any), "latest should match the final limited row")
+
+	first := values[0].(map[string]any)
+	assert.InDelta(t, 352.0, first["range_252_high"], 0.1, "first row should use candles 0-251")
+	assert.InDelta(t, 99.0, first["range_252_low"], 0.1, "first row should use candles 0-251")
+	assert.InDelta(t, 354.0, latest["range_252_high"], 0.1, "latest row should use candles 2-253")
+	assert.InDelta(t, 101.0, latest["range_252_low"], 0.1, "latest row should use candles 2-253")
+}
+
+func TestTADashboard_FlatHistoryDoesNotPanic(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockFlatCandleListJSON("FLAT", 252)))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClient(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "FLAT")
+	require.NoError(t, err)
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	latest, ok := data["latest"].(map[string]any)
+	require.True(t, ok, "latest should be an object")
+	assert.InDelta(t, 0.0, latest["macd"], 0.1)
+	assert.InDelta(t, 0.0, latest["macd_signal"], 0.1)
+	assert.InDelta(t, 0.0, latest["macd_histogram"], 0.1)
+	assert.InDelta(t, 0.0, latest["atr_14"], 0.1)
+	assert.InDelta(t, 100.0, latest["range_252_high"], 0.1)
+	assert.InDelta(t, 100.0, latest["range_252_low"], 0.1)
+}
+
+func TestTADashboard_InsufficientHistory(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 100))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClient(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "AAPL")
+
+	// Assert
+	require.Error(t, err)
+	var validationErr *apperr.ValidationError
+	assert.ErrorAs(t, err, &validationErr)
 }
 
 func TestTASMA_ValidEnvelope(t *testing.T) {

--- a/llms.txt
+++ b/llms.txt
@@ -124,6 +124,14 @@ more market names to filter.
 or PERCENT_CHANGE_DOWN. Use --frequency to filter by minimum percent change
 magnitude (0, 1, 5, 10, 30, 60). Quote shell-special characters in index
 names (e.g. '$SPX').
+- [schwab-agent option](#schwab-agent-option): Option planning workflows that combine quote, chain, and symbol context for agents.
+- [schwab-agent option ticket](#schwab-agent-option-ticket): Build an option planning ticket from live market data. The ticket combines
+the underlying quote, a narrowly filtered option chain, the matching contract,
+and the OCC symbol in one read-only command. Use order preview option when you
+are ready to turn the ticket into a Schwab preview request.
+- [schwab-agent option ticket get](#schwab-agent-option-ticket-get): Get a compact option ticket for one underlying, expiration, strike, and
+contract side. This collapses the common agent workflow of quote lookup, chain
+lookup, and OCC symbol construction into one read-only CLI call.
 - [schwab-agent order](#schwab-agent-order): Manage orders across your Schwab accounts. Supports listing, viewing, placing,
 previewing, building, canceling, and replacing orders. Placing, canceling, and
 replacing orders require the "i-also-like-to-live-dangerously" config flag.
@@ -197,8 +205,10 @@ priority. Requires a default account or --account flag.
 - [schwab-agent order list](#schwab-agent-order-list): List orders for the current account, or all accounts when no --account is set.
 By default, terminal statuses (FILLED, CANCELED, REJECTED, EXPIRED, REPLACED)
 are filtered out to show only actionable orders. Use --status all to see
-everything. Multiple --status values fan out into separate API calls with
-merged, deduplicated results.
+everything. Use --recent for an agent-friendly recent activity view that keeps
+terminal statuses and narrows the default lookback to 24 hours. Multiple
+--status values fan out into separate API calls with merged, deduplicated
+results.
 - [schwab-agent order place](#schwab-agent-order-place): Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
 with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
 Recommended workflow: check the price with quote get, build the order JSON with
@@ -219,10 +229,24 @@ bracket orders, OCO has no entry leg.
 and exactly one of --call or --put. Use BUY_TO_OPEN/SELL_TO_CLOSE for new
 positions and SELL_TO_OPEN/BUY_TO_CLOSE for existing ones. Requires
 i-also-like-to-live-dangerously in config for placement.
-- [schwab-agent order preview](#schwab-agent-order-preview): Preview an order from a JSON spec without placing it. Returns estimated
-commissions, fees, and order details. Pipe output from order build for a
-build-then-preview workflow. Does not require safety guards since no order
-is actually placed.
+- [schwab-agent order preview](#schwab-agent-order-preview): Preview an order from a JSON spec or typed subcommand flags without placing it.
+Typed preview subcommands reuse the same local builders as order place, then
+return both the built order request and Schwab preview response in one envelope.
+This removes the build-then-preview round trip while keeping placement explicit.
+Does not require safety guards since no order is actually placed.
+- [schwab-agent order preview bracket](#schwab-agent-order-preview-bracket): Preview a bracket order without placing it. At least one of --take-profit or
+--stop-loss is required. The preview response includes the locally built trigger
+order and Schwab's validation, fee, and commission details.
+- [schwab-agent order preview equity](#schwab-agent-order-preview-equity): Preview an equity (stock) order without placing it. Supports the same flags
+as order place equity, but skips the mutable-operation safety gate because no
+order is submitted. The response includes the built order request plus Schwab's
+preview details so agents can inspect both in one call.
+- [schwab-agent order preview oco](#schwab-agent-order-preview-oco): Preview a one-cancels-other order for an existing position without placing it.
+When both exits are present, the built order shows the OCO relationship Schwab
+will validate during preview.
+- [schwab-agent order preview option](#schwab-agent-order-preview-option): Preview a single-leg option order without placing it. Requires --underlying,
+--expiration, --strike, and exactly one of --call or --put. The response includes
+the locally built OCC order request and Schwab's preview response.
 - [schwab-agent order replace](#schwab-agent-order-replace): Replace an existing order with a new equity order. The original order is
 canceled and a new one is created with a new ID. Only equity order flags are
 accepted. Requires the "i-also-like-to-live-dangerously" config flag. The
@@ -258,6 +282,10 @@ data with Wilder smoothing. Default period is 14.
 - [schwab-agent ta bbands](#schwab-agent-ta-bbands): Compute Bollinger Bands for a symbol. Output keys are upper, middle, and lower
 bands. Price near the upper band is relatively high, near the lower band is
 relatively low. Use --std-dev to widen or narrow the bands (default 2.0).
+- [schwab-agent ta dashboard](#schwab-agent-ta-dashboard): Compute an opinionated technical-analysis dashboard for a symbol with one
+price-history fetch. The dashboard includes SMA 21/50/200 trend context, RSI 14,
+MACD 12/26/9, ATR 14, Bollinger Bands 20/2, volume context, and 20/252-candle
+high-low ranges. Signals are neutral factual labels for agents, not trading advice.
 - [schwab-agent ta ema](#schwab-agent-ta-ema): Compute Exponential Moving Average for a symbol. EMA gives more weight to
 recent prices than SMA. The --period flag can be repeated or comma-separated
 for multiple lookbacks in one command (e.g. --period 12,26 for crossover
@@ -553,6 +581,30 @@ names (e.g. '$SPX').
 
 - `--frequency` (string): Minimum percent change magnitude (0, 1, 5, 10, 30, 60) {,0,1,10,30,5,60}
 - `--sort` (string): Sort order (VOLUME, TRADES, PERCENT_CHANGE_UP, PERCENT_CHANGE_DOWN) {,PERCENT_CHANGE_DOWN,PERCENT_CHANGE_UP,TRADES,VOLUME}
+
+## schwab-agent option
+
+Option planning workflows that combine quote, chain, and symbol context for agents.
+
+## schwab-agent option ticket
+
+Build an option planning ticket from live market data. The ticket combines
+the underlying quote, a narrowly filtered option chain, the matching contract,
+and the OCC symbol in one read-only command. Use order preview option when you
+are ready to turn the ticket into a Schwab preview request.
+
+## schwab-agent option ticket get
+
+Get a compact option ticket for one underlying, expiration, strike, and
+contract side. This collapses the common agent workflow of quote lookup, chain
+lookup, and OCC symbol construction into one read-only CLI call.
+
+### Flags
+
+- `--call` (bool, default: false): Select the call contract
+- `--expiration` (string): Option expiration date (YYYY-MM-DD)
+- `--put` (bool, default: false): Select the put contract
+- `--strike` (float64, default: 0): Option strike price
 
 ## schwab-agent order
 
@@ -970,12 +1022,15 @@ priority. Requires a default account or --account flag.
 List orders for the current account, or all accounts when no --account is set.
 By default, terminal statuses (FILLED, CANCELED, REJECTED, EXPIRED, REPLACED)
 are filtered out to show only actionable orders. Use --status all to see
-everything. Multiple --status values fan out into separate API calls with
-merged, deduplicated results.
+everything. Use --recent for an agent-friendly recent activity view that keeps
+terminal statuses and narrows the default lookback to 24 hours. Multiple
+--status values fan out into separate API calls with merged, deduplicated
+results.
 
 ### Flags
 
 - `--from` (string): Filter by entered time lower bound
+- `--recent` (bool, default: false): Show recent order activity, including terminal statuses, from the last 24 hours unless --from is set
 - `--status` (stringSlice, default: []): Filter by order status (repeatable, use 'all' for unfiltered): WORKING, PENDING_ACTIVATION, FILLED, EXPIRED, CANCELED, REJECTED, etc.
 - `--to` (string): Filter by entered time upper bound
 
@@ -1080,14 +1135,100 @@ i-also-like-to-live-dangerously in config for placement.
 
 ## schwab-agent order preview
 
-Preview an order from a JSON spec without placing it. Returns estimated
-commissions, fees, and order details. Pipe output from order build for a
-build-then-preview workflow. Does not require safety guards since no order
-is actually placed.
+Preview an order from a JSON spec or typed subcommand flags without placing it.
+Typed preview subcommands reuse the same local builders as order place, then
+return both the built order request and Schwab preview response in one envelope.
+This removes the build-then-preview round trip while keeping placement explicit.
+Does not require safety guards since no order is actually placed.
 
 ### Flags
 
 - `--spec` (string, required): Inline JSON, @file, or - for stdin
+
+## schwab-agent order preview bracket
+
+Preview a bracket order without placing it. At least one of --take-profit or
+--stop-loss is required. The preview response includes the locally built trigger
+order and Schwab's validation, fee, and commission details.
+
+### Flags
+
+- `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--price` (float64, default: 0): Entry price
+- `--quantity` (float64, default: 0, required): Share quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--stop-loss` (float64, default: 0): Stop-loss exit price
+- `--symbol` (string, required): Equity symbol
+- `--take-profit` (float64, default: 0): Take-profit exit price
+- `--type` (string): Entry order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT}
+
+## schwab-agent order preview equity
+
+Preview an equity (stock) order without placing it. Supports the same flags
+as order place equity, but skips the mutable-operation safety gate because no
+order is submitted. The response includes the built order request plus Schwab's
+preview details so agents can inspect both in one call.
+
+### Flags
+
+- `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
+- `--activation-price` (float64, default: 0): Price that activates the trailing stop
+- `--destination` (string): Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX}
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--price` (float64, default: 0): Limit price
+- `--price-link-basis` (string): Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER}
+- `--price-link-type` (string): Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE}
+- `--quantity` (float64, default: 0, required): Share quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--special-instruction` (string): Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE}
+- `--stop-link-basis` (string): Trailing stop reference price (LAST, BID, ASK, MARK) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER}
+- `--stop-link-type` (string): Trailing stop offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE}
+- `--stop-offset` (float64, default: 0): Trailing stop offset amount
+- `--stop-price` (float64, default: 0): Stop price
+- `--stop-type` (string): Trailing stop trigger type (STANDARD, BID, ASK, LAST, MARK) {,ASK,BID,LAST,MARK,STANDARD}
+- `--symbol` (string, required): Equity symbol
+- `--type` (string): Order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT}
+
+## schwab-agent order preview oco
+
+Preview a one-cancels-other order for an existing position without placing it.
+When both exits are present, the built order shows the OCO relationship Schwab
+will validate during preview.
+
+### Flags
+
+- `--action` (string, required): Exit action (SELL to close long, BUY to close short) {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--quantity` (float64, default: 0, required): Share quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--stop-loss` (float64, default: 0): Stop-loss exit price (stop order)
+- `--symbol` (string, required): Equity symbol
+- `--take-profit` (float64, default: 0): Take-profit exit price (limit order)
+
+## schwab-agent order preview option
+
+Preview a single-leg option order without placing it. Requires --underlying,
+--expiration, --strike, and exactly one of --call or --put. The response includes
+the locally built OCC order request and Schwab's preview response.
+
+### Flags
+
+- `--action` (string, required): Order action {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
+- `--call` (bool, default: false): Call option
+- `--destination` (string): Order routing destination (INET, ECN_ARCA, CBOE, AMEX, PHLX, ISE, BOX, NYSE, NASDAQ, BATS, C2, AUTO) {,AMEX,AUTO,BATS,BOX,C2,CBOE,ECN_ARCA,INET,ISE,NASDAQ,NYSE,PHLX}
+- `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
+- `--expiration` (string, required): Expiration date (YYYY-MM-DD)
+- `--price` (float64, default: 0): Limit price
+- `--price-link-basis` (string): Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER}
+- `--price-link-type` (string): Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE}
+- `--put` (bool, default: false): Put option
+- `--quantity` (float64, default: 0, required): Contract quantity
+- `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
+- `--special-instruction` (string): Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE}
+- `--strike` (float64, default: 0, required): Strike price
+- `--type` (string): Order type {,LIMIT,LIMIT_ON_CLOSE,MARKET,MARKET_ON_CLOSE,NET_CREDIT,NET_DEBIT,NET_ZERO,STOP,STOP_LIMIT,TRAILING_STOP,TRAILING_STOP_LIMIT}
+- `--underlying` (string, required): Underlying symbol
 
 ## schwab-agent order replace
 
@@ -1216,6 +1357,18 @@ relatively low. Use --std-dev to widen or narrow the bands (default 2.0).
 - `--period` (int, default: 20): BBands period
 - `--points` (int, default: 1): Number of output points (0 = all)
 - `--std-dev` (float64, default: 2.0): Standard deviations
+
+## schwab-agent ta dashboard
+
+Compute an opinionated technical-analysis dashboard for a symbol with one
+price-history fetch. The dashboard includes SMA 21/50/200 trend context, RSI 14,
+MACD 12/26/9, ATR 14, Bollinger Bands 20/2, volume context, and 20/252-candle
+high-low ranges. Signals are neutral factual labels for agents, not trading advice.
+
+### Flags
+
+- `--interval` (string, default: daily): Data interval (daily, weekly, 1min, 5min, 15min, 30min)
+- `--points` (int, default: 1): Number of output points (0 = all)
 
 ## schwab-agent ta ema
 


### PR DESCRIPTION
## Summary
- Add `schwab-agent ta dashboard` to fetch price history once and return SMA 21/50/200, RSI, MACD, ATR, Bollinger Bands, volume context, ranges, and neutral signal labels.
- Cover dashboard output, `--points`, insufficient history, and flat-history all-zero indicator cases.
- Regenerate README, SKILL.md, and llms.txt docs, with generated SKILL code fences labeled for markdownlint.

## Verification
- `/usr/local/go/bin/go test ./internal/commands -run 'TestTADashboard'`
- `make test`
- `PATH="/tmp/opencode/gobin-v211:$PATH" make lint`
- `make build`
- `git diff --check`