### PR TITLE
docs: sharpen Copilot review instructions to reduce noise

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,11 @@
 
 Review this repository as a Go CLI for AI agents that trade through Charles Schwab APIs. The command output contract is JSON-first, safety checks protect real brokerage accounts, and workflow knowledge belongs in command help text plus generated agent docs.
 
-Focus on bugs, security, data loss, broken command contracts, and project conventions. Do not nitpick formatting or style that golangci-lint already handles.
+## Review focus
+
+Flag bugs, security issues, data loss risks, broken command contracts, and correctness problems. These are the only categories worth commenting on.
+
+Do not comment on style, naming choices, comment formatting, missing documentation, or code organization. Automated linters and formatters (golangci-lint, gofmt, goimports) handle style enforcement for this project. Naming and documentation decisions are made by the maintainer during development, not during review.
 
 ## Project invariants
 

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -4,13 +4,32 @@ applyTo: "**/*.go"
 
 # Go review instructions
 
-- Prefer small, focused functions with explicit error handling and clear return values.
-- Use `%w` when wrapping errors with `fmt.Errorf`.
-- Use `errors.As()` for typed error checks. Do not use raw type assertions for project errors.
-- Avoid `init()` functions. Setup belongs in `main()` or command construction hooks.
-- Preserve context propagation for API calls and cancellation.
-- Keep exported identifiers documented with useful Go comments.
-- Do not suggest style-only changes that `gofmt` or golangci-lint already enforces.
+## Flag these (bugs, safety, correctness)
+
+- Discarded errors assigned to `_` that silently hide failures.
+- Missing or incorrect error wrapping (must use `%w` with `fmt.Errorf`).
+- Raw type assertions on project errors instead of `errors.As()`.
+- `init()` functions. Setup belongs in `main()` or command construction hooks.
+- Broken context propagation for API calls and cancellation.
+- `math/rand` used where `crypto/rand` is needed for keys or tokens.
+- `panic` used for normal error handling instead of error returns.
+- Unclosed response bodies or resources missing `defer` cleanup.
+
+## Do not flag
+
+- Comment style, grammar, punctuation, or missing doc comments.
+- Variable, function, or receiver naming preferences.
+- Import ordering or grouping.
+- Line length, wrapping, or whitespace style.
+- `any` vs `interface{}` usage.
+- File organization or function ordering within a file.
+- Suggesting code structure refactors (splitting functions, extracting helpers, reordering logic).
+- Error message wording when the message already conveys the failure.
+- Naked returns or named result parameter style.
+- String concatenation style (`+` vs `fmt.Sprintf` vs `strings.Builder`).
+- Adding type annotations, comments, or documentation that the author omitted.
+
+golangci-lint, gofmt, and goimports handle formatting and style for this project. Do not duplicate their job.
 
 ## CLI patterns
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -11,3 +11,5 @@ applyTo: "**/*_test.go"
 - Use `t.TempDir()` for file I/O.
 - Keep generated data inline unless there is a clear reason to introduce fixtures.
 - Do not request coverage-only tests when critical behavior is already covered.
+- Do not suggest restructuring tests that already verify the correct behavior.
+- Do not comment on test naming conventions or test organization style.


### PR DESCRIPTION
## Summary

- Add explicit "do not flag" lists to Copilot review instructions, suppressing style, naming, comment grammar, and documentation nitpicks that don't improve code quality
- Restructure `go.instructions.md` into "flag these" (bugs, safety, correctness) vs "do not flag" (style, naming, docs) sections so Copilot focuses on what matters
- Add a "Review focus" section to the global `copilot-instructions.md` that sets the baseline: bugs and safety only, no style polish
- Add test review noise reduction (no restructuring suggestions, no naming comments)

Informed by the go-code-review skill's severity model (must-fix vs nit) to decide what's worth flagging in automated review vs what's maintainer-discretion.