### PR TITLE
chore: tune automated review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,7 +30,8 @@ reviews:
       mode: warning
 
   auto_review:
-    enabled: true
+    # Keep automatic reviews off so maintainers can request CodeRabbit manually when quota is available.
+    enabled: false
     drafts: false
     auto_pause_after_reviewed_commits: 0
     base_branches:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,37 @@
+# schwab-agent review instructions
+
+Review this repository as a Go CLI for AI agents that trade through Charles Schwab APIs. The command output contract is JSON-first, safety checks protect real brokerage accounts, and workflow knowledge belongs in command help text plus generated agent docs.
+
+Focus on bugs, security, data loss, broken command contracts, and project conventions. Do not nitpick formatting or style that golangci-lint already handles.
+
+## Project invariants
+
+- Use typed errors from `internal/apperr` and check them with `errors.As()`.
+- Command output must go through `output.WriteSuccess`, `output.WriteError`, or `output.WritePartial`.
+- JSON encoders must call `SetEscapeHTML(false)`.
+- Mutable account operations require the explicit safety config flag and the preview digest flow where applicable.
+- Market orders must not include price fields.
+- Config values come from JSON files with environment variable overrides.
+- Keep command help text, `README.md`, `SKILL.md`, and `llms.txt` aligned when command behavior changes.
+
+## Security and trading safety
+
+- Flag any credential, token, account hash, or secret exposure in logs, errors, tests, docs, or generated output.
+- Verify order placement, cancellation, replacement, and preview flows keep account-bound safety checks intact.
+- Check preview digest handling for exact payload reuse, SHA-256 digest validation, file permissions, account mismatches, and TTL enforcement.
+- Treat silent fallback behavior around auth, token files, and API errors as risky unless it returns a clear structured error or documented degradation.
+
+## Testing expectations
+
+- Use `testify/require` for assertions that must stop a test and `testify/assert` for non-critical checks.
+- Use `httptest.NewServer()` for HTTP API mocks with inline request validation.
+- Mark test helpers with `t.Helper()`.
+- Prefer table-driven subtests with `t.Run()`.
+- Use `t.TempDir()` for file I/O. Do not introduce a `testdata/` directory.
+- Validate typed errors with `assert.ErrorAs()` or `require.ErrorAs()`.
+
+## Build and lint expectations
+
+- CI runs `go test -v -race -coverprofile=coverage.out ./...`, build verification, smoke tests, govulncheck, CodeQL, and golangci-lint v2.
+- Nolint directives require a specific linter name and an explanation.
+- US English spelling is enforced.

--- a/.github/instructions/auth-client.instructions.md
+++ b/.github/instructions/auth-client.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "internal/auth/**/*.go"
+---
+
+# Auth review instructions
+
+- Verify credentials and tokens are never logged, returned in structured errors, or exposed in test output.
+- Config loading must preserve the precedence of environment variables over JSON config values and defaults.
+- Token file handling should degrade gracefully on permission and missing-file errors when that behavior is documented.
+- OAuth token exchange and refresh flows use resty v3 and must respect configured TLS behavior.

--- a/.github/instructions/automation.instructions.md
+++ b/.github/instructions/automation.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: ".github/workflows/**"
+---
+
+# GitHub Actions review instructions
+
+- Validate GitHub Actions syntax, minimum permissions, and secret handling.
+- Actions should be pinned consistently with the existing workflow style.
+- Avoid workflow changes that spend extra CI minutes without a clear project benefit.

--- a/.github/instructions/client.instructions.md
+++ b/.github/instructions/client.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "internal/client/**/*.go"
+---
+
+# Client review instructions
+
+- `client.Ref` embeds `*Client`; it is pre-allocated for commands and populated after auth completes.
+- HTTP errors should map to typed project errors with clear remediation context.
+- Response bodies and idle connections must be closed where required.
+- Preserve context propagation for cancellation and request timeouts.

--- a/.github/instructions/coderabbit.instructions.md
+++ b/.github/instructions/coderabbit.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".coderabbit.yaml"
+---
+
+# CodeRabbit review instructions
+
+- CodeRabbit automatic reviews should stay disabled so reviews are requested manually when quota is available.
+- Preserve `chat.auto_reply: true` so maintainers can request manual reviews from GitHub comments.

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**/*.go"
+---
+
+# Go review instructions
+
+- Prefer small, focused functions with explicit error handling and clear return values.
+- Use `%w` when wrapping errors with `fmt.Errorf`.
+- Use `errors.As()` for typed error checks. Do not use raw type assertions for project errors.
+- Avoid `init()` functions. Setup belongs in `main()` or command construction hooks.
+- Preserve context propagation for API calls and cancellation.
+- Keep exported identifiers documented with useful Go comments.
+- Do not suggest style-only changes that `gofmt` or golangci-lint already enforces.
+
+## CLI patterns
+
+- Command factories should follow the existing `FooCommand(ref *client.Ref, w io.Writer) *cli.Command` style when applicable.
+- Struct-tag flags should use structcli `Define()` during setup and `Unmarshal()` at the top of `RunE`.
+- Root persistent flags and Cobra relationship checks may remain raw Cobra calls.
+- Noun-only shorthand commands must dispatch to their documented default subcommands without bypassing auth behavior.

--- a/.github/instructions/makefile.instructions.md
+++ b/.github/instructions/makefile.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "Makefile"
+---
+
+# Makefile review instructions
+
+- Makefile targets should have matching `.PHONY` declarations when they are not real files.
+- Avoid adding flags that are already defaults.
+- Keep task names aligned with `AGENTS.md`, `README.md`, and CI workflow usage.

--- a/.github/instructions/models.instructions.md
+++ b/.github/instructions/models.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "internal/models/**/*.go"
+---
+
+# Model review instructions
+
+- Model structs should match Schwab API JSON field names and avoid silently dropping important response fields.
+- Changes to request payload structs need tests or smoke coverage that proves the emitted JSON shape.
+- Avoid adding speculative fields unless Schwab API behavior or fixtures show they are needed.

--- a/.github/instructions/orders-models.instructions.md
+++ b/.github/instructions/orders-models.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "internal/orderbuilder/**/*.go"
+---
+
+# Order builder review instructions
+
+- Order builders must validate equity, option, bracket, OCO, and multi-leg strategies without accepting incomplete or contradictory inputs.
+- OCC symbol build and parse logic must follow standard OCC formatting and preserve expiration, strike, and call or put semantics.
+- Market orders intentionally exclude price fields.
+- Mutable trading flows must retain safety guards and must not create shortcuts around preview digest checks.

--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -1,0 +1,8 @@
+---
+applyTo: ".goreleaser.yml"
+---
+
+# Release review instructions
+
+- Release automation must keep GoReleaser v2 behavior, CGO-disabled builds, version injection, and keyless cosign signing intact.
+- Platform matrices should remain limited to the supported Linux and Darwin amd64 and arm64 targets unless project support changes.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "**/*_test.go"
+---
+
+# Test review instructions
+
+- Use `testify/assert` and `testify/require`, not bare `if` checks for assertions.
+- Mock HTTP with `httptest.NewServer()` and validate expected request method, path, query, headers, and body inline.
+- Mark reusable helpers with `t.Helper()`.
+- Prefer table-driven subtests with `t.Run()`.
+- Use `t.TempDir()` for file I/O.
+- Keep generated data inline unless there is a clear reason to introduce fixtures.
+- Do not request coverage-only tests when critical behavior is already covered.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 > Keep this file and all subdirectory AGENTS.md files updated when the project changes.
 > Keep README.md updated whenever the project changes.
+> Keep `.coderabbit.yaml` and `.github/copilot-instructions.md` plus `.github/instructions/*.instructions.md` aligned with current repo conventions when review-relevant behavior changes.
 > Check /usr/local for newer Go versions before assuming the system Go is current.
 > Leave generous comments when fixing bugs or working around API quirks. Anything that might save a future developer from re-discovering the same issue is worth writing down.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,12 @@ make lint       # Run golangci-lint
 
 CI runs the same checks with `go test -v -race -coverprofile=coverage.out ./...` and golangci-lint. Your PR won't merge if either fails.
 
+### Automated review tools
+
+CodeRabbit automatic PR reviews are disabled to preserve quota. Maintainers can still request a manual CodeRabbit review in GitHub when needed.
+
+GitHub Copilot code review uses the repository instructions in `.github/copilot-instructions.md` and the path-specific files in `.github/instructions/`. Automatic Copilot review requests are managed by a GitHub branch ruleset rather than a workflow file.
+
 ### Code style
 
 The project uses golangci-lint v2 with these active linters: bodyclose, errorlint, gocritic, gosec, misspell, nolintlint, revive, unconvert, unparam.


### PR DESCRIPTION
## Summary
- Disable automatic CodeRabbit reviews while preserving manual review requests.
- Add GitHub Copilot review instructions for repo-wide and path-specific guidance.
- Document review tool behavior and keep AGENTS.md aligned with review config maintenance.

## Testing
- Parsed `.coderabbit.yaml` successfully.
- Checked Copilot instruction files for required frontmatter and 4,000 character limit.
- Checked changed Markdown for em dashes and unlabeled fenced code blocks.