### PR TITLE
fix(ta): buffer daily history lookbacks

### DIFF
--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -217,7 +217,7 @@ func TestTADashboard_ValidEnvelope(t *testing.T) {
 		requestCount++
 		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
 		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
-		assert.Equal(t, "1", r.URL.Query().Get("period"), "252 daily candles should fit in one year")
+		assert.Equal(t, "2", r.URL.Query().Get("period"), "252 daily candles need a buffered request")
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(mockCandleListJSON("AAPL", 252)))
@@ -273,6 +273,36 @@ func TestTADashboard_ValidEnvelope(t *testing.T) {
 	require.True(t, ok, "values should be an array")
 	require.Len(t, values, 1, "dashboard defaults to the latest point")
 	assert.Equal(t, latest, values[0].(map[string]any), "default values row should match latest")
+}
+
+func TestTADashboard_DailyLongRangeUsesBufferedHistoryRequest(t *testing.T) {
+	// Arrange: Schwab can return only 251 candles for a 1-year daily request, so
+	// dashboard must request a wider period while still accepting exactly the 252
+	// candles needed for a complete long-range row.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/marketdata/v1/pricehistory")
+		assert.Equal(t, "GNRC", r.URL.Query().Get("symbol"))
+		assert.Equal(t, "year", r.URL.Query().Get("periodType"))
+		assert.Equal(t, "2", r.URL.Query().Get("period"))
+		assert.Equal(t, "daily", r.URL.Query().Get("frequencyType"))
+		assert.Equal(t, "1", r.URL.Query().Get("frequency"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockCandleListJSON("GNRC", 252)))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClient(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "GNRC", "--points", "1")
+	require.NoError(t, err)
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 1)
 }
 
 func TestTADashboard_SingleSymbolReturnsSymbolMap(t *testing.T) {

--- a/internal/ta/interval.go
+++ b/internal/ta/interval.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	weeksPerYear = 52
+	weeksPerYear               = 52
+	dailyLookbackSafetyCandles = 10
 
 	// regularSessionMinutesPerDay is the number of 1-minute candles in a regular
 	// US market session (9:30-16:00 = 6.5 hours). Extended hours are excluded;
@@ -92,7 +93,12 @@ func IntervalToHistoryParams(interval string, requiredCandles int) (periodType, 
 
 	switch interval {
 	case "daily":
-		years := max(1, ceilDiv(requiredCandles, tradingDaysPerYear))
+		// A one-calendar-year daily Schwab request can return fewer than 252
+		// candles depending on holidays, current market timing, and symbol-level
+		// gaps. Add a small sizing buffer before rounding to documented periods so
+		// callers that need a complete 252-candle trading-year window request 2
+		// years, while smaller daily indicators still use the minimum 1-year fetch.
+		years := max(1, ceilDiv(requiredCandles+dailyLookbackSafetyCandles, tradingDaysPerYear))
 		years = nextValidPeriod(years, validYearPeriods)
 		return "year", strconv.Itoa(years), "daily", "1", nil
 	case "weekly":

--- a/internal/ta/interval.go
+++ b/internal/ta/interval.go
@@ -8,7 +8,13 @@ import (
 )
 
 const (
-	weeksPerYear               = 52
+	weeksPerYear = 52
+
+	// dailyLookbackSafetyCandles is added before sizing daily Schwab API period
+	// requests. The daily endpoint can return fewer candles than a plain 1-year
+	// request suggests because of holidays, partial current sessions, and
+	// symbol-level data gaps, so keep a 10-candle margin before reducing this;
+	// IntervalToHistoryParams has the request-sizing rationale where this is used.
 	dailyLookbackSafetyCandles = 10
 
 	// regularSessionMinutesPerDay is the number of 1-minute candles in a regular

--- a/internal/ta/interval_test.go
+++ b/internal/ta/interval_test.go
@@ -87,13 +87,32 @@ func TestIntervalToHistoryParams(t *testing.T) {
 			wantFT:          "daily",
 			wantF:           "1",
 		},
-		// 252 candles fits in 1 year
 		{
-			name:            "daily stays 1 year when sufficient",
+			name:            "daily stays 1 year below buffered boundary",
+			interval:        "daily",
+			requiredCandles: 242,
+			wantPT:          "year",
+			wantP:           "1",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+		{
+			name:            "daily uses 2 years at buffered boundary",
+			interval:        "daily",
+			requiredCandles: 243,
+			wantPT:          "year",
+			wantP:           "2",
+			wantFT:          "daily",
+			wantF:           "1",
+		},
+		// 252 candles needs a 2-year request because Schwab can return too few daily
+		// candles for a one-calendar-year lookback around holidays/current sessions.
+		{
+			name:            "daily uses 2 years at trading-year requirement",
 			interval:        "daily",
 			requiredCandles: 252,
 			wantPT:          "year",
-			wantP:           "1",
+			wantP:           "2",
 			wantFT:          "daily",
 			wantF:           "1",
 		},
@@ -189,6 +208,13 @@ func TestIntervalToHistoryParams(t *testing.T) {
 			errMsg:          "indicator requires 999999 candles but daily interval supports at most 5040",
 		},
 		{
+			name:            "daily exceeds max capacity by one candle",
+			interval:        "daily",
+			requiredCandles: 5041,
+			wantErr:         true,
+			errMsg:          "indicator requires 5041 candles but daily interval supports at most 5040",
+		},
+		{
 			name:            "15min exceeds max capacity",
 			interval:        "15min",
 			requiredCandles: 999999,
@@ -255,9 +281,9 @@ func TestCeilDiv(t *testing.T) {
 
 func TestNextValidPeriod(t *testing.T) {
 	tests := []struct {
-		n    int
+		n     int
 		valid []int
-		want int
+		want  int
 	}{
 		{1, validYearPeriods, 1},
 		{3, validYearPeriods, 3},


### PR DESCRIPTION
## Summary
- Add a 10-candle safety buffer when sizing daily Schwab history lookbacks so 252-candle dashboard windows request 2 years instead of a brittle 1-year period.
- Keep dashboard validation strict for complete 252-candle range rows and add regression/boundary coverage for the buffered request behavior.

## Verification
- /usr/local/go/bin/go test ./internal/ta ./internal/commands
- /usr/local/go/bin/go test ./...
- make build