### PR TITLE
refactor(tests): use testify assertions consistently

### DIFF
--- a/internal/apperr/errors_test.go
+++ b/internal/apperr/errors_test.go
@@ -6,194 +6,154 @@ import (
 	"testing"
 
 	structclierrors "github.com/leodido/structcli/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestExitCodeForAuthRequiredError verifies AuthRequiredError maps to exit code 3.
 func TestExitCodeForAuthRequiredError(t *testing.T) {
 	err := NewAuthRequiredError("auth required", nil)
 	code := ExitCodeFor(err)
-	if code != 3 {
-		t.Errorf("ExitCodeFor(AuthRequiredError) = %d, want 3", code)
-	}
+	assert.Equal(t, 3, code)
 }
 
 // TestExitCodeForAuthExpiredError verifies AuthExpiredError maps to exit code 3.
 func TestExitCodeForAuthExpiredError(t *testing.T) {
 	err := NewAuthExpiredError("auth expired", nil)
 	code := ExitCodeFor(err)
-	if code != 3 {
-		t.Errorf("ExitCodeFor(AuthExpiredError) = %d, want 3", code)
-	}
+	assert.Equal(t, 3, code)
 }
 
 // TestExitCodeForAuthCallbackError verifies AuthCallbackError maps to exit code 3.
 func TestExitCodeForAuthCallbackError(t *testing.T) {
 	err := NewAuthCallbackError("auth callback failed", nil)
 	code := ExitCodeFor(err)
-	if code != 3 {
-		t.Errorf("ExitCodeFor(AuthCallbackError) = %d, want 3", code)
-	}
+	assert.Equal(t, 3, code)
 }
 
 // TestExitCodeForOrderRejectedError verifies OrderRejectedError maps to exit code 5.
 func TestExitCodeForOrderRejectedError(t *testing.T) {
 	err := NewOrderRejectedError("order rejected", nil)
 	code := ExitCodeFor(err)
-	if code != 5 {
-		t.Errorf("ExitCodeFor(OrderRejectedError) = %d, want 5", code)
-	}
+	assert.Equal(t, 5, code)
 }
 
 // TestExitCodeForSymbolNotFoundError verifies SymbolNotFoundError maps to exit code 2.
 func TestExitCodeForSymbolNotFoundError(t *testing.T) {
 	err := NewSymbolNotFoundError("symbol not found", nil)
 	code := ExitCodeFor(err)
-	if code != 2 {
-		t.Errorf("ExitCodeFor(SymbolNotFoundError) = %d, want 2", code)
-	}
+	assert.Equal(t, 2, code)
 }
 
 // TestExitCodeForAccountNotFoundError verifies AccountNotFoundError maps to exit code 2.
 func TestExitCodeForAccountNotFoundError(t *testing.T) {
 	err := NewAccountNotFoundError("account not found", nil)
 	code := ExitCodeFor(err)
-	if code != 2 {
-		t.Errorf("ExitCodeFor(AccountNotFoundError) = %d, want 2", code)
-	}
+	assert.Equal(t, 2, code)
 }
 
 // TestExitCodeForHTTPError verifies HTTPError maps to exit code 4.
 func TestExitCodeForHTTPError(t *testing.T) {
 	err := NewHTTPError("http error", 500, "Internal Server Error", nil)
 	code := ExitCodeFor(err)
-	if code != 4 {
-		t.Errorf("ExitCodeFor(HTTPError) = %d, want 4", code)
-	}
+	assert.Equal(t, 4, code)
 }
 
 // TestExitCodeForValidationError verifies ValidationError maps to exit code 1.
 func TestExitCodeForValidationError(t *testing.T) {
 	err := NewValidationError("validation failed", nil)
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(ValidationError) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestExitCodeForOrderBuildError verifies OrderBuildError maps to exit code 1.
 func TestExitCodeForOrderBuildError(t *testing.T) {
 	err := NewOrderBuildError("order build failed", nil)
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(OrderBuildError) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestExitCodeForSchwabError verifies SchwabError maps to exit code 1.
 func TestExitCodeForSchwabError(t *testing.T) {
 	err := NewSchwabError("generic error", nil)
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(SchwabError) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestExitCodeForNilError verifies nil error maps to exit code 0.
 func TestExitCodeForNilError(t *testing.T) {
 	code := ExitCodeFor(nil)
-	if code != 0 {
-		t.Errorf("ExitCodeFor(nil) = %d, want 0", code)
-	}
+	assert.Equal(t, 0, code)
 }
 
 // TestExitCodeForStandardError verifies standard errors.New() maps to exit code 1.
 func TestExitCodeForStandardError(t *testing.T) {
 	err := errors.New("standard error")
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(standard error) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestErrorCodeForAuthRequiredError verifies ErrorCode returns correct string.
 func TestErrorCodeForAuthRequiredError(t *testing.T) {
 	err := NewAuthRequiredError("auth required", nil)
 	code := ErrorCode(err)
-	if code != "AUTH_REQUIRED" {
-		t.Errorf("ErrorCode(AuthRequiredError) = %q, want %q", code, "AUTH_REQUIRED")
-	}
+	assert.Equal(t, "AUTH_REQUIRED", code)
 }
 
 // TestErrorCodeForAuthExpiredError verifies ErrorCode returns correct string.
 func TestErrorCodeForAuthExpiredError(t *testing.T) {
 	err := NewAuthExpiredError("auth expired", nil)
 	code := ErrorCode(err)
-	if code != "AUTH_EXPIRED" {
-		t.Errorf("ErrorCode(AuthExpiredError) = %q, want %q", code, "AUTH_EXPIRED")
-	}
+	assert.Equal(t, "AUTH_EXPIRED", code)
 }
 
 // TestErrorCodeForAuthCallbackError verifies ErrorCode returns correct string.
 func TestErrorCodeForAuthCallbackError(t *testing.T) {
 	err := NewAuthCallbackError("auth callback failed", nil)
 	code := ErrorCode(err)
-	if code != "AUTH_CALLBACK" {
-		t.Errorf("ErrorCode(AuthCallbackError) = %q, want %q", code, "AUTH_CALLBACK")
-	}
+	assert.Equal(t, "AUTH_CALLBACK", code)
 }
 
 // TestErrorCodeForOrderRejectedError verifies ErrorCode returns correct string.
 func TestErrorCodeForOrderRejectedError(t *testing.T) {
 	err := NewOrderRejectedError("order rejected", nil)
 	code := ErrorCode(err)
-	if code != "ORDER_REJECTED" {
-		t.Errorf("ErrorCode(OrderRejectedError) = %q, want %q", code, "ORDER_REJECTED")
-	}
+	assert.Equal(t, "ORDER_REJECTED", code)
 }
 
 // TestErrorCodeForSymbolNotFoundError verifies ErrorCode returns correct string.
 func TestErrorCodeForSymbolNotFoundError(t *testing.T) {
 	err := NewSymbolNotFoundError("symbol not found", nil)
 	code := ErrorCode(err)
-	if code != "SYMBOL_NOT_FOUND" {
-		t.Errorf("ErrorCode(SymbolNotFoundError) = %q, want %q", code, "SYMBOL_NOT_FOUND")
-	}
+	assert.Equal(t, "SYMBOL_NOT_FOUND", code)
 }
 
 // TestErrorCodeForAccountNotFoundError verifies ErrorCode returns correct string.
 func TestErrorCodeForAccountNotFoundError(t *testing.T) {
 	err := NewAccountNotFoundError("account not found", nil)
 	code := ErrorCode(err)
-	if code != "ACCOUNT_NOT_FOUND" {
-		t.Errorf("ErrorCode(AccountNotFoundError) = %q, want %q", code, "ACCOUNT_NOT_FOUND")
-	}
+	assert.Equal(t, "ACCOUNT_NOT_FOUND", code)
 }
 
 // TestErrorCodeForHTTPError verifies ErrorCode returns correct string.
 func TestErrorCodeForHTTPError(t *testing.T) {
 	err := NewHTTPError("http error", 500, "Internal Server Error", nil)
 	code := ErrorCode(err)
-	if code != "HTTP_ERROR" {
-		t.Errorf("ErrorCode(HTTPError) = %q, want %q", code, "HTTP_ERROR")
-	}
+	assert.Equal(t, "HTTP_ERROR", code)
 }
 
 // TestErrorCodeForValidationError verifies ErrorCode returns correct string.
 func TestErrorCodeForValidationError(t *testing.T) {
 	err := NewValidationError("validation failed", nil)
 	code := ErrorCode(err)
-	if code != "VALIDATION_ERROR" {
-		t.Errorf("ErrorCode(ValidationError) = %q, want %q", code, "VALIDATION_ERROR")
-	}
+	assert.Equal(t, "VALIDATION_ERROR", code)
 }
 
 // TestErrorCodeForOrderBuildError verifies ErrorCode returns correct string.
 func TestErrorCodeForOrderBuildError(t *testing.T) {
 	err := NewOrderBuildError("order build failed", nil)
 	code := ErrorCode(err)
-	if code != "ORDER_BUILD_ERROR" {
-		t.Errorf("ErrorCode(OrderBuildError) = %q, want %q", code, "ORDER_BUILD_ERROR")
-	}
+	assert.Equal(t, "ORDER_BUILD_ERROR", code)
 }
 
 // TestErrorCodeForStructcliValidationError verifies structcli's ValidationError
@@ -205,9 +165,7 @@ func TestErrorCodeForStructcliValidationError(t *testing.T) {
 		Errors:      []error{fmt.Errorf("field is invalid")},
 	}
 	code := ErrorCode(err)
-	if code != "VALIDATION_ERROR" {
-		t.Errorf("ErrorCode(structcli ValidationError) = %q, want %q", code, "VALIDATION_ERROR")
-	}
+	assert.Equal(t, "VALIDATION_ERROR", code)
 }
 
 // TestExitCodeForStructcliValidationError verifies structcli's ValidationError
@@ -218,36 +176,28 @@ func TestExitCodeForStructcliValidationError(t *testing.T) {
 		Errors:      []error{fmt.Errorf("field is invalid")},
 	}
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(structcli ValidationError) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestErrorCodeForSchwabError verifies ErrorCode returns correct string.
 func TestErrorCodeForSchwabError(t *testing.T) {
 	err := NewSchwabError("generic error", nil)
 	code := ErrorCode(err)
-	if code != "UNKNOWN" {
-		t.Errorf("ErrorCode(SchwabError) = %q, want %q", code, "UNKNOWN")
-	}
+	assert.Equal(t, "UNKNOWN", code)
 }
 
 // TestErrorCodeForStandardError verifies ErrorCode returns UNKNOWN for standard errors.
 func TestErrorCodeForStandardError(t *testing.T) {
 	err := errors.New("standard error")
 	code := ErrorCode(err)
-	if code != "UNKNOWN" {
-		t.Errorf("ErrorCode(standard error) = %q, want %q", code, "UNKNOWN")
-	}
+	assert.Equal(t, "UNKNOWN", code)
 }
 
 // TestErrorMessagePreservation verifies error messages are preserved.
 func TestErrorMessagePreservation(t *testing.T) {
 	message := "test error message"
 	err := NewSchwabError(message, nil)
-	if err.Error() != message {
-		t.Errorf("Error() = %q, want %q", err.Error(), message)
-	}
+	assert.Equal(t, message, err.Error())
 }
 
 // TestErrorChainPreservation verifies error chains are preserved through wrapping.
@@ -255,13 +205,8 @@ func TestErrorChainPreservation(t *testing.T) {
 	underlying := errors.New("root cause")
 	err := NewAuthRequiredError("auth required", underlying)
 
-	if !errors.Is(err, underlying) {
-		t.Error("error chain not preserved: errors.Is(err, underlying) returned false")
-	}
-
-	if !errors.Is(err.Unwrap(), underlying) {
-		t.Error("Unwrap() did not return the underlying error")
-	}
+	assert.ErrorIs(t, err, underlying)
+	assert.ErrorIs(t, err.Unwrap(), underlying)
 }
 
 // TestErrorChainTraversal verifies errors.AsType() can traverse the error chain.
@@ -270,16 +215,12 @@ func TestErrorChainTraversal(t *testing.T) {
 	err := NewAuthRequiredError("auth required", underlying)
 
 	authErr, ok := errors.AsType[*AuthRequiredError](err)
-	if !ok {
-		t.Error("errors.AsType() failed to find AuthRequiredError in chain")
-	}
+	require.True(t, ok, "errors.AsType() should find AuthRequiredError in chain")
 
 	// Note: errors.AsType() does not automatically traverse to parent types
 	// without explicit As() method implementation. This test verifies
 	// that the specific error type can be found.
-	if authErr.Message != "auth required" {
-		t.Errorf("AuthRequiredError message = %q, want %q", authErr.Message, "auth required")
-	}
+	assert.Equal(t, "auth required", authErr.Message)
 }
 
 // TestHTTPErrorAttributes verifies HTTPError stores status code and body.
@@ -287,21 +228,15 @@ func TestHTTPErrorAttributes(t *testing.T) {
 	statusCode := 500
 	body := "Internal Server Error"
 	err := NewHTTPError("http error", statusCode, body, nil)
-	if err.StatusCode != statusCode {
-		t.Errorf("HTTPError.StatusCode = %d, want %d", err.StatusCode, statusCode)
-	}
-	if err.Body != body {
-		t.Errorf("HTTPError.Body = %q, want %q", err.Body, body)
-	}
+	assert.Equal(t, statusCode, err.StatusCode)
+	assert.Equal(t, body, err.Body)
 }
 
 // TestDetailsFieldPreservation verifies Details is set through constructor option.
 func TestDetailsFieldPreservation(t *testing.T) {
 	details := "Try checking your credentials"
 	err := NewAuthRequiredError("auth required", nil, WithDetails(details))
-	if err.Details() != details {
-		t.Errorf("Details() = %q, want %q", err.Details(), details)
-	}
+	assert.Equal(t, details, err.Details())
 }
 
 // TestWrappedAuthRequiredError verifies wrapped AuthRequiredError maps correctly.
@@ -309,9 +244,7 @@ func TestWrappedAuthRequiredError(t *testing.T) {
 	underlying := errors.New("invalid token")
 	err := NewAuthRequiredError("auth required", underlying)
 	code := ExitCodeFor(err)
-	if code != 3 {
-		t.Errorf("ExitCodeFor(wrapped AuthRequiredError) = %d, want 3", code)
-	}
+	assert.Equal(t, 3, code)
 }
 
 // TestWrappedOrderRejectedError verifies wrapped OrderRejectedError maps correctly.
@@ -319,9 +252,7 @@ func TestWrappedOrderRejectedError(t *testing.T) {
 	underlying := errors.New("insufficient funds")
 	err := NewOrderRejectedError("order rejected", underlying)
 	code := ExitCodeFor(err)
-	if code != 5 {
-		t.Errorf("ExitCodeFor(wrapped OrderRejectedError) = %d, want 5", code)
-	}
+	assert.Equal(t, 5, code)
 }
 
 // TestWrappedSymbolNotFoundError verifies wrapped SymbolNotFoundError maps correctly.
@@ -329,9 +260,7 @@ func TestWrappedSymbolNotFoundError(t *testing.T) {
 	underlying := errors.New("api returned empty data")
 	err := NewSymbolNotFoundError("symbol not found", underlying)
 	code := ExitCodeFor(err)
-	if code != 2 {
-		t.Errorf("ExitCodeFor(wrapped SymbolNotFoundError) = %d, want 2", code)
-	}
+	assert.Equal(t, 2, code)
 }
 
 // TestWrappedAccountNotFoundError verifies wrapped AccountNotFoundError maps correctly.
@@ -339,9 +268,7 @@ func TestWrappedAccountNotFoundError(t *testing.T) {
 	underlying := errors.New("account lookup failed")
 	err := NewAccountNotFoundError("account not found", underlying)
 	code := ExitCodeFor(err)
-	if code != 2 {
-		t.Errorf("ExitCodeFor(wrapped AccountNotFoundError) = %d, want 2", code)
-	}
+	assert.Equal(t, 2, code)
 }
 
 // TestWrappedHTTPError verifies wrapped HTTPError maps correctly.
@@ -349,9 +276,7 @@ func TestWrappedHTTPError(t *testing.T) {
 	underlying := errors.New("connection failed")
 	err := NewHTTPError("http error", 502, "Bad Gateway", underlying)
 	code := ExitCodeFor(err)
-	if code != 4 {
-		t.Errorf("ExitCodeFor(wrapped HTTPError) = %d, want 4", code)
-	}
+	assert.Equal(t, 4, code)
 }
 
 // TestWrappedValidationError verifies wrapped ValidationError maps correctly.
@@ -359,9 +284,7 @@ func TestWrappedValidationError(t *testing.T) {
 	underlying := errors.New("symbol is empty")
 	err := NewValidationError("validation failed", underlying)
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(wrapped ValidationError) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestWrappedOrderBuildError verifies wrapped OrderBuildError maps correctly.
@@ -369,9 +292,7 @@ func TestWrappedOrderBuildError(t *testing.T) {
 	underlying := errors.New("invalid order parameters")
 	err := NewOrderBuildError("order build failed", underlying)
 	code := ExitCodeFor(err)
-	if code != 1 {
-		t.Errorf("ExitCodeFor(wrapped OrderBuildError) = %d, want 1", code)
-	}
+	assert.Equal(t, 1, code)
 }
 
 // TestWithDetails_AllConstructors verifies the WithDetails option sets the
@@ -397,9 +318,7 @@ func TestWithDetails_AllConstructors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.details != hint {
-				t.Errorf("Details() = %q, want %q", tt.details, hint)
-			}
+			assert.Equal(t, hint, tt.details)
 		})
 	}
 }

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -385,7 +385,7 @@ func TestCallbackHandler_Idempotency_OnlyProcessesFirstRequest(t *testing.T) {
 	// Channel should be empty - second request did not send a result
 	select {
 	case r := <-resultCh:
-		t.Fatalf("second request should not have sent a result, got: %+v", r)
+		require.Failf(t, "unexpected channel result", "second request should not have sent a result, got: %+v", r)
 	default:
 		// expected: sync.Once prevented second write
 	}

--- a/internal/client/orders_test.go
+++ b/internal/client/orders_test.go
@@ -124,7 +124,7 @@ func TestListOrders_MultipleStatuses(t *testing.T) {
 			}}
 			require.NoError(t, json.NewEncoder(w).Encode(response))
 		default:
-			t.Errorf("unexpected status filter: %q", status)
+			assert.Failf(t, "unexpected status filter", "got status %q", status)
 		}
 	}))
 	defer srv.Close()

--- a/internal/commands/account_test.go
+++ b/internal/commands/account_test.go
@@ -290,10 +290,10 @@ func TestNewAccountCmd_Summary_Success(t *testing.T) {
 				{"accountNumber":"67890","nickName":"Joint Taxable","primaryAccount":false,"type":"CASH"}
 			]}`))
 		case "/trader/v1/accounts":
-			t.Errorf("account summary should not fetch the full account payload")
+			assert.Fail(t, "account summary should not fetch the full account payload")
 			w.WriteHeader(http.StatusInternalServerError)
 		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
@@ -366,7 +366,7 @@ func TestNewAccountCmd_Summary_WithPositionsFlag(t *testing.T) {
 				}
 			}]`))
 		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
@@ -425,10 +425,10 @@ func TestNewAccountCmd_Summary_WithPositionsFlag_EmptyAccountsSkipsPositions(t *
 			_, _ = w.Write([]byte(`[]`))
 		case "/trader/v1/accounts":
 			accountPayloadRequests++
-			t.Errorf("empty account summary should not fetch positions")
+			assert.Fail(t, "empty account summary should not fetch positions")
 			w.WriteHeader(http.StatusInternalServerError)
 		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
@@ -466,7 +466,7 @@ func TestNewAccountCmd_Summary_PreferencesFailure_StillReturnsPositions(t *testi
 				}
 			}]`))
 		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
@@ -510,10 +510,10 @@ func TestNewAccountCmd_Summary_PreferencesFailure_StillReturnsHashes(t *testing.
 		case "/trader/v1/userPreference":
 			w.WriteHeader(http.StatusInternalServerError)
 		case "/trader/v1/accounts":
-			t.Errorf("account summary should not fetch the full account payload")
+			assert.Fail(t, "account summary should not fetch the full account payload")
 			w.WriteHeader(http.StatusInternalServerError)
 		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
@@ -554,10 +554,10 @@ func TestNewAccountCmd_Summary_EmptyAccountsSkipsPreferences(t *testing.T) {
 			_, _ = w.Write([]byte(`[]`))
 		case "/trader/v1/userPreference":
 			preferenceRequests++
-			t.Errorf("empty account summary should not fetch preferences")
+			assert.Fail(t, "empty account summary should not fetch preferences")
 			w.WriteHeader(http.StatusInternalServerError)
 		default:
-			t.Errorf("unexpected request: %s", r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))

--- a/internal/commands/order_test.go
+++ b/internal/commands/order_test.go
@@ -220,7 +220,7 @@ func TestNewOrderCmdSpecSemanticValidation(t *testing.T) {
 	var requests int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
-		t.Errorf("unexpected API request for invalid spec: %s %s", r.Method, r.URL.Path)
+		assert.Failf(t, "unexpected API request for invalid spec", "%s %s", r.Method, r.URL.Path)
 		http.NotFound(w, r)
 	}))
 	defer server.Close()
@@ -544,7 +544,7 @@ func TestNewOrderCmdPlaceEquityPipeline(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/default-hash/orders/67890":
 			writeTestOrderResponse(t, w, 67890, models.OrderStatusQueued, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -609,7 +609,7 @@ func TestNewOrderCmdPlaceSpecFromFile(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/24680":
 			writeTestOrderResponse(t, w, 24680, models.OrderStatusQueued, "MSFT")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -674,7 +674,7 @@ func TestNewOrderCmdPreviewSaveAndPlaceFromPreview(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/13579":
 			writeTestOrderResponse(t, w, 13579, models.OrderStatusQueued, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -753,10 +753,10 @@ func TestNewOrderCmdPlaceNoLocationReturnsPartialSuccess(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 		case r.Method == http.MethodGet:
 			getRequests++
-			t.Errorf("unexpected follow-up GET without an order ID: %s", r.URL.Path)
+			assert.Failf(t, "unexpected follow-up GET", "request without order ID: %s", r.URL.Path)
 			http.NotFound(w, r)
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -989,7 +989,7 @@ func TestNewOrderCmdPlaceOCOPipeline(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/default-hash/orders/55555":
 			writeTestOrderResponse(t, w, 55555, models.OrderStatusQueued, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -1976,7 +1976,7 @@ func TestNewOrderCmdListMultipleStatuses(t *testing.T) {
 			_, err := w.Write([]byte(`[{"session":"NORMAL","duration":"DAY","orderType":"MARKET","orderStrategyType":"SINGLE","orderId":222,"status":"FILLED","orderLegCollection":[{"instruction":"SELL","quantity":5,"instrument":{"assetType":"EQUITY","symbol":"MSFT"}}]}]`))
 			require.NoError(t, err)
 		default:
-			t.Errorf("unexpected status filter: %q", status)
+			assert.Failf(t, "unexpected status filter", "got status %q", status)
 		}
 	}))
 	defer server.Close()
@@ -2396,7 +2396,7 @@ func TestNewOrderCmdCancelSuccess(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
 			writeTestOrderResponse(t, w, 12345, models.OrderStatusCanceled, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2435,7 +2435,7 @@ func TestNewOrderCmdCancelOrderIDFlagSuccess(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/1234567890":
 			writeTestOrderResponse(t, w, 1234567890, models.OrderStatusCanceled, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2473,7 +2473,7 @@ func TestNewOrderCmdCancelGetFailureReturnsPartialSuccess(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
 			http.Error(w, "eventual consistency", http.StatusInternalServerError)
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2562,7 +2562,7 @@ func TestNewOrderCmdReplaceSuccess(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
 			writeTestOrderResponse(t, w, 12345, models.OrderStatusReplaced, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2630,7 +2630,7 @@ func TestNewOrderCmdReplaceOrderIDFlagSuccess(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/1234567890":
 			writeTestOrderResponse(t, w, 1234567890, models.OrderStatusReplaced, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2690,7 +2690,7 @@ func TestNewOrderCmdReplaceOriginalStatusMismatchReturnsPartialSuccess(t *testin
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
 			writeTestOrderResponse(t, w, 12345, models.OrderStatusPendingReplace, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2771,7 +2771,7 @@ func TestOrderReplaceEquityFlagAliases(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
 			writeTestOrderResponse(t, w, 12345, models.OrderStatusReplaced, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))
@@ -2818,7 +2818,7 @@ func TestOrderReplaceOptionSuccess(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/trader/v1/accounts/hash123/orders/12345":
 			writeTestOrderResponse(t, w, 12345, models.OrderStatusReplaced, "AAPL")
 		default:
-			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			assert.Failf(t, "unexpected request", "%s %s", r.Method, r.URL.Path)
 			http.NotFound(w, r)
 		}
 	}))

--- a/internal/orderbuilder/fuzz_test.go
+++ b/internal/orderbuilder/fuzz_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/major/schwab-agent/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // FuzzParseOCCSymbol verifies that ParseOCCSymbol never panics on arbitrary input.
@@ -35,25 +37,20 @@ func FuzzParseOCCSymbol(f *testing.F) {
 		}
 
 		// If parsing succeeded, verify invariants.
-		if result.Underlying == "" {
-			t.Error("parsed successfully but underlying is empty")
-		}
+		assert.NotEmpty(t, result.Underlying, "parsed successfully but underlying is empty")
 
-		if result.PutCall != "CALL" && result.PutCall != "PUT" {
-			t.Errorf("parsed successfully but put/call is %q", result.PutCall)
-		}
+		assert.True(
+			t,
+			result.PutCall == "CALL" || result.PutCall == "PUT",
+			"parsed successfully but put/call is %q",
+			result.PutCall,
+		)
 
-		if result.Strike <= 0 {
-			t.Errorf("parsed successfully but strike is %f", result.Strike)
-		}
+		assert.Greater(t, result.Strike, 0.0, "parsed successfully but strike is non-positive")
 
-		if result.Expiration.IsZero() {
-			t.Error("parsed successfully but expiration is zero")
-		}
+		assert.False(t, result.Expiration.IsZero(), "parsed successfully but expiration is zero")
 
-		if result.Symbol != input {
-			t.Errorf("parsed successfully but Symbol field is %q, want %q", result.Symbol, input)
-		}
+		assert.Equal(t, input, result.Symbol, "parsed Symbol field mismatch")
 	})
 }
 
@@ -113,30 +110,18 @@ func FuzzBuildParseOCCRoundTrip(f *testing.F) {
 		symbol := BuildOCCSymbol(trimmed, expiration, strike, putCall)
 
 		parsed, err := ParseOCCSymbol(symbol)
-		if err != nil {
-			t.Fatalf("BuildOCCSymbol produced unparseable symbol %q: %v", symbol, err)
-		}
+		require.NoError(t, err, "BuildOCCSymbol produced unparseable symbol %q", symbol)
 
 		// BuildOCCSymbol right-pads to 6 chars, ParseOCCSymbol trims.
 		// Compare against the trimmed input to account for this.
-		if parsed.Underlying != trimmed {
-			t.Errorf("underlying: got %q, want %q", parsed.Underlying, trimmed)
-		}
+		assert.Equal(t, trimmed, parsed.Underlying, "underlying mismatch")
 
-		if parsed.PutCall != putCall {
-			t.Errorf("putCall: got %q, want %q", parsed.PutCall, putCall)
-		}
+		assert.Equal(t, putCall, parsed.PutCall, "putCall mismatch")
 
-		if parsed.Expiration.Year() != year {
-			t.Errorf("year: got %d, want %d", parsed.Expiration.Year(), year)
-		}
+		assert.Equal(t, year, parsed.Expiration.Year(), "year mismatch")
 
-		if parsed.Expiration.Month() != time.Month(month) {
-			t.Errorf("month: got %v, want %v", parsed.Expiration.Month(), time.Month(month))
-		}
+		assert.Equal(t, time.Month(month), parsed.Expiration.Month(), "month mismatch")
 
-		if parsed.Expiration.Day() != day {
-			t.Errorf("day: got %d, want %d", parsed.Expiration.Day(), day)
-		}
+		assert.Equal(t, day, parsed.Expiration.Day(), "day mismatch")
 	})
 }


### PR DESCRIPTION
## Summary
- Convert remaining raw `t.Error`, `t.Errorf`, and `t.Fatalf` calls in tests to testify assertions.
- Use `assert.Fail` and `assert.Failf` in mock HTTP handlers to preserve handler goroutine behavior.
- Use `require` only where later assertions depend on the checked condition.

## Verification
- LSP diagnostics on modified test files: no diagnostics.
- Raw assertion sweep under `internal/**/*_test.go`: no standalone `t.Error`, `t.Errorf`, `t.Fatal`, or `t.Fatalf` matches.
- `make test`
- `make lint`
- `make build`
- `make smoke-ci` (186 passed, 0 failed)