### PR TITLE
Wire market hours to schwab-go

### DIFF
--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -65,19 +65,20 @@ more market names to filter.`,
 				markets = allMarkets()
 			}
 
-			// Use the single-market endpoint when exactly one market
-			// is requested, and the multi-market endpoint otherwise.
+			// Use the single-market endpoint when exactly one market is requested,
+			// matching Schwab's two market-hours routes while keeping the CLI output
+			// shape identical for both paths.
 			if len(markets) == 1 {
-				result, err := c.Market(cmd.Context(), markets[0])
+				result, err := c.MarketData.GetMarketHoursSingle(cmd.Context(), markets[0], "")
 				if err != nil {
-					return err
+					return mapSchwabGoError(err)
 				}
 				return output.WriteSuccess(w, result, output.NewMetadata())
 			}
 
-			result, err := c.Markets(cmd.Context(), markets)
+			result, err := c.MarketData.GetMarketHours(cmd.Context(), markets, "")
 			if err != nil {
-				return err
+				return mapSchwabGoError(err)
 			}
 			return output.WriteSuccess(w, result, output.NewMetadata())
 		},

--- a/internal/commands/market.go
+++ b/internal/commands/market.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
+	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/output"
 )
 
@@ -23,6 +24,11 @@ func allMarkets() []string {
 type moversData struct {
 	Movers *marketdata.MoverResponse `json:"movers"`
 }
+
+// marketHoursData is the market-hours output shape historically returned by
+// schwab-agent. schwab-go intentionally uses value fields, so the command adapts
+// those values back to the existing pointer-based model before writing JSON.
+type marketHoursData map[string]map[string]models.MarketHours
 
 // marketMoversOpts holds the options for the market movers subcommand.
 type marketMoversOpts struct {
@@ -73,16 +79,76 @@ more market names to filter.`,
 				if err != nil {
 					return mapSchwabGoError(err)
 				}
-				return output.WriteSuccess(w, result, output.NewMetadata())
+				return output.WriteSuccess(w, convertMarketHours(result), output.NewMetadata())
 			}
 
 			result, err := c.MarketData.GetMarketHours(cmd.Context(), markets, "")
 			if err != nil {
 				return mapSchwabGoError(err)
 			}
-			return output.WriteSuccess(w, result, output.NewMetadata())
+			return output.WriteSuccess(w, convertMarketHours(result), output.NewMetadata())
 		},
 	}
+}
+
+func convertMarketHours(hours marketdata.MarketHoursMap) marketHoursData {
+	converted := make(marketHoursData, len(hours))
+	for market, products := range hours {
+		convertedProducts := make(map[string]models.MarketHours, len(products))
+		for product, productHours := range products {
+			convertedProducts[product] = convertMarketHoursEntry(productHours)
+		}
+		converted[market] = convertedProducts
+	}
+	return converted
+}
+
+func convertMarketHoursEntry(hours marketdata.MarketHours) models.MarketHours {
+	isOpen := hours.IsOpen
+	return models.MarketHours{
+		MarketType:   stringPtr(hours.MarketType),
+		Product:      stringPtr(hours.Product),
+		ProductName:  stringPtr(hours.ProductName),
+		IsOpen:       &isOpen,
+		SessionHours: convertMarketSessionHours(hours.SessionHours),
+		Exchange:     stringPtr(hours.Exchange),
+		Category:     stringPtr(hours.Category),
+		Date:         stringPtr(hours.Date),
+	}
+}
+
+func convertMarketSessionHours(sessionHours map[string][]marketdata.SessionHours) *models.SessionHours {
+	if len(sessionHours) == 0 {
+		return nil
+	}
+
+	return &models.SessionHours{
+		PreMarket:     convertMarketSessions(sessionHours["preMarket"]),
+		RegularMarket: convertMarketSessions(sessionHours["regularMarket"]),
+		PostMarket:    convertMarketSessions(sessionHours["postMarket"]),
+	}
+}
+
+func convertMarketSessions(sessions []marketdata.SessionHours) []models.MarketSession {
+	if len(sessions) == 0 {
+		return nil
+	}
+
+	converted := make([]models.MarketSession, 0, len(sessions))
+	for _, session := range sessions {
+		converted = append(converted, models.MarketSession{
+			Start: stringPtr(session.Start),
+			End:   stringPtr(session.End),
+		})
+	}
+	return converted
+}
+
+func stringPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
 }
 
 // newMarketMoversCmd returns the Cobra subcommand for market movers.

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -20,13 +20,16 @@ import (
 
 // testClientWithMarketData creates a *client.Ref with both the internal client
 // and a schwab-go marketdata.Client pointing at the given httptest server.
-// Use this for movers tests; hours tests use testClient.
+// Use this for market commands that are backed by schwab-go.
 func testClientWithMarketData(t *testing.T, server *httptest.Server) *client.Ref {
 	t.Helper()
 	ref := testClient(t, server)
 	ref.MarketData = marketdata.NewClient(
 		schwab.WithToken("test-token"),
-		schwab.WithBaseURL(server.URL),
+		// Production root wiring configures schwab-go with the marketdata base
+		// path already included, so mirror that here instead of testing a
+		// package-internal route relative to the httptest root.
+		schwab.WithBaseURL(server.URL+"/marketdata/v1"),
 	)
 	return ref
 }
@@ -47,7 +50,7 @@ func TestNewMarketCmd_Hours_AllMarkets(t *testing.T) {
 
 	// Act
 	var buf bytes.Buffer
-	cmd := NewMarketCmd(testClient(t, srv), &buf)
+	cmd := NewMarketCmd(testClientWithMarketData(t, srv), &buf)
 	_, err := runTestCommand(t, cmd, "hours")
 
 	// Assert
@@ -72,7 +75,7 @@ func TestNewMarketCmd_Hours_SpecificMarket(t *testing.T) {
 
 	// Act
 	var buf bytes.Buffer
-	cmd := NewMarketCmd(testClient(t, srv), &buf)
+	cmd := NewMarketCmd(testClientWithMarketData(t, srv), &buf)
 	_, err := runTestCommand(t, cmd, "hours", "equity")
 
 	// Assert
@@ -93,7 +96,7 @@ func TestNewMarketCmd_Hours_APIError(t *testing.T) {
 
 	// Act
 	var buf bytes.Buffer
-	cmd := NewMarketCmd(testClient(t, srv), &buf)
+	cmd := NewMarketCmd(testClientWithMarketData(t, srv), &buf)
 	_, err := runTestCommand(t, cmd, "hours")
 
 	// Assert
@@ -110,7 +113,7 @@ func TestNewMarketCmd_Hours_SpecificMarketAPIError(t *testing.T) {
 
 	// Act
 	var buf bytes.Buffer
-	cmd := NewMarketCmd(testClient(t, srv), &buf)
+	cmd := NewMarketCmd(testClientWithMarketData(t, srv), &buf)
 	_, err := runTestCommand(t, cmd, "hours", "invalid")
 
 	// Assert

--- a/internal/commands/market_test.go
+++ b/internal/commands/market_test.go
@@ -55,9 +55,17 @@ func TestNewMarketCmd_Hours_AllMarkets(t *testing.T) {
 
 	// Assert
 	require.NoError(t, err)
-	var envelope output.Envelope
+	var envelope testEnvelope
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
-	assert.NotNil(t, envelope.Data)
+	assert.JSONEq(t, `{
+		"equity": {
+			"EQ": {
+				"marketType": "EQUITY",
+				"isOpen": true,
+				"date": "2024-01-15"
+			}
+		}
+	}`, string(envelope.Data))
 	assert.NotEmpty(t, envelope.Metadata.Timestamp)
 }
 
@@ -80,10 +88,54 @@ func TestNewMarketCmd_Hours_SpecificMarket(t *testing.T) {
 
 	// Assert
 	require.NoError(t, err)
-	var envelope output.Envelope
+	var envelope testEnvelope
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
-	assert.NotNil(t, envelope.Data)
+	assert.JSONEq(t, `{
+		"equity": {
+			"EQ": {
+				"marketType": "EQUITY",
+				"isOpen": true,
+				"date": "2024-01-15"
+			}
+		}
+	}`, string(envelope.Data))
 	assert.NotEmpty(t, envelope.Metadata.Timestamp)
+}
+
+func TestNewMarketCmd_Hours_OmitsMissingOptionalFields(t *testing.T) {
+	// Arrange
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// schwab-go decodes the response into value fields, but schwab-agent's
+		// historical output model used pointers with omitempty. This partial
+		// fixture catches accidental zero-value fields leaking into the CLI JSON.
+		resp := `{"equity":{"EQ":{"date":"2024-01-15","isOpen":false,` +
+			`"sessionHours":{"regularMarket":[` +
+			`{"start":"2024-01-15T09:30:00-05:00"}]}}}}`
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewMarketCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "hours", "equity")
+
+	// Assert
+	require.NoError(t, err)
+	var envelope testEnvelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.JSONEq(t, `{
+		"equity": {
+			"EQ": {
+				"date": "2024-01-15",
+				"isOpen": false,
+				"sessionHours": {
+					"regularMarket": [{"start": "2024-01-15T09:30:00-05:00"}]
+				}
+			}
+		}
+	}`, string(envelope.Data))
 }
 
 func TestNewMarketCmd_Hours_APIError(t *testing.T) {
@@ -101,6 +153,9 @@ func TestNewMarketCmd_Hours_APIError(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 }
 
 func TestNewMarketCmd_Hours_SpecificMarketAPIError(t *testing.T) {
@@ -118,6 +173,9 @@ func TestNewMarketCmd_Hours_SpecificMarketAPIError(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
 }
 
 func TestNewMarketCmd_Movers_Success(t *testing.T) {


### PR DESCRIPTION
## Summary
- Route `market hours` through schwab-go marketdata methods, matching the existing movers integration.
- Preserve the historical schwab-agent market-hours JSON shape by adapting schwab-go value fields back into the pointer-based output model.
- Add tests for all-market and single-market hours paths, API error mapping, and partial optional-field output.

## Verification
- LSP diagnostics: `internal/commands/market.go`, `internal/commands/market_test.go`
- `/usr/local/go/bin/go test ./internal/commands`
- `/usr/local/go/bin/go test ./...`
- `make build`
- `make lint`
- `make smoke-ci`
- `~/bin/coderabbit review --agent --base main -c .coderabbit.yaml` (0 findings, rerun after Oracle follow-up)

## Related
- major/schwab-go#26