### PR TITLE
refactor(quote): use schwab-go market data client

### DIFF
--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -446,7 +446,6 @@ func TestIntegration_ValidToken_QuoteGet(t *testing.T) {
 
 	configPath := filepath.Join(tmpDir, "schwab-agent", "config.json")
 	tokenPath := filepath.Join(tmpDir, "schwab-agent", "token.json")
-	writeTestConfig(t, configPath)
 	writeTestToken(t, tokenPath, freshToken())
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -457,14 +456,14 @@ func TestIntegration_ValidToken_QuoteGet(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(
 				[]byte(
-					`{"AAPL":{"assetMainType":"EQUITY","symbol":"AAPL","bidPrice":150.0,"askPrice":151.0,"lastPrice":150.5,"totalVolume":1000000}}`,
+					`{"AAPL":{"assetMainType":"EQUITY","symbol":"AAPL","quote":{"bidPrice":150.0,"askPrice":151.0,"lastPrice":150.5,"totalVolume":1000000}}}`,
 				),
 			)
 		case r.URL.Path == "/marketdata/v1/quotes" && r.URL.Query().Get("symbols") == "AAPL":
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(
 				[]byte(
-					`{"AAPL":{"assetMainType":"EQUITY","symbol":"AAPL","bidPrice":150.0,"askPrice":151.0,"lastPrice":150.5,"totalVolume":1000000}}`,
+					`{"AAPL":{"assetMainType":"EQUITY","symbol":"AAPL","quote":{"bidPrice":150.0,"askPrice":151.0,"lastPrice":150.5,"totalVolume":1000000}}}`,
 				),
 			)
 		default:
@@ -472,6 +471,12 @@ func TestIntegration_ValidToken_QuoteGet(t *testing.T) {
 		}
 	}))
 	defer server.Close()
+	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		BaseURL:      server.URL,
+		CallbackURL:  "https://127.0.0.1:8182",
+	}))
 
 	deps := commands.DefaultRootDeps()
 	deps.NewClient = func(token string, _ ...client.Option) *client.Client {
@@ -493,6 +498,8 @@ func TestIntegration_ValidToken_QuoteGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout, `"data"`)
 	assert.Contains(t, stdout, `"AAPL"`)
+	assert.Contains(t, stdout, `"quote"`)
+	assert.Contains(t, stdout, `"lastPrice":150.5`)
 }
 
 func TestUnknownCommand_SuggestsClosestMatch(t *testing.T) {

--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -2,11 +2,14 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"slices"
 	"strings"
 
+	"github.com/major/schwab-go/schwab/marketdata"
 	"github.com/spf13/cobra"
 
 	"github.com/major/schwab-agent/internal/apperr"
@@ -60,6 +63,12 @@ type quoteGetOpts struct {
 	Strike     float64  `flag:"strike"     flagdescr:"Strike price for option quote"`
 	Call       bool     `flag:"call"       flagdescr:"Call option"`
 	Put        bool     `flag:"put"        flagdescr:"Put option"`
+}
+
+// schwabGoQuoteParams holds quote options in the shape accepted by schwab-go.
+type schwabGoQuoteParams struct {
+	Fields     string
+	Indicative bool
 }
 
 // Validate is called by validateCobraOptions after Cobra decodes bound flags.
@@ -202,9 +211,9 @@ func validateOptionQuoteFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-// buildCobraQuoteParams constructs a QuoteParams from the validated option struct.
+// buildCobraQuoteParams constructs schwab-go quote params from the validated option struct.
 // Field validation has already been performed by quoteGetOpts.Validate().
-func buildCobraQuoteParams(opts *quoteGetOpts) client.QuoteParams {
+func buildCobraQuoteParams(opts *quoteGetOpts) schwabGoQuoteParams {
 	fields := make([]string, 0, len(opts.Fields))
 	for _, f := range opts.Fields {
 		// Support both repeatable (--fields QUOTE --fields FUNDAMENTAL)
@@ -217,8 +226,8 @@ func buildCobraQuoteParams(opts *quoteGetOpts) client.QuoteParams {
 			fields = append(fields, strings.ToLower(trimmed))
 		}
 	}
-	return client.QuoteParams{
-		Fields:     fields,
+	return schwabGoQuoteParams{
+		Fields:     strings.Join(fields, ","),
 		Indicative: opts.Indicative,
 	}
 }
@@ -241,26 +250,61 @@ func sortedQuoteFieldNames() string {
 // The result is wrapped in a symbol-keyed map so the response shape
 // matches multi-symbol requests (data.SYMBOL.field). This lets agents
 // parse quotes without branching on argument count. See issue #48.
-func quoteSingle(ctx context.Context, c *client.Ref, w io.Writer, symbol string, p client.QuoteParams) error {
-	quote, err := c.Quote(ctx, symbol, p)
-	if err != nil {
-		return err
+func quoteSingle(ctx context.Context, c *client.Ref, w io.Writer, symbol string, p schwabGoQuoteParams) error {
+	var quotes marketdata.QuoteResponse
+	if p.Indicative {
+		// schwab-go only exposes the indicative flag on GetQuotes, not GetQuote.
+		// Route a one-symbol request through the multi-symbol endpoint so the CLI
+		// keeps honoring --indicative while still returning the normalized
+		// symbol-keyed response shape.
+		response, _, err := c.MarketData.GetQuotes(ctx, []string{symbol}, p.Fields, p.Indicative)
+		if err != nil {
+			return mapQuoteSingleError(symbol, err)
+		}
+		quotes = quoteResponseValue(response)
+	} else {
+		response, err := c.MarketData.GetQuote(ctx, symbol, p.Fields)
+		if err != nil {
+			return mapQuoteSingleError(symbol, err)
+		}
+		quotes = quoteResponseValue(response)
 	}
-	return output.WriteSuccess(w, map[string]any{symbol: quote}, output.NewMetadata())
+
+	quote, ok := quotes[symbol]
+	if !ok || quote == nil {
+		return apperr.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), nil)
+	}
+
+	return output.WriteSuccess(w, marketdata.QuoteResponse{symbol: quote}, output.NewMetadata())
 }
 
 // quoteMulti fetches quotes for multiple symbols, using WritePartial when some are missing.
-func quoteMulti(ctx context.Context, c *client.Ref, w io.Writer, symbols []string, p client.QuoteParams) error {
-	quotes, err := c.Quotes(ctx, symbols, p)
+func quoteMulti(ctx context.Context, c *client.Ref, w io.Writer, symbols []string, p schwabGoQuoteParams) error {
+	response, quoteErr, err := c.MarketData.GetQuotes(ctx, symbols, p.Fields, p.Indicative)
 	if err != nil {
-		return err
+		return mapSchwabGoError(err)
+	}
+	quotes := quoteResponseValue(response)
+
+	var missing []string
+	seenMissing := make(map[string]struct{})
+	addMissing := func(sym string) {
+		if _, seen := seenMissing[sym]; seen {
+			return
+		}
+		seenMissing[sym] = struct{}{}
+		missing = append(missing, fmt.Sprintf("symbol %s not found", sym))
 	}
 
 	// Identify symbols absent from the response.
-	var missing []string
 	for _, sym := range symbols {
-		if _, ok := quotes[sym]; !ok {
-			missing = append(missing, fmt.Sprintf("symbol %s not found", sym))
+		if quote, ok := quotes[sym]; !ok || quote == nil {
+			addMissing(sym)
+		}
+	}
+	if quoteErr != nil {
+		for _, sym := range quoteErr.InvalidSymbols {
+			addMissing(sym)
 		}
 	}
 
@@ -272,4 +316,24 @@ func quoteMulti(ctx context.Context, c *client.Ref, w io.Writer, symbols []strin
 	meta.Requested = len(symbols)
 	meta.Returned = len(quotes)
 	return output.WritePartial(w, quotes, missing, meta)
+}
+
+// quoteResponseValue converts schwab-go's optional response pointer to the
+// zero-value-safe map used by output writers.
+func quoteResponseValue(response *marketdata.QuoteResponse) marketdata.QuoteResponse {
+	if response == nil {
+		return marketdata.QuoteResponse{}
+	}
+	return *response
+}
+
+// mapQuoteSingleError keeps the command's historical 404 contract while using
+// the shared schwab-go mapper for all other Schwab API failures.
+func mapQuoteSingleError(symbol string, err error) error {
+	mappedErr := mapSchwabGoError(err)
+	var httpErr *apperr.HTTPError
+	if errors.As(mappedErr, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		return apperr.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), mappedErr)
+	}
+	return mappedErr
 }

--- a/internal/commands/quote_test.go
+++ b/internal/commands/quote_test.go
@@ -14,6 +14,19 @@ import (
 	"github.com/major/schwab-agent/internal/output"
 )
 
+const (
+	aaplQuoteEntryPrefix    = `{"AAPL":{"assetMainType":"EQUITY","symbol":"AAPL","quote":{"lastPrice":150.0}}`
+	aaplQuoteEntryResponse  = aaplQuoteEntryPrefix + `}`
+	multiQuoteEntryResponse = aaplQuoteEntryPrefix +
+		`,"MSFT":{"assetMainType":"EQUITY","symbol":"MSFT","quote":{"lastPrice":400.0}}}`
+	amznCallQuoteEntryResponse = `{"AMZN  260515C00270000":` +
+		`{"assetMainType":"OPTION","symbol":"AMZN  260515C00270000",` +
+		`"quote":{"lastPrice":5.50}}}`
+	amznPutQuoteEntryResponse = `{"AMZN  260515P00270000":` +
+		`{"assetMainType":"OPTION","symbol":"AMZN  260515P00270000",` +
+		`"quote":{"lastPrice":3.25}}}`
+)
+
 func TestNewQuoteCmd(t *testing.T) {
 	// Table-driven test covering both explicit ("quote get") and shorthand
 	// ("quote") invocation paths for single and multi-symbol lookups.
@@ -29,14 +42,14 @@ func TestNewQuoteCmd(t *testing.T) {
 		{
 			name:       "explicit single symbol",
 			serverPath: "/marketdata/v1/AAPL/quotes",
-			serverBody: `{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`,
+			serverBody: aaplQuoteEntryResponse,
 			args:       []string{"get", "AAPL"},
 			expectKeys: []string{"AAPL"},
 		},
 		{
 			name:       "explicit multiple symbols",
 			serverPath: "/marketdata/v1/quotes",
-			serverBody: `{"AAPL":{"symbol":"AAPL","lastPrice":150.0},"MSFT":{"symbol":"MSFT","lastPrice":400.0}}`,
+			serverBody: multiQuoteEntryResponse,
 			args:       []string{"get", "AAPL", "MSFT"},
 			expectKeys: []string{"AAPL", "MSFT"},
 		},
@@ -55,7 +68,7 @@ func TestNewQuoteCmd(t *testing.T) {
 			defer server.Close()
 
 			var buf bytes.Buffer
-			cmd := NewQuoteCmd(testClient(t, server), &buf)
+			cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 			_, err := runTestCommand(t, cmd, tt.args...)
 			require.NoError(t, err)
 
@@ -78,7 +91,7 @@ func TestNewQuoteGetPartialSuccess(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/marketdata/v1/quotes" {
 			// Only AAPL found; INVALID is absent from the response.
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -86,7 +99,7 @@ func TestNewQuoteGetPartialSuccess(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get", "AAPL", "INVALID")
 	require.NoError(t, err)
 
@@ -114,7 +127,7 @@ func TestNewQuoteGetSingleNotFound(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get", "INVALID")
 	require.Error(t, err)
 
@@ -128,7 +141,7 @@ func TestNewQuoteGetNoArgs(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get")
 	require.Error(t, err)
 
@@ -145,7 +158,7 @@ func TestNewQuoteNoSubcommand(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd)
 	require.Error(t, err)
 
@@ -164,7 +177,7 @@ func TestNewQuoteGetWithFields(t *testing.T) {
 		assert.Equal(t, "quote,fundamental", q.Get("fields"))
 
 		if r.URL.Path == "/marketdata/v1/AAPL/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -172,7 +185,7 @@ func TestNewQuoteGetWithFields(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--fields", "quote",
 		"--fields", "fundamental",
@@ -198,9 +211,7 @@ func TestNewQuoteGetMultiWithFields(t *testing.T) {
 		assert.Equal(t, "extended", q.Get("fields"))
 
 		if r.URL.Path == "/marketdata/v1/quotes" {
-			_, _ = w.Write(
-				[]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0},"MSFT":{"symbol":"MSFT","lastPrice":400.0}}`),
-			)
+			_, _ = w.Write([]byte(multiQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -208,7 +219,7 @@ func TestNewQuoteGetMultiWithFields(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--fields", "extended",
 		"AAPL", "MSFT",
@@ -230,9 +241,10 @@ func TestNewQuoteGetWithIndicative(t *testing.T) {
 		// Verify the indicative query parameter is set to "true".
 		q := r.URL.Query()
 		assert.Equal(t, "true", q.Get("indicative"))
+		assert.Equal(t, "AAPL", q.Get("symbols"))
 
-		if r.URL.Path == "/marketdata/v1/AAPL/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+		if r.URL.Path == "/marketdata/v1/quotes" {
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -240,7 +252,7 @@ func TestNewQuoteGetWithIndicative(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--indicative",
 		"AAPL",
@@ -257,7 +269,7 @@ func TestNewQuoteGetInvalidField(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--fields", "bogus",
 		"AAPL",
@@ -277,7 +289,7 @@ func TestNewQuoteGetTechnicalFieldSuggestsTAHelp(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--fields", "technical",
 		"AAPL",
@@ -300,7 +312,7 @@ func TestNewQuoteGetNoFlagsNoExtraParams(t *testing.T) {
 		assert.Empty(t, q.Get("indicative"), "indicative should be absent when not specified")
 
 		if r.URL.Path == "/marketdata/v1/AAPL/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -308,7 +320,7 @@ func TestNewQuoteGetNoFlagsNoExtraParams(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get", "AAPL")
 	require.NoError(t, err)
 
@@ -327,7 +339,7 @@ func TestNewQuoteGetCommaSeparatedFields(t *testing.T) {
 		assert.Equal(t, "quote,fundamental", q.Get("fields"))
 
 		if r.URL.Path == "/marketdata/v1/AAPL/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -335,7 +347,7 @@ func TestNewQuoteGetCommaSeparatedFields(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--fields", "QUOTE,FUNDAMENTAL",
 		"AAPL",
@@ -357,12 +369,12 @@ func TestNewQuoteGetOptionFlagsCall(t *testing.T) {
 	occSymbol := "AMZN  260515C00270000"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"AMZN  260515C00270000":{"symbol":"AMZN  260515C00270000","lastPrice":5.50}}`))
+		_, _ = w.Write([]byte(amznCallQuoteEntryResponse))
 	}))
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--underlying", "AMZN",
 		"--expiration", "2026-05-15",
@@ -383,12 +395,12 @@ func TestNewQuoteGetOptionFlagsPut(t *testing.T) {
 	occSymbol := "AMZN  260515P00270000"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"AMZN  260515P00270000":{"symbol":"AMZN  260515P00270000","lastPrice":3.25}}`))
+		_, _ = w.Write([]byte(amznPutQuoteEntryResponse))
 	}))
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--underlying", "AMZN",
 		"--expiration", "2026-05-15",
@@ -410,7 +422,7 @@ func TestNewQuoteGetOptionFlagsWithPositionalArgs(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"AAPL",
 		"--underlying", "AMZN",
@@ -433,7 +445,7 @@ func TestNewQuoteGetOptionFlagsMissingRequired(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--underlying", "AMZN",
 		"--strike", "270",
@@ -453,7 +465,7 @@ func TestNewQuoteGetCallAndPutMutuallyExclusive(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--underlying", "AMZN",
 		"--expiration", "2026-05-15",
@@ -475,7 +487,7 @@ func TestNewQuoteGetFieldsCaseInsensitive(t *testing.T) {
 		assert.Equal(t, "quote,reference", q.Get("fields"))
 
 		if r.URL.Path == "/marketdata/v1/AAPL/quotes" {
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -483,7 +495,7 @@ func TestNewQuoteGetFieldsCaseInsensitive(t *testing.T) {
 	defer server.Close()
 
 	var buf bytes.Buffer
-	cmd := NewQuoteCmd(testClient(t, server), &buf)
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
 	_, err := runTestCommand(t, cmd, "get",
 		"--fields", "Quote",
 		"--fields", "REFERENCE",


### PR DESCRIPTION
## Summary
- Move the quote command to schwab-go market data quote APIs while preserving symbol-keyed output and single-symbol 404 behavior.
- Keep `--indicative` support by routing single-symbol indicative requests through the multi-quote endpoint.
- Update quote command and integration tests to use schwab-go `QuoteEntry` response fixtures.

## Verification
- LSP diagnostics: no diagnostics on modified files
- `/usr/local/go/bin/go test ./internal/commands -run 'TestNewQuote'`
- `/usr/local/go/bin/go test ./cmd/schwab-agent -run 'TestIntegration_ValidToken_QuoteGet'`
- `make test`
- `make lint`
- `make build`

## Notes
- Local CodeRabbit review was attempted but the CLI hit a recoverable rate limit. Skipped after request to open the PR now.