### PR TITLE
refactor: remove structcli app name option

### DIFF
--- a/cmd/generate-docs/main.go
+++ b/cmd/generate-docs/main.go
@@ -53,7 +53,6 @@ func run() error {
 		structcli.WithJSONSchema(),
 		structcli.WithHelpTopics(),
 		structcli.WithFlagErrors(),
-		structcli.WithAppName("schwab-agent"),
 	); err != nil {
 		return fmt.Errorf("structcli setup: %w", err)
 	}

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -51,7 +51,6 @@ func buildAppWithDeps(w io.Writer, deps commands.RootDeps) *cobra.Command {
 		structcli.WithJSONSchema(),
 		structcli.WithHelpTopics(),
 		structcli.WithFlagErrors(),
-		structcli.WithAppName("schwab-agent"),
 		structcli.WithDebug(debug.Options{Exit: true}),
 	); err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary
- Remove the explicit `structcli.WithAppName("schwab-agent")` option from the CLI and docs generator setup.
- Rely on the Cobra root command `Use: "schwab-agent"` as the command name source during the structcli removal path.

## Testing
- `/usr/local/go/bin/go test ./cmd/schwab-agent ./cmd/generate-docs`