### PR TITLE
fix(quote): filter missing quote entries

### DIFF
--- a/internal/commands/quote.go
+++ b/internal/commands/quote.go
@@ -285,6 +285,11 @@ func quoteMulti(ctx context.Context, c *client.Ref, w io.Writer, symbols []strin
 		return mapSchwabGoError(err)
 	}
 	quotes := quoteResponseValue(response)
+	for sym, quote := range quotes {
+		if quoteEntryMissing(quote) {
+			delete(quotes, sym)
+		}
+	}
 
 	var missing []string
 	seenMissing := make(map[string]struct{})
@@ -298,7 +303,7 @@ func quoteMulti(ctx context.Context, c *client.Ref, w io.Writer, symbols []strin
 
 	// Identify symbols absent from the response.
 	for _, sym := range symbols {
-		if quote, ok := quotes[sym]; !ok || quote == nil {
+		if _, ok := quotes[sym]; !ok {
 			addMissing(sym)
 		}
 	}
@@ -316,6 +321,10 @@ func quoteMulti(ctx context.Context, c *client.Ref, w io.Writer, symbols []strin
 	meta.Requested = len(symbols)
 	meta.Returned = len(quotes)
 	return output.WritePartial(w, quotes, missing, meta)
+}
+
+func quoteEntryMissing(quote *marketdata.QuoteEntry) bool {
+	return quote == nil || quote.Symbol == ""
 }
 
 // quoteResponseValue converts schwab-go's optional response pointer to the

--- a/internal/commands/quote_test.go
+++ b/internal/commands/quote_test.go
@@ -19,6 +19,8 @@ const (
 	aaplQuoteEntryResponse  = aaplQuoteEntryPrefix + `}`
 	multiQuoteEntryResponse = aaplQuoteEntryPrefix +
 		`,"MSFT":{"assetMainType":"EQUITY","symbol":"MSFT","quote":{"lastPrice":400.0}}}`
+	multiQuoteEntryWithNullResponse = `{"AAPL":null,` +
+		`"MSFT":{"assetMainType":"EQUITY","symbol":"MSFT","quote":{"lastPrice":400.0}}}`
 	amznCallQuoteEntryResponse = `{"AMZN  260515C00270000":` +
 		`{"assetMainType":"OPTION","symbol":"AMZN  260515C00270000",` +
 		`"quote":{"lastPrice":5.50}}}`
@@ -112,6 +114,39 @@ func TestNewQuoteGetPartialSuccess(t *testing.T) {
 
 	require.Len(t, envelope.Errors, 1)
 	assert.Contains(t, envelope.Errors[0], "INVALID")
+
+	assert.Equal(t, 2, envelope.Metadata.Requested)
+	assert.Equal(t, 1, envelope.Metadata.Returned)
+	assert.NotEmpty(t, envelope.Metadata.Timestamp)
+}
+
+func TestNewQuoteGetPartialSuccessFiltersNullQuotes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/marketdata/v1/quotes" {
+			// Schwab-go currently decodes a JSON null entry as an empty QuoteEntry.
+			// Treat that as missing and keep partial data free of empty quote rows.
+			_, _ = w.Write([]byte(multiQuoteEntryWithNullResponse))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	var buf bytes.Buffer
+	cmd := NewQuoteCmd(testClientWithMarketData(t, server), &buf)
+	_, err := runTestCommand(t, cmd, "get", "AAPL", "MSFT")
+	require.NoError(t, err)
+
+	var envelope output.Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, data, "AAPL")
+	assert.Contains(t, data, "MSFT")
+
+	require.Len(t, envelope.Errors, 1)
+	assert.Contains(t, envelope.Errors[0], "AAPL")
 
 	assert.Equal(t, 2, envelope.Metadata.Requested)
 	assert.Equal(t, 1, envelope.Metadata.Returned)


### PR DESCRIPTION
## Summary
- Filter empty quote entries before writing multi-symbol quote data.
- Count only returned quote entries in partial response metadata.
- Add a regression test for null quote rows from schwab-go decoding.

Fixes Copilot feedback from #121: https://github.com/major/schwab-agent/pull/121#discussion_r3197943839

## Verification
- /usr/local/go/bin/go test ./internal/commands -run 'TestNewQuote' -v
- /usr/local/go/bin/go test ./...
- make lint