### PR TITLE
refactor(ta): use schwab-go option chain

### DIFF
--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
-	"github.com/major/schwab-agent/internal/models"
 	"github.com/major/schwab-agent/internal/output"
 	"github.com/major/schwab-agent/internal/ta"
 )
@@ -1513,13 +1512,14 @@ func buildExpectedMoveOutput(
 ) (expectedMoveOutput, error) {
 	// Expected Move needs the underlying quote and near-the-money contracts in one response.
 	// Keep this to a single chain call so the underlying snapshot and option prices stay aligned.
-	chain, err := c.OptionChain(ctx, symbol, &client.ChainParams{
-		ContractType:           "ALL",
-		IncludeUnderlyingQuote: annotationValueTrue,
-		StrikeRange:            "NTM",
+	chain, err := c.MarketData.GetOptionChain(ctx, &marketdata.OptionChainParams{
+		Symbol:                 symbol,
+		ContractType:           marketdata.OptionChainContractTypeAll,
+		IncludeUnderlyingQuote: true,
+		Range:                  marketdata.OptionChainRangeNearTheMoney,
 	})
 	if err != nil {
-		return expectedMoveOutput{}, err
+		return expectedMoveOutput{}, mapSchwabGoError(err)
 	}
 
 	if chain.Underlying == nil {
@@ -1589,20 +1589,20 @@ func buildExpectedMoveOutput(
 	}, nil
 }
 
-func expectedMoveUnderlyingPrice(chain *models.OptionChain, symbol string) (float64, error) {
+func expectedMoveUnderlyingPrice(chain *marketdata.OptionChain, symbol string) (float64, error) {
 	switch {
-	case chain.Underlying.Mark != nil:
-		return *chain.Underlying.Mark, nil
-	case chain.Underlying.Last != nil:
-		return *chain.Underlying.Last, nil
-	case chain.UnderlyingPrice != nil:
-		return *chain.UnderlyingPrice, nil
+	case chain.Underlying.Mark > 0:
+		return chain.Underlying.Mark, nil
+	case chain.Underlying.Last > 0:
+		return chain.Underlying.Last, nil
+	case chain.UnderlyingPrice > 0:
+		return chain.UnderlyingPrice, nil
 	default:
 		return 0, fmt.Errorf("unable to determine underlying price for %s", symbol)
 	}
 }
 
-func expectedMoveExpiration(chain *models.OptionChain, symbol string, targetDTE int) (string, error) {
+func expectedMoveExpiration(chain *marketdata.OptionChain, symbol string, targetDTE int) (string, error) {
 	if len(chain.CallExpDateMap) == 0 {
 		return "", fmt.Errorf("no options available for %s", symbol)
 	}
@@ -1633,7 +1633,7 @@ func expectedMoveExpiration(chain *models.OptionChain, symbol string, targetDTE 
 	return selectedExpKey, nil
 }
 
-func expectedMoveATMStrike(callStrikes map[string][]*models.OptionContract, underlyingPrice float64) string {
+func expectedMoveATMStrike(callStrikes map[string][]marketdata.OptionContract, underlyingPrice float64) string {
 	atmStrikeKey := ""
 	bestStrikeDiff := -1.0
 	for strikeKey := range callStrikes {
@@ -1653,12 +1653,14 @@ func expectedMoveATMStrike(callStrikes map[string][]*models.OptionContract, unde
 	return atmStrikeKey
 }
 
-func contractPrice(contract *models.OptionContract, symbol, strike, putCall string) (float64, error) {
-	if contract.Mark != nil {
-		return *contract.Mark, nil
+func contractPrice(contract marketdata.OptionContract, symbol, strike, putCall string) (float64, error) {
+	// schwab-go models option prices as values, so an omitted mark decodes to 0.
+	// Fall back to the midpoint when mark is absent/zero to preserve the old pointer-based behavior.
+	if contract.MarkPrice > 0 {
+		return contract.MarkPrice, nil
 	}
-	if contract.Bid != nil && contract.Ask != nil {
-		return (*contract.Bid + *contract.Ask) / quoteMidpointDivisor, nil
+	if contract.BidPrice > 0 && contract.AskPrice > 0 {
+		return (contract.BidPrice + contract.AskPrice) / quoteMidpointDivisor, nil
 	}
 
 	return 0, fmt.Errorf("unable to determine %s price for %s at strike %s", putCall, symbol, strike)

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -130,16 +130,16 @@ func mockOptionChainJSON(symbol string) string {
 		"underlyingPrice": 150.0,
 		"callExpDateMap": {
 			"2025-06-20:30": {
-				"148.0": [{"mark": 7.0, "bid": 6.9, "ask": 7.1, "strikePrice": 148.0, "daysToExpiration": 30, "inTheMoney": true}],
-				"150.0": [{"mark": 5.0, "bid": 4.9, "ask": 5.1, "strikePrice": 150.0, "daysToExpiration": 30, "inTheMoney": false}],
-				"152.0": [{"mark": 3.0, "bid": 2.9, "ask": 3.1, "strikePrice": 152.0, "daysToExpiration": 30, "inTheMoney": false}]
+				"148.0": [{"markPrice": 7.0, "bidPrice": 6.9, "askPrice": 7.1, "strikePrice": 148.0, "daysToExpiration": 30, "inTheMoney": true}],
+				"150.0": [{"markPrice": 5.0, "bidPrice": 4.9, "askPrice": 5.1, "strikePrice": 150.0, "daysToExpiration": 30, "inTheMoney": false}],
+				"152.0": [{"markPrice": 3.0, "bidPrice": 2.9, "askPrice": 3.1, "strikePrice": 152.0, "daysToExpiration": 30, "inTheMoney": false}]
 			}
 		},
 		"putExpDateMap": {
 			"2025-06-20:30": {
-				"148.0": [{"mark": 2.5, "bid": 2.4, "ask": 2.6, "strikePrice": 148.0, "daysToExpiration": 30, "inTheMoney": false}],
-				"150.0": [{"mark": 4.5, "bid": 4.4, "ask": 4.6, "strikePrice": 150.0, "daysToExpiration": 30, "inTheMoney": false}],
-				"152.0": [{"mark": 6.5, "bid": 6.4, "ask": 6.6, "strikePrice": 152.0, "daysToExpiration": 30, "inTheMoney": true}]
+				"148.0": [{"markPrice": 2.5, "bidPrice": 2.4, "askPrice": 2.6, "strikePrice": 148.0, "daysToExpiration": 30, "inTheMoney": false}],
+				"150.0": [{"markPrice": 4.5, "bidPrice": 4.4, "askPrice": 4.6, "strikePrice": 150.0, "daysToExpiration": 30, "inTheMoney": false}],
+				"152.0": [{"markPrice": 6.5, "bidPrice": 6.4, "askPrice": 6.6, "strikePrice": 152.0, "daysToExpiration": 30, "inTheMoney": true}]
 			}
 		}
 	}`, symbol)
@@ -153,18 +153,18 @@ func mockOptionChainTwoDTEJSON(symbol string) string {
 		"underlyingPrice": 150.0,
 		"callExpDateMap": {
 			"2025-06-20:30": {
-				"150.0": [{"mark": 5.0, "bid": 4.9, "ask": 5.1, "strikePrice": 150.0, "daysToExpiration": 30}]
+				"150.0": [{"markPrice": 5.0, "bidPrice": 4.9, "askPrice": 5.1, "strikePrice": 150.0, "daysToExpiration": 30}]
 			},
 			"2025-07-18:60": {
-				"150.0": [{"mark": 7.0, "bid": 6.9, "ask": 7.1, "strikePrice": 150.0, "daysToExpiration": 60}]
+				"150.0": [{"markPrice": 7.0, "bidPrice": 6.9, "askPrice": 7.1, "strikePrice": 150.0, "daysToExpiration": 60}]
 			}
 		},
 		"putExpDateMap": {
 			"2025-06-20:30": {
-				"150.0": [{"mark": 4.5, "bid": 4.4, "ask": 4.6, "strikePrice": 150.0, "daysToExpiration": 30}]
+				"150.0": [{"markPrice": 4.5, "bidPrice": 4.4, "askPrice": 4.6, "strikePrice": 150.0, "daysToExpiration": 30}]
 			},
 			"2025-07-18:60": {
-				"150.0": [{"mark": 6.5, "bid": 6.4, "ask": 6.6, "strikePrice": 150.0, "daysToExpiration": 60}]
+				"150.0": [{"markPrice": 6.5, "bidPrice": 6.4, "askPrice": 6.6, "strikePrice": 150.0, "daysToExpiration": 60}]
 			}
 		}
 	}`, symbol)
@@ -178,12 +178,12 @@ func mockOptionChainNilMarkJSON(symbol string) string {
 		"underlyingPrice": 150.0,
 		"callExpDateMap": {
 			"2025-06-20:30": {
-				"150.0": [{"bid": 4.9, "ask": 5.1, "strikePrice": 150.0, "daysToExpiration": 30}]
+				"150.0": [{"bidPrice": 4.9, "askPrice": 5.1, "strikePrice": 150.0, "daysToExpiration": 30}]
 			}
 		},
 		"putExpDateMap": {
 			"2025-06-20:30": {
-				"150.0": [{"bid": 4.4, "ask": 4.6, "strikePrice": 150.0, "daysToExpiration": 30}]
+				"150.0": [{"bidPrice": 4.4, "askPrice": 4.6, "strikePrice": 150.0, "daysToExpiration": 30}]
 			}
 		}
 	}`, symbol)
@@ -205,6 +205,11 @@ func optionChainHandler(t *testing.T, body string) http.Handler {
 	t.Helper()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "/marketdata/v1/chains")
+		query := r.URL.Query()
+		assert.Equal(t, "AAPL", query.Get("symbol"))
+		assert.Equal(t, "ALL", query.Get("contractType"))
+		assert.Equal(t, "true", query.Get("includeUnderlyingQuote"))
+		assert.Equal(t, "NTM", query.Get("range"))
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(body))
 	})


### PR DESCRIPTION
## Summary
- Route TA expected-move option-chain requests through schwab-go marketdata instead of the legacy internal client method.
- Update expected-move helpers and fixtures for schwab-go option-chain response fields while preserving the CLI output contract.
- Add request query assertions for the option-chain call.

## Verification
- go test ./internal/commands -run 'TestTA(ExpectedMove|SMA_APIError)|TestTAHV_InvalidPeriod' -count=1
- go test ./internal/commands -run 'TestTAExpectedMove' -count=1
- go test ./internal/commands -count=1
- go test ./...
- make build
- make lint
- make smoke-ci
- coderabbit review --agent --base main -c .coderabbit.yaml (0 findings)