### PR TITLE
Add preview digest order placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,7 @@ JSON at `~/.config/schwab-agent/config.json`. Fields: `client_id`, `client_secre
 ## Safety Guards
 
 - **Mutable operations** require `"i-also-like-to-live-dangerously": true` in config
+- **Preview digest ledger**: `order preview --save-preview` stores the exact canonical order payload under the local state dir (`$SCHWAB_AGENT_STATE_DIR/previews`, `$XDG_STATE_HOME/schwab-agent/previews`, or `~/.local/state/schwab-agent/previews`) with `0700` directories and `0600` files. `order place --from-preview <digest>` reloads the account-bound payload, verifies the SHA-256 digest and 15-minute TTL, rejects account mismatches, and submits the stored payload unchanged.
 - Market orders intentionally exclude price fields in the builder
 
 ## Testing Conventions

--- a/README.md
+++ b/README.md
@@ -130,12 +130,16 @@ schwab-agent order place equity \
   --price 150.00 \
   --duration DAY
 
-# Preview an order without placing it
+# Preview an order without placing it, then save the exact reviewed payload
 schwab-agent order preview equity \
   --symbol AAPL \
   --action BUY \
   --quantity 10 \
-  --type MARKET
+  --type MARKET \
+  --save-preview
+
+# Place the exact payload returned by previewDigest.digest
+schwab-agent order place --from-preview <digest>
 
 # Show recent order activity, including filled/canceled/replaced orders
 schwab-agent order list --recent
@@ -208,9 +212,10 @@ schwab-agent order place --spec @order.json
 
 ## Safety
 
-schwab-agent has a single layer of protection for operations that modify your account:
+schwab-agent has two layers of protection for operations that modify your account:
 
 1. **Config flag**: Set `"i-also-like-to-live-dangerously": true` in your config file to enable mutable operations (order placement, cancellation, replacement).
+2. **Preview digest flow**: Add `--save-preview` to `order preview` to store the exact payload locally for 15 minutes, then submit that same payload with `order place --from-preview <digest>`. The digest is bound to the account, operation, endpoint, and canonical order JSON. It is a local safety reference, not a Schwab reservation or idempotency key.
 
 This prevents accidental trades from misconfigured agents.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1125,26 +1125,31 @@ schwab-agent order list
 
 #### `schwab-agent order place`
 
-Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
-Recommended workflow: check the price with quote get, build the order JSON with
-order build, preview it with order preview, then place.
+Place an order via subcommand (equity, option, bracket, oco), from a JSON spec
+with --spec, or from an exact saved preview with --from-preview. Requires
+"i-also-like-to-live-dangerously" set to true in config.json. The safest workflow
+is to run order preview --save-preview, inspect the response, then place with the
+returned previewDigest.digest value.
 
 **Flags:**
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
-| `--spec` | string | - | yes | Inline JSON, @file, or - for stdin |
+| `--from-preview` | string | - | no | Place the exact order payload saved by order preview --save-preview |
+| `--spec` | string | - | no | Inline JSON, @file, or - for stdin |
 
 **Example:**
 
 ```bash
 # Place from a JSON file
-   schwab-agent order place --spec @order.json
-   # Place from stdin (piped from order build)
-   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
-   # Place from inline JSON
-   schwab-agent order place --spec '{"orderType":"LIMIT",...}'
+  schwab-agent order place --spec @order.json
+  # Place the exact payload saved by a previous preview
+  schwab-agent order preview equity --account abc123 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --save-preview
+  schwab-agent order place --from-preview <digest>
+  # Place from stdin (piped from order build)
+  schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
+  # Place from inline JSON
+  schwab-agent order place --spec '{"orderType":"LIMIT",...}'
 ```
 
 #### `schwab-agent order place bracket`
@@ -1295,19 +1300,22 @@ Preview an order from a JSON spec or typed subcommand flags without placing it.
 Typed preview subcommands reuse the same local builders as order place, then
 return both the built order request and Schwab preview response in one envelope.
 This removes the build-then-preview round trip while keeping placement explicit.
-Does not require safety guards since no order is actually placed.
+Use --save-preview to store the exact reviewed payload locally and return a
+previewDigest.digest value for order place --from-preview. Does not require
+safety guards since no order is actually placed.
 
 **Flags:**
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
+| `--save-preview` | bool | false | no | Save this preview locally and return a digest for order place --from-preview |
 | `--spec` | string | - | yes | Inline JSON, @file, or - for stdin |
 
 **Example:**
 
 ```bash
 schwab-agent order preview --spec @order.json
-  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200
+  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --save-preview
   schwab-agent order preview option --underlying AAPL --expiration 2026-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
 ```
@@ -1326,6 +1334,7 @@ order and Schwab's validation, fee, and commission details.
 | `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
 | `--price` | float64 | 0 | no | Entry price |
 | `--quantity` | float64 | 0 | yes | Share quantity |
+| `--save-preview` | bool | false | no | Save this preview locally and return a digest for order place --from-preview |
 | `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
 | `--stop-loss` | float64 | 0 | no | Stop-loss exit price |
 | `--symbol` | string | - | yes | Equity symbol |
@@ -1344,7 +1353,8 @@ schwab-agent order preview bracket --symbol NVDA --action BUY --quantity 10 --ty
 Preview an equity (stock) order without placing it. Supports the same flags
 as order place equity, but skips the mutable-operation safety gate because no
 order is submitted. The response includes the built order request plus Schwab's
-preview details so agents can inspect both in one call.
+preview details so agents can inspect both in one call. Add --save-preview to
+return a digest for exact-payload placement.
 
 **Flags:**
 
@@ -1358,6 +1368,7 @@ preview details so agents can inspect both in one call.
 | `--price-link-basis` | string | - | no | Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER} |
 | `--price-link-type` | string | - | no | Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE} |
 | `--quantity` | float64 | 0 | yes | Share quantity |
+| `--save-preview` | bool | false | no | Save this preview locally and return a digest for order place --from-preview |
 | `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
 | `--special-instruction` | string | - | no | Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE} |
 | `--stop-link-basis` | string | - | no | Trailing stop reference price (LAST, BID, ASK, MARK) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER} |
@@ -1388,6 +1399,7 @@ will validate during preview.
 | `--action` | string | - | yes | Exit action (SELL to close long, BUY to close short) {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN} |
 | `--duration` | string | - | no | Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH} |
 | `--quantity` | float64 | 0 | yes | Share quantity |
+| `--save-preview` | bool | false | no | Save this preview locally and return a digest for order place --from-preview |
 | `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
 | `--stop-loss` | float64 | 0 | no | Stop-loss exit price (stop order) |
 | `--symbol` | string | - | yes | Equity symbol |
@@ -1404,7 +1416,8 @@ schwab-agent order preview oco --symbol AAPL --action SELL --quantity 100 --take
 
 Preview a single-leg option order without placing it. Requires --underlying,
 --expiration, --strike, and exactly one of --call or --put. The response includes
-the locally built OCC order request and Schwab's preview response.
+the locally built OCC order request and Schwab's preview response. Add
+--save-preview to return a digest for exact-payload placement.
 
 **Flags:**
 
@@ -1420,6 +1433,7 @@ the locally built OCC order request and Schwab's preview response.
 | `--price-link-type` | string | - | no | Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE} |
 | `--put` | bool | false | no | Put option |
 | `--quantity` | float64 | 0 | yes | Contract quantity |
+| `--save-preview` | bool | false | no | Save this preview locally and return a digest for order place --from-preview |
 | `--session` | string | - | no | Trading session {,AM,NORMAL,PM,SEAMLESS} |
 | `--special-instruction` | string | - | no | Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE} |
 | `--strike` | float64 | 0 | yes | Strike price |
@@ -2180,11 +2194,14 @@ schwab-agent order list
 
 ```bash
 # Place from a JSON file
-   schwab-agent order place --spec @order.json
-   # Place from stdin (piped from order build)
-   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
-   # Place from inline JSON
-   schwab-agent order place --spec '{"orderType":"LIMIT",...}'
+  schwab-agent order place --spec @order.json
+  # Place the exact payload saved by a previous preview
+  schwab-agent order preview equity --account abc123 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --save-preview
+  schwab-agent order place --from-preview <digest>
+  # Place from stdin (piped from order build)
+  schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
+  # Place from inline JSON
+  schwab-agent order place --spec '{"orderType":"LIMIT",...}'
 ```
 
 #### schwab-agent order place bracket
@@ -2237,7 +2254,7 @@ schwab-agent order list
 
 ```bash
 schwab-agent order preview --spec @order.json
-  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200
+  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --save-preview
   schwab-agent order preview option --underlying AAPL --expiration 2026-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -
 ```

--- a/internal/commands/AGENTS.md
+++ b/internal/commands/AGENTS.md
@@ -72,6 +72,7 @@ if err := requireMutableEnabled(configPath); err != nil { return err }
 ```
 
 - `requireMutableEnabled`: Checks `i-also-like-to-live-dangerously` in config
+- `preview_ledger.go`: Saves `order preview --save-preview` payloads in the local state dir with 15-minute TTLs. `order place --from-preview <digest>` must submit the saved `models.OrderRequest` unchanged after digest, TTL, and optional `--account` checks pass.
 
 ## Account Resolution
 
@@ -97,6 +98,7 @@ Four order types share a common pattern: parse flags -> validate -> build -> pla
 - **OCO**: `parseOCOParams` -> `orderbuilder.ValidateOCOOrder` -> `orderbuilder.BuildOCOOrder`
 
 Spec mode (`--spec`): Accepts inline JSON, `@file` path, or `-` for stdin via `readSpecSource()`.
+Preview digest mode (`order preview --save-preview` then `order place --from-preview <digest>`): Binds the canonical order JSON to the account, operation, and endpoint so agents can separate review from mutation without rebuilding the payload.
 
 ## Enum Parsing
 

--- a/internal/commands/order_place.go
+++ b/internal/commands/order_place.go
@@ -25,6 +25,7 @@ type orderActionData struct {
 	Action               string               `json:"action"`
 	OrderID              int64                `json:"orderId"`
 	OriginalOrderID      *int64               `json:"originalOrderId,omitempty"`
+	PreviewDigest        string               `json:"previewDigest,omitempty"`
 	SubmittedOrder       *models.OrderRequest `json:"submittedOrder,omitempty"`
 	Canceled             bool                 `json:"canceled,omitempty"`
 	Replaced             bool                 `json:"replaced,omitempty"`
@@ -38,14 +39,16 @@ type orderActionData struct {
 
 // orderPreviewData wraps an order preview response.
 type orderPreviewData struct {
-	BuiltOrder *models.OrderRequest `json:"builtOrder,omitempty"`
-	Preview    *models.PreviewOrder `json:"preview"`
-	OrderID    *int64               `json:"orderId,omitempty"`
+	BuiltOrder    *models.OrderRequest `json:"builtOrder,omitempty"`
+	Preview       *models.PreviewOrder `json:"preview"`
+	OrderID       *int64               `json:"orderId,omitempty"`
+	PreviewDigest *previewDigestData   `json:"previewDigest,omitempty"`
 }
 
 // orderPlaceOpts holds local flags for top-level spec-based order placement.
 type orderPlaceOpts struct {
-	Spec string `flag:"spec" flagdescr:"Inline JSON, @file, or - for stdin" flagrequired:"true"`
+	Spec        string `flag:"spec" flagdescr:"Inline JSON, @file, or - for stdin"`
+	FromPreview string `flag:"from-preview" flagdescr:"Place the exact order payload saved by order preview --save-preview"`
 }
 
 // Attach implements structcli.Options interface.
@@ -53,7 +56,8 @@ func (o *orderPlaceOpts) Attach(_ *cobra.Command) error { return nil }
 
 // orderPreviewOpts holds local flags for order preview.
 type orderPreviewOpts struct {
-	Spec string `flag:"spec" flagdescr:"Inline JSON, @file, or - for stdin" flagrequired:"true"`
+	Spec        string `flag:"spec" flagdescr:"Inline JSON, @file, or - for stdin" flagrequired:"true"`
+	SavePreview bool   `flag:"save-preview" flagdescr:"Save this preview locally and return a digest for order place --from-preview"`
 }
 
 // Attach implements structcli.Options interface.
@@ -162,29 +166,101 @@ func writeOrderActionResult(w io.Writer, data *orderActionData, errs []string) e
 	return output.WriteSuccess(w, data, metadata)
 }
 
+type orderPlacePayload struct {
+	Account       string
+	Order         *models.OrderRequest
+	PreviewDigest string
+}
+
+// resolveOrderPlacePayload returns the account and order payload for top-level
+// placement. `--from-preview` deliberately bypasses spec parsing so the mutable
+// submit path reuses the exact payload saved during preview instead of rebuilding
+// an order from fresh flags or JSON.
+func resolveOrderPlacePayload(cmd *cobra.Command, c *client.Ref, configPath string, opts *orderPlaceOpts) (*orderPlacePayload, error) {
+	if strings.TrimSpace(opts.FromPreview) != "" {
+		entry, err := loadOrderPreview(opts.FromPreview)
+		if err != nil {
+			return nil, err
+		}
+
+		accountFlag, err := cmd.Flags().GetString("account")
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(accountFlag) != "" {
+			account, err := resolveAccount(c, accountFlag, configPath, nil)
+			if err != nil {
+				return nil, err
+			}
+			if account != entry.Account {
+				return nil, newValidationError("--account does not match the account bound to the preview digest")
+			}
+		}
+
+		return &orderPlacePayload{Account: entry.Account, Order: entry.Order, PreviewDigest: entry.Digest}, nil
+	}
+
+	accountFlag, err := cmd.Flags().GetString("account")
+	if err != nil {
+		return nil, err
+	}
+	account, err := resolveAccount(c, accountFlag, configPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	order, err := parseSpecOrder(cmd, opts.Spec)
+	if err != nil {
+		return nil, err
+	}
+	return &orderPlacePayload{Account: account, Order: order}, nil
+}
+
+// writeOrderPreviewResult optionally saves the previewed order to the local
+// digest ledger before emitting the standard preview envelope.
+func writeOrderPreviewResult(w io.Writer, account string, order *models.OrderRequest, preview *models.PreviewOrder, savePreview bool) error {
+	data := orderPreviewData{BuiltOrder: order, Preview: preview, OrderID: preview.OrderID}
+	if savePreview {
+		digestData, err := saveOrderPreview(account, order, preview)
+		if err != nil {
+			return err
+		}
+		data.PreviewDigest = digestData
+	}
+
+	return output.WriteSuccess(w, data, output.NewMetadata())
+}
+
 // newOrderPlaceCmd places new orders from either flags or a JSON spec.
 func newOrderPlaceCmd(c *client.Ref, configPath string, w io.Writer) *cobra.Command {
 	opts := &orderPlaceOpts{}
 	cmd := &cobra.Command{
 		Use:   "place",
 		Short: "Place an order",
-		Long: `Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
-Recommended workflow: check the price with quote get, build the order JSON with
-order build, preview it with order preview, then place.`,
+		Long: `Place an order via subcommand (equity, option, bracket, oco), from a JSON spec
+with --spec, or from an exact saved preview with --from-preview. Requires
+"i-also-like-to-live-dangerously" set to true in config.json. The safest workflow
+is to run order preview --save-preview, inspect the response, then place with the
+returned previewDigest.digest value.`,
 		Example: `  # Place from a JSON file
-   schwab-agent order place --spec @order.json
-   # Place from stdin (piped from order build)
-   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
-   # Place from inline JSON
-   schwab-agent order place --spec '{"orderType":"LIMIT",...}'`,
+  schwab-agent order place --spec @order.json
+  # Place the exact payload saved by a previous preview
+  schwab-agent order preview equity --account abc123 --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --save-preview
+  schwab-agent order place --from-preview <digest>
+  # Place from stdin (piped from order build)
+  schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order place --spec -
+  # Place from inline JSON
+  schwab-agent order place --spec '{"orderType":"LIMIT",...}'`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := structcli.Unmarshal(cmd, opts); err != nil {
 				return err
 			}
 
-			if strings.TrimSpace(opts.Spec) == "" {
-				return newValidationError("spec is required for `order place` without a subcommand")
+			specProvided := strings.TrimSpace(opts.Spec) != ""
+			previewDigest := strings.TrimSpace(opts.FromPreview)
+			fromPreviewProvided := previewDigest != ""
+			if specProvided == fromPreviewProvided {
+				return newValidationError("provide exactly one of --spec or --from-preview for `order place` without a subcommand")
 			}
 
 			configFlag, err := cmd.Flags().GetString("config")
@@ -199,30 +275,21 @@ order build, preview it with order preview, then place.`,
 				return err
 			}
 
-			accountFlag, err := cmd.Flags().GetString("account")
+			payload, err := resolveOrderPlacePayload(cmd, c, configFlag, opts)
+			if err != nil {
+				return err
+			}
+			if err := orderbuilder.ValidateOrderRequest(payload.Order); err != nil {
+				return err
+			}
+
+			response, err := c.PlaceOrder(cmd.Context(), payload.Account, payload.Order)
 			if err != nil {
 				return err
 			}
 
-			account, err := resolveAccount(c, accountFlag, configFlag, nil)
-			if err != nil {
-				return err
-			}
-
-			order, err := parseSpecOrder(cmd, opts.Spec)
-			if err != nil {
-				return err
-			}
-			if err := orderbuilder.ValidateOrderRequest(order); err != nil {
-				return err
-			}
-
-			response, err := c.PlaceOrder(cmd.Context(), account, order)
-			if err != nil {
-				return err
-			}
-
-			data, errs := fetchOrderActionData(cmd, c, account, "place", response.OrderID, order)
+			data, errs := fetchOrderActionData(cmd, c, payload.Account, "place", response.OrderID, payload.Order)
+			data.PreviewDigest = payload.PreviewDigest
 			return writeOrderActionResult(w, &data, errs)
 		},
 	}
@@ -231,6 +298,7 @@ order build, preview it with order preview, then place.`,
 	if err := structcli.Define(cmd, opts); err != nil {
 		panic(err)
 	}
+	cmd.MarkFlagsMutuallyExclusive("spec", "from-preview")
 
 	equityCmd := makeCobraPlaceOrderCommand(c, configPath, w, "equity", "Place an equity order", func() *equityPlaceOpts { return &equityPlaceOpts{} }, func(cmd *cobra.Command, opts *equityPlaceOpts) { defineAndConstrain(cmd, opts) }, parseEquityParams, orderbuilder.ValidateEquityOrder, orderbuilder.BuildEquityOrder)
 	equityCmd.Long = `Place an equity (stock) order. Supports MARKET, LIMIT, STOP, STOP_LIMIT, and
@@ -381,9 +449,11 @@ func newOrderPreviewCmd(c *client.Ref, configPath string, w io.Writer) *cobra.Co
 Typed preview subcommands reuse the same local builders as order place, then
 return both the built order request and Schwab preview response in one envelope.
 This removes the build-then-preview round trip while keeping placement explicit.
-Does not require safety guards since no order is actually placed.`,
+Use --save-preview to store the exact reviewed payload locally and return a
+previewDigest.digest value for order place --from-preview. Does not require
+safety guards since no order is actually placed.`,
 		Example: `  schwab-agent order preview --spec @order.json
-  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200
+  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 --save-preview
   schwab-agent order preview option --underlying AAPL --expiration 2026-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1 --type LIMIT --price 5.00
   schwab-agent order build equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 200 | schwab-agent order preview --spec -`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -395,12 +465,20 @@ Does not require safety guards since no order is actually placed.`,
 				return newValidationError("spec is required")
 			}
 
+			configFlag, err := cmd.Flags().GetString("config")
+			if err != nil {
+				return err
+			}
+			if configFlag == "" {
+				configFlag = configPath
+			}
+
 			accountFlag, err := cmd.Flags().GetString("account")
 			if err != nil {
 				return err
 			}
 
-			account, err := resolveAccount(c, accountFlag, configPath, nil)
+			account, err := resolveAccount(c, accountFlag, configFlag, nil)
 			if err != nil {
 				return err
 			}
@@ -418,7 +496,7 @@ Does not require safety guards since no order is actually placed.`,
 				return err
 			}
 
-			return output.WriteSuccess(w, orderPreviewData{BuiltOrder: order, Preview: preview, OrderID: preview.OrderID}, output.NewMetadata())
+			return writeOrderPreviewResult(w, account, order, preview, opts.SavePreview)
 		},
 	}
 
@@ -430,7 +508,8 @@ Does not require safety guards since no order is actually placed.`,
 	equityCmd.Long = `Preview an equity (stock) order without placing it. Supports the same flags
 as order place equity, but skips the mutable-operation safety gate because no
 order is submitted. The response includes the built order request plus Schwab's
-preview details so agents can inspect both in one call.`
+preview details so agents can inspect both in one call. Add --save-preview to
+return a digest for exact-payload placement.`
 	equityCmd.Example = `  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10
 	  schwab-agent order preview equity --symbol AAPL --action BUY --quantity 10 --type LIMIT --price 150 --duration GTC`
 
@@ -439,7 +518,8 @@ preview details so agents can inspect both in one call.`
 	}, parseOptionParams, orderbuilder.ValidateOptionOrder, orderbuilder.BuildOptionOrder)
 	optionCmd.Long = `Preview a single-leg option order without placing it. Requires --underlying,
 --expiration, --strike, and exactly one of --call or --put. The response includes
-the locally built OCC order request and Schwab's preview response.`
+the locally built OCC order request and Schwab's preview response. Add
+--save-preview to return a digest for exact-payload placement.`
 	optionCmd.Example = `  schwab-agent order preview option --underlying AAPL --expiration 2025-06-20 --strike 200 --call --action BUY_TO_OPEN --quantity 1
 	  schwab-agent order preview option --underlying AAPL --expiration 2025-06-20 --strike 190 --put --action SELL_TO_OPEN --quantity 1 --type LIMIT --price 3.50`
 
@@ -492,12 +572,20 @@ func makeCobraPreviewOrderCommand[O any, P any](
 				return err
 			}
 
+			configFlag, err := cmd.Flags().GetString("config")
+			if err != nil {
+				return err
+			}
+			if configFlag == "" {
+				configFlag = configPath
+			}
+
 			accountFlag, err := cmd.Flags().GetString("account")
 			if err != nil {
 				return err
 			}
 
-			account, err := resolveAccount(c, accountFlag, configPath, nil)
+			account, err := resolveAccount(c, accountFlag, configFlag, nil)
 			if err != nil {
 				return err
 			}
@@ -521,7 +609,11 @@ func makeCobraPreviewOrderCommand[O any, P any](
 				return err
 			}
 
-			return output.WriteSuccess(w, orderPreviewData{BuiltOrder: order, Preview: preview, OrderID: preview.OrderID}, output.NewMetadata())
+			savePreview, err := cmd.Flags().GetBool("save-preview")
+			if err != nil {
+				return err
+			}
+			return writeOrderPreviewResult(w, account, order, preview, savePreview)
 		},
 	}
 	cmd.SetFlagErrorFunc(normalizeFlagValidationErrorFunc)
@@ -529,6 +621,7 @@ func makeCobraPreviewOrderCommand[O any, P any](
 	if flagSetup != nil {
 		flagSetup(cmd, opts)
 	}
+	cmd.Flags().Bool("save-preview", false, "Save this preview locally and return a digest for order place --from-preview")
 
 	return cmd
 }

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -649,6 +649,100 @@ func TestNewOrderCmdPlaceSpecFromFile(t *testing.T) {
 	assert.Equal(t, "QUEUED", order["status"])
 }
 
+func TestNewOrderCmdPreviewSaveAndPlaceFromPreview(t *testing.T) {
+	orderID := int64(13579)
+	previewResponse := models.PreviewOrder{OrderID: &orderID}
+	var previewedOrder models.OrderRequest
+	var placedOrder models.OrderRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/trader/v1/accounts/hash123/previewOrder":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &previewedOrder))
+
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(previewResponse))
+		case r.Method == http.MethodPost && r.URL.Path == "/trader/v1/accounts/hash123/orders":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(body, &placedOrder))
+
+			w.Header().Set("Location", "/trader/v1/accounts/hash123/orders/13579")
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/13579":
+			writeTestOrderResponse(t, w, 13579, models.OrderStatusQueued, "AAPL")
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", t.TempDir())
+	configPath := writeTestConfigMutable(t, "hash123")
+	cliClient := &client.Ref{Client: client.NewClient("test-token", client.WithBaseURL(server.URL))}
+
+	previewStdout, err := runOrderCommand(
+		t,
+		cliClient,
+		configPath,
+		"",
+		"order", "preview", "equity",
+		"--symbol", "AAPL",
+		"--action", "BUY",
+		"--quantity", "10",
+		"--type", "LIMIT",
+		"--price", "185.25",
+		"--save-preview",
+	)
+	require.NoError(t, err)
+
+	previewEnvelope := decodeEnvelope(t, previewStdout)
+	previewData, ok := previewEnvelope.Data.(map[string]any)
+	require.True(t, ok)
+	digestData, ok := previewData["previewDigest"].(map[string]any)
+	require.True(t, ok)
+	digest, ok := digestData["digest"].(string)
+	require.True(t, ok)
+	require.Len(t, digest, 64)
+	assert.Equal(t, "hash123", digestData["account"])
+	assert.Equal(t, "order.place", digestData["operation"])
+
+	placeStdout, err := runOrderCommand(t, cliClient, configPath, "", "order", "place", "--from-preview", digest)
+	require.NoError(t, err)
+
+	assert.Equal(t, previewedOrder, placedOrder)
+	placeEnvelope := decodeEnvelope(t, placeStdout)
+	placeData, ok := placeEnvelope.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "place", placeData["action"])
+	assert.Equal(t, float64(13579), placeData["orderId"])
+	assert.Equal(t, digest, placeData["previewDigest"])
+	assert.Equal(t, "verified", placeData["verificationState"])
+}
+
+func TestNewOrderCmdPlaceFromPreviewRejectsAccountMismatch(t *testing.T) {
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", t.TempDir())
+	configPath := writeTestConfigMutable(t, "hash123")
+	cliClient := &client.Ref{}
+	digestData, err := saveOrderPreview("hash123", testPreviewLedgerOrder(t), nil)
+	require.NoError(t, err)
+
+	_, err = runOrderCommand(
+		t,
+		cliClient,
+		configPath,
+		"",
+		"order", "place",
+		"--account", "hash999",
+		"--from-preview", digestData.Digest,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}
+
 func TestNewOrderCmdPlaceNoLocationReturnsPartialSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/internal/commands/preview_ledger.go
+++ b/internal/commands/preview_ledger.go
@@ -1,0 +1,217 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/major/schwab-agent/internal/apperr"
+	"github.com/major/schwab-agent/internal/models"
+)
+
+const (
+	previewLedgerSchemaVersion = 1
+	previewLedgerOperation     = "order.place"
+	previewLedgerEndpoint      = "/trader/v1/accounts/{accountHash}/orders"
+	previewLedgerTTL           = 15 * time.Minute
+)
+
+// previewDigestData is the small machine-readable reference returned from
+// `order preview --save-preview`. The digest is intentionally just a local
+// safety reference, not an authorization token or Schwab-side reservation.
+type previewDigestData struct {
+	Digest    string `json:"digest"`
+	ExpiresAt string `json:"expiresAt"`
+	Account   string `json:"account"`
+	Operation string `json:"operation"`
+}
+
+// savedOrderPreview is the on-disk ledger entry used by `order place --from-preview`.
+// The canonical order JSON is stored alongside the decoded request so load can
+// prove the file still matches its digest before submitting anything mutable.
+type savedOrderPreview struct {
+	Version        int                  `json:"version"`
+	Digest         string               `json:"digest"`
+	Operation      string               `json:"operation"`
+	Endpoint       string               `json:"endpoint"`
+	Account        string               `json:"account"`
+	CreatedAt      time.Time            `json:"createdAt"`
+	ExpiresAt      time.Time            `json:"expiresAt"`
+	CanonicalOrder json.RawMessage      `json:"canonicalOrder"`
+	Order          *models.OrderRequest `json:"order"`
+	Preview        *models.PreviewOrder `json:"preview,omitempty"`
+	OrderID        *int64               `json:"orderId,omitempty"`
+}
+
+// saveOrderPreview stores a previewed order in the local state ledger and
+// returns the digest metadata callers should include in the preview envelope.
+func saveOrderPreview(account string, order *models.OrderRequest, preview *models.PreviewOrder) (*previewDigestData, error) {
+	createdAt := time.Now().UTC()
+	expiresAt := createdAt.Add(previewLedgerTTL)
+	canonicalOrder, digest, err := previewDigestFor(account, order)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := savedOrderPreview{
+		Version:        previewLedgerSchemaVersion,
+		Digest:         digest,
+		Operation:      previewLedgerOperation,
+		Endpoint:       previewLedgerEndpoint,
+		Account:        account,
+		CreatedAt:      createdAt,
+		ExpiresAt:      expiresAt,
+		CanonicalOrder: canonicalOrder,
+		Order:          order,
+		Preview:        preview,
+	}
+	if preview != nil {
+		entry.OrderID = preview.OrderID
+	}
+
+	ledgerDir, err := previewLedgerDir()
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(ledgerDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create preview ledger directory: %w", err)
+	}
+	// MkdirAll only applies the requested mode when it creates a directory.
+	// Tighten existing directories too, because preview files contain exact order
+	// payloads and the command help promises private ledger storage.
+	if err := os.Chmod(ledgerDir, 0o700); err != nil { //nolint:gosec // Directories need execute bits; 0700 keeps the ledger private.
+		return nil, fmt.Errorf("secure preview ledger directory: %w", err)
+	}
+
+	encoded, err := json.MarshalIndent(&entry, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal preview ledger entry: %w", err)
+	}
+
+	path := filepath.Join(ledgerDir, digest+".json")
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		return nil, fmt.Errorf("write preview ledger entry: %w", err)
+	}
+
+	return &previewDigestData{
+		Digest:    digest,
+		ExpiresAt: expiresAt.Format(time.RFC3339),
+		Account:   account,
+		Operation: previewLedgerOperation,
+	}, nil
+}
+
+// loadOrderPreview validates and returns a saved preview entry. Digest checking
+// happens before expiry/account decisions so local tampering always fails closed.
+func loadOrderPreview(digest string) (*savedOrderPreview, error) {
+	digest = strings.TrimSpace(digest)
+	if !isPreviewDigest(digest) {
+		return nil, apperr.NewValidationError("preview digest must be a 64-character lowercase SHA-256 hex string", nil)
+	}
+
+	ledgerDir, err := previewLedgerDir()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(filepath.Join(ledgerDir, digest+".json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, apperr.NewValidationError("preview digest was not found or has already been cleaned up", err)
+		}
+		return nil, fmt.Errorf("read preview ledger entry: %w", err)
+	}
+
+	var entry savedOrderPreview
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, apperr.NewValidationError("preview ledger entry is not valid JSON", err)
+	}
+	if entry.Version != previewLedgerSchemaVersion || entry.Operation != previewLedgerOperation || entry.Endpoint != previewLedgerEndpoint {
+		return nil, apperr.NewValidationError("preview ledger entry uses an unsupported schema or operation", nil)
+	}
+	if entry.Order == nil {
+		return nil, apperr.NewValidationError("preview ledger entry is missing its order payload", nil)
+	}
+
+	canonicalOrder, expectedDigest, err := previewDigestFor(entry.Account, entry.Order)
+	if err != nil {
+		return nil, err
+	}
+	var compactedLedgerOrder bytes.Buffer
+	if err := json.Compact(&compactedLedgerOrder, entry.CanonicalOrder); err != nil {
+		return nil, apperr.NewValidationError("preview ledger entry has invalid canonical order JSON", err)
+	}
+	if expectedDigest != digest || entry.Digest != digest || string(canonicalOrder) != compactedLedgerOrder.String() {
+		return nil, apperr.NewValidationError("preview ledger entry no longer matches its digest", nil)
+	}
+	if time.Now().UTC().After(entry.ExpiresAt) {
+		return nil, apperr.NewValidationError("preview digest expired; run order preview --save-preview again", nil)
+	}
+
+	return &entry, nil
+}
+
+// previewDigestFor returns the canonical order JSON and the account-bound digest
+// used as the immutable handoff between preview and place.
+func previewDigestFor(account string, order *models.OrderRequest) (json.RawMessage, string, error) {
+	canonicalOrder, err := json.Marshal(order)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal canonical order: %w", err)
+	}
+
+	boundPayload := struct {
+		Version        int             `json:"version"`
+		Operation      string          `json:"operation"`
+		Endpoint       string          `json:"endpoint"`
+		Account        string          `json:"account"`
+		CanonicalOrder json.RawMessage `json:"canonicalOrder"`
+	}{
+		Version:        previewLedgerSchemaVersion,
+		Operation:      previewLedgerOperation,
+		Endpoint:       previewLedgerEndpoint,
+		Account:        account,
+		CanonicalOrder: canonicalOrder,
+	}
+	encoded, err := json.Marshal(boundPayload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal preview digest payload: %w", err)
+	}
+
+	sum := sha256.Sum256(encoded)
+	return canonicalOrder, hex.EncodeToString(sum[:]), nil
+}
+
+// previewLedgerDir resolves the local state directory for saved previews.
+func previewLedgerDir() (string, error) {
+	if stateDir := strings.TrimSpace(os.Getenv("SCHWAB_AGENT_STATE_DIR")); stateDir != "" {
+		return filepath.Join(stateDir, "previews"), nil
+	}
+	if xdgStateHome := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); xdgStateHome != "" {
+		return filepath.Join(xdgStateHome, "schwab-agent", "previews"), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for preview ledger: %w", err)
+	}
+	return filepath.Join(homeDir, ".local", "state", "schwab-agent", "previews"), nil
+}
+
+// isPreviewDigest rejects path traversal and non-canonical hex before any file
+// path is built from user input.
+func isPreviewDigest(digest string) bool {
+	if len(digest) != sha256.Size*2 {
+		return false
+	}
+	for _, r := range digest {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/commands/preview_ledger_test.go
+++ b/internal/commands/preview_ledger_test.go
@@ -1,0 +1,137 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/major/schwab-agent/internal/models"
+	"github.com/major/schwab-agent/internal/orderbuilder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testPreviewLedgerOrder(t *testing.T) *models.OrderRequest {
+	t.Helper()
+
+	order, err := orderbuilder.BuildEquityOrder(&orderbuilder.EquityParams{
+		Symbol:    "AAPL",
+		Action:    models.InstructionBuy,
+		Quantity:  10,
+		OrderType: models.OrderTypeLimit,
+		Price:     185.25,
+	})
+	require.NoError(t, err)
+	return order
+}
+
+func testSavedPreviewEntry(t *testing.T, stateDir, digest string) savedOrderPreview {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(stateDir, "previews", digest+".json"))
+	require.NoError(t, err)
+
+	var entry savedOrderPreview
+	require.NoError(t, json.Unmarshal(data, &entry))
+	return entry
+}
+
+func writeSavedPreviewEntry(t *testing.T, stateDir string, entry *savedOrderPreview) {
+	t.Helper()
+
+	data, err := json.MarshalIndent(&entry, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "previews", entry.Digest+".json"), data, 0o600))
+}
+
+func TestPreviewLedgerRejectsUnsafeDigestInput(t *testing.T) {
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", t.TempDir())
+
+	for _, digest := range []string{
+		"",
+		"../" + strings.Repeat("a", 64),
+		strings.Repeat("A", 64),
+		strings.Repeat("g", 64),
+		strings.Repeat("a", 63),
+	} {
+		t.Run(digest, func(t *testing.T) {
+			_, err := loadOrderPreview(digest)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "64-character lowercase SHA-256")
+		})
+	}
+}
+
+func TestPreviewLedgerRejectsMissingDigest(t *testing.T) {
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", t.TempDir())
+
+	_, err := loadOrderPreview(strings.Repeat("a", 64))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestPreviewLedgerRejectsTamperedOrderPayload(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", stateDir)
+
+	digestData, err := saveOrderPreview("hash123", testPreviewLedgerOrder(t), nil)
+	require.NoError(t, err)
+	entry := testSavedPreviewEntry(t, stateDir, digestData.Digest)
+	entry.Order.OrderLegCollection[0].Instrument.Symbol = "MSFT"
+	writeSavedPreviewEntry(t, stateDir, &entry)
+
+	_, err = loadOrderPreview(digestData.Digest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer matches")
+}
+
+func TestPreviewLedgerRejectsTamperedCanonicalOrder(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", stateDir)
+
+	digestData, err := saveOrderPreview("hash123", testPreviewLedgerOrder(t), nil)
+	require.NoError(t, err)
+	entry := testSavedPreviewEntry(t, stateDir, digestData.Digest)
+	entry.CanonicalOrder = json.RawMessage(`{"tampered":true}`)
+	writeSavedPreviewEntry(t, stateDir, &entry)
+
+	_, err = loadOrderPreview(digestData.Digest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer matches")
+}
+
+func TestPreviewLedgerRejectsExpiredEntry(t *testing.T) {
+	stateDir := t.TempDir()
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", stateDir)
+
+	digestData, err := saveOrderPreview("hash123", testPreviewLedgerOrder(t), nil)
+	require.NoError(t, err)
+	entry := testSavedPreviewEntry(t, stateDir, digestData.Digest)
+	entry.ExpiresAt = time.Now().UTC().Add(-time.Minute)
+	writeSavedPreviewEntry(t, stateDir, &entry)
+
+	_, err = loadOrderPreview(digestData.Digest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+func TestPreviewLedgerSecuresExistingDirectory(t *testing.T) {
+	stateDir := t.TempDir()
+	ledgerDir := filepath.Join(stateDir, "previews")
+	require.NoError(t, os.MkdirAll(ledgerDir, 0o755))
+	t.Setenv("SCHWAB_AGENT_STATE_DIR", stateDir)
+
+	digestData, err := saveOrderPreview("hash123", testPreviewLedgerOrder(t), nil)
+	require.NoError(t, err)
+
+	dirInfo, err := os.Stat(ledgerDir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+
+	fileInfo, err := os.Stat(filepath.Join(ledgerDir, digestData.Digest+".json"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
+}

--- a/llms.txt
+++ b/llms.txt
@@ -218,10 +218,11 @@ everything. Use --recent for an agent-friendly recent activity view that keeps
 terminal statuses and narrows the default lookback to 24 hours. Multiple
 --status values fan out into separate API calls with merged, deduplicated
 results.
-- [schwab-agent order place](#schwab-agent-order-place): Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
-Recommended workflow: check the price with quote get, build the order JSON with
-order build, preview it with order preview, then place.
+- [schwab-agent order place](#schwab-agent-order-place): Place an order via subcommand (equity, option, bracket, oco), from a JSON spec
+with --spec, or from an exact saved preview with --from-preview. Requires
+"i-also-like-to-live-dangerously" set to true in config.json. The safest workflow
+is to run order preview --save-preview, inspect the response, then place with the
+returned previewDigest.digest value.
 - [schwab-agent order place bracket](#schwab-agent-order-place-bracket): Place a bracket order that combines an entry trade with automatic exit orders.
 At least one of --take-profit or --stop-loss is required. Exit instructions are
 auto-inverted from the entry action (BUY entry creates SELL exits). Canceling
@@ -242,20 +243,24 @@ i-also-like-to-live-dangerously in config for placement.
 Typed preview subcommands reuse the same local builders as order place, then
 return both the built order request and Schwab preview response in one envelope.
 This removes the build-then-preview round trip while keeping placement explicit.
-Does not require safety guards since no order is actually placed.
+Use --save-preview to store the exact reviewed payload locally and return a
+previewDigest.digest value for order place --from-preview. Does not require
+safety guards since no order is actually placed.
 - [schwab-agent order preview bracket](#schwab-agent-order-preview-bracket): Preview a bracket order without placing it. At least one of --take-profit or
 --stop-loss is required. The preview response includes the locally built trigger
 order and Schwab's validation, fee, and commission details.
 - [schwab-agent order preview equity](#schwab-agent-order-preview-equity): Preview an equity (stock) order without placing it. Supports the same flags
 as order place equity, but skips the mutable-operation safety gate because no
 order is submitted. The response includes the built order request plus Schwab's
-preview details so agents can inspect both in one call.
+preview details so agents can inspect both in one call. Add --save-preview to
+return a digest for exact-payload placement.
 - [schwab-agent order preview oco](#schwab-agent-order-preview-oco): Preview a one-cancels-other order for an existing position without placing it.
 When both exits are present, the built order shows the OCO relationship Schwab
 will validate during preview.
 - [schwab-agent order preview option](#schwab-agent-order-preview-option): Preview a single-leg option order without placing it. Requires --underlying,
 --expiration, --strike, and exactly one of --call or --put. The response includes
-the locally built OCC order request and Schwab's preview response.
+the locally built OCC order request and Schwab's preview response. Add
+--save-preview to return a digest for exact-payload placement.
 - [schwab-agent order replace](#schwab-agent-order-replace): Replace an existing order with a new equity order. The original order is
 canceled and a new one is created with a new ID. Only equity order flags are
 accepted. Requires the "i-also-like-to-live-dangerously" config flag. The
@@ -1079,14 +1084,16 @@ results.
 
 ## schwab-agent order place
 
-Place an order via subcommand (equity, option, bracket, oco) or from a JSON spec
-with --spec. Requires "i-also-like-to-live-dangerously" set to true in config.json.
-Recommended workflow: check the price with quote get, build the order JSON with
-order build, preview it with order preview, then place.
+Place an order via subcommand (equity, option, bracket, oco), from a JSON spec
+with --spec, or from an exact saved preview with --from-preview. Requires
+"i-also-like-to-live-dangerously" set to true in config.json. The safest workflow
+is to run order preview --save-preview, inspect the response, then place with the
+returned previewDigest.digest value.
 
 ### Flags
 
-- `--spec` (string, required): Inline JSON, @file, or - for stdin
+- `--from-preview` (string): Place the exact order payload saved by order preview --save-preview
+- `--spec` (string): Inline JSON, @file, or - for stdin
 
 ## schwab-agent order place bracket
 
@@ -1182,10 +1189,13 @@ Preview an order from a JSON spec or typed subcommand flags without placing it.
 Typed preview subcommands reuse the same local builders as order place, then
 return both the built order request and Schwab preview response in one envelope.
 This removes the build-then-preview round trip while keeping placement explicit.
-Does not require safety guards since no order is actually placed.
+Use --save-preview to store the exact reviewed payload locally and return a
+previewDigest.digest value for order place --from-preview. Does not require
+safety guards since no order is actually placed.
 
 ### Flags
 
+- `--save-preview` (bool, default: false): Save this preview locally and return a digest for order place --from-preview
 - `--spec` (string, required): Inline JSON, @file, or - for stdin
 
 ## schwab-agent order preview bracket
@@ -1200,6 +1210,7 @@ order and Schwab's validation, fee, and commission details.
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--price` (float64, default: 0): Entry price
 - `--quantity` (float64, default: 0, required): Share quantity
+- `--save-preview` (bool, default: false): Save this preview locally and return a digest for order place --from-preview
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
 - `--stop-loss` (float64, default: 0): Stop-loss exit price
 - `--symbol` (string, required): Equity symbol
@@ -1211,7 +1222,8 @@ order and Schwab's validation, fee, and commission details.
 Preview an equity (stock) order without placing it. Supports the same flags
 as order place equity, but skips the mutable-operation safety gate because no
 order is submitted. The response includes the built order request plus Schwab's
-preview details so agents can inspect both in one call.
+preview details so agents can inspect both in one call. Add --save-preview to
+return a digest for exact-payload placement.
 
 ### Flags
 
@@ -1223,6 +1235,7 @@ preview details so agents can inspect both in one call.
 - `--price-link-basis` (string): Price link reference price (MANUAL, BASE, TRIGGER, LAST, BID, ASK, ASK_BID, MARK, AVERAGE) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER}
 - `--price-link-type` (string): Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE}
 - `--quantity` (float64, default: 0, required): Share quantity
+- `--save-preview` (bool, default: false): Save this preview locally and return a digest for order place --from-preview
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
 - `--special-instruction` (string): Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE}
 - `--stop-link-basis` (string): Trailing stop reference price (LAST, BID, ASK, MARK) {,ASK,ASK_BID,AVERAGE,BASE,BID,LAST,MANUAL,MARK,TRIGGER}
@@ -1244,6 +1257,7 @@ will validate during preview.
 - `--action` (string, required): Exit action (SELL to close long, BUY to close short) {,BUY,BUY_TO_CLOSE,BUY_TO_COVER,BUY_TO_OPEN,EXCHANGE,SELL,SELL_SHORT,SELL_SHORT_EXEMPT,SELL_TO_CLOSE,SELL_TO_OPEN}
 - `--duration` (string): Order duration {,DAY,END_OF_MONTH,END_OF_WEEK,FILL_OR_KILL,GOOD_TILL_CANCEL,IMMEDIATE_OR_CANCEL,NEXT_END_OF_MONTH}
 - `--quantity` (float64, default: 0, required): Share quantity
+- `--save-preview` (bool, default: false): Save this preview locally and return a digest for order place --from-preview
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
 - `--stop-loss` (float64, default: 0): Stop-loss exit price (stop order)
 - `--symbol` (string, required): Equity symbol
@@ -1253,7 +1267,8 @@ will validate during preview.
 
 Preview a single-leg option order without placing it. Requires --underlying,
 --expiration, --strike, and exactly one of --call or --put. The response includes
-the locally built OCC order request and Schwab's preview response.
+the locally built OCC order request and Schwab's preview response. Add
+--save-preview to return a digest for exact-payload placement.
 
 ### Flags
 
@@ -1267,6 +1282,7 @@ the locally built OCC order request and Schwab's preview response.
 - `--price-link-type` (string): Price link offset type (VALUE, PERCENT, TICK) {,PERCENT,TICK,VALUE}
 - `--put` (bool, default: false): Put option
 - `--quantity` (float64, default: 0, required): Contract quantity
+- `--save-preview` (bool, default: false): Save this preview locally and return a digest for order place --from-preview
 - `--session` (string): Trading session {,AM,NORMAL,PM,SEAMLESS}
 - `--special-instruction` (string): Special instruction (ALL_OR_NONE, DO_NOT_REDUCE, ALL_OR_NONE_DO_NOT_REDUCE) {,ALL_OR_NONE,ALL_OR_NONE_DO_NOT_REDUCE,DO_NOT_REDUCE}
 - `--strike` (float64, default: 0, required): Strike price

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -263,6 +263,9 @@ run_help_contains_test "order replace shows equity symbol flag" "--symbol" order
 run_help_contains_test "order replace option shows underlying flag" "--underlying" order replace option
 run_help_contains_test "order replace option shows call flag" "--call" order replace option
 run_help_contains_test "order replace option shows put flag" "--put" order replace option
+run_help_contains_test "order preview shows save-preview flag" "--save-preview" order preview
+run_help_contains_test "order preview equity shows save-preview flag" "--save-preview" order preview equity
+run_help_contains_test "order place shows from-preview flag" "--from-preview" order place
 
 run_help_contains_test "quote get shows underlying flag" "--underlying" quote get
 run_help_contains_test "quote get shows call flag" "--call" quote get


### PR DESCRIPTION
## Summary
- Add `order preview --save-preview` to store exact reviewed order payloads in a local 15-minute digest ledger.
- Add `order place --from-preview <digest>` to submit the saved payload unchanged after digest, TTL, account, and mutable guard checks.
- Update docs, generated agent references, unit coverage, and smoke help checks for the new workflow.

## Verification
- `make lint`
- `make test`
- `make build`
- `make smoke-ci` (186/186)
- 5-agent review passed: goal, QA, code quality, security, context mining

Skipped local CodeRabbit review per request.