### PR TITLE
refactor(commands): use schwab-go for analyze quotes

### DIFF
--- a/internal/commands/analyze.go
+++ b/internal/commands/analyze.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/client"
 	"github.com/major/schwab-agent/internal/output"
 )
@@ -133,14 +134,20 @@ func buildAnalyzeResult(
 	var result analyzeResult
 	var quoteErr, taErr error
 
-	// Fetch quote. Use zero-value QuoteParams since analyze does not expose
-	// --fields or --indicative flags. The full default quote is what agents
-	// need for combined analysis.
-	quote, err := c.Quote(ctx, symbol, client.QuoteParams{})
+	// Fetch quote via schwab-go. analyze does not expose --fields or
+	// --indicative flags, so an empty fields string asks Schwab for the
+	// default quote payload while keeping this command on the same marketdata
+	// client path as quote, instrument, and market commands.
+	quoteResponse, err := c.MarketData.GetQuote(ctx, symbol, "")
 	if err != nil {
-		quoteErr = err
+		quoteErr = mapQuoteSingleError(symbol, err)
 	} else {
-		result.Quote = quote
+		quote := quoteResponseValue(quoteResponse)[symbol]
+		if quoteEntryMissing(quote) {
+			quoteErr = apperr.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), nil)
+		} else {
+			result.Quote = quote
+		}
 	}
 
 	// Compute TA dashboard.

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -245,6 +245,56 @@ func TestNewAnalyzeCmd_PartialFailure_TAFails(t *testing.T) {
 	assert.Equal(t, 2, envelope.Metadata.Returned)
 }
 
+func TestNewAnalyzeCmd_QuoteHTTPNotFound(t *testing.T) {
+	// Arrange - schwab-go turns a 404 quote response into an API error. analyze
+	// should preserve the existing quote command behavior by mapping that to the
+	// user-facing SymbolNotFoundError type.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(r.URL.Path, "/quotes"):
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"symbol not found"}`))
+		case strings.Contains(r.URL.Path, "/pricehistory"):
+			_, _ = w.Write([]byte(mockCandleListJSON("MISSING", 252)))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "MISSING")
+
+	// Assert
+	var symErr *apperr.SymbolNotFoundError
+	require.ErrorAs(t, err, &symErr)
+}
+
+func TestNewAnalyzeCmd_QuoteResponseMissingSymbol(t *testing.T) {
+	// Arrange - Schwab can return a successful quote envelope that still omits
+	// the requested symbol. Treat that as the same symbol-not-found condition as
+	// quote.go rather than returning a nil quote with successful analysis.
+	srv := analyzeServer(
+		t,
+		`{"OTHER":{"assetMainType":"EQUITY","symbol":"OTHER","quote":{"lastPrice":1.0}}}`,
+		mockCandleListJSON("MISSING", 252),
+	)
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "MISSING")
+
+	// Assert
+	var symErr *apperr.SymbolNotFoundError
+	require.ErrorAs(t, err, &symErr)
+}
+
 func TestNewAnalyzeCmd_InvalidInterval(t *testing.T) {
 	// Arrange
 	ref := &client.Ref{}

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -16,6 +16,14 @@ import (
 	"github.com/major/schwab-agent/internal/output"
 )
 
+const invalidAnalyzeQuoteEntryResponse = `{
+	"INVALID": {
+		"assetMainType": "EQUITY",
+		"symbol": "INVALID",
+		"quote": {"lastPrice": 100.0}
+	}
+}`
+
 // analyzeServer returns an [httptest.Server] that handles both quote and
 // price-history requests. quoteBody is keyed by symbol path suffix
 // (e.g., "/marketdata/v1/AAPL/quotes"), and candleBody applies to all
@@ -99,7 +107,7 @@ func TestNewAnalyzeCmd_HelpText(t *testing.T) {
 
 func TestNewAnalyzeCmd_SingleSymbol(t *testing.T) {
 	// Arrange - server handles both quote and price-history endpoints
-	quoteJSON := `{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`
+	quoteJSON := aaplQuoteEntryResponse
 	candleJSON := mockCandleListJSON("AAPL", 252)
 	srv := analyzeServer(t, quoteJSON, candleJSON)
 	defer srv.Close()
@@ -141,9 +149,9 @@ func TestNewAnalyzeCmd_MultiSymbol(t *testing.T) {
 
 		switch {
 		case strings.Contains(r.URL.Path, "AAPL/quotes"):
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 		case strings.Contains(r.URL.Path, "NVDA/quotes"):
-			_, _ = w.Write([]byte(`{"NVDA":{"symbol":"NVDA","lastPrice":800.0}}`))
+			_, _ = w.Write([]byte(`{"NVDA":{"assetMainType":"EQUITY","symbol":"NVDA","quote":{"lastPrice":800.0}}}`))
 		case strings.Contains(r.URL.Path, "/pricehistory"):
 			// Determine symbol from query param
 			sym := r.URL.Query().Get("symbol")
@@ -191,10 +199,10 @@ func TestNewAnalyzeCmd_PartialFailure_TAFails(t *testing.T) {
 
 		switch {
 		case strings.Contains(r.URL.Path, "AAPL/quotes"):
-			_, _ = w.Write([]byte(`{"AAPL":{"symbol":"AAPL","lastPrice":150.0}}`))
+			_, _ = w.Write([]byte(aaplQuoteEntryResponse))
 		case strings.Contains(r.URL.Path, "INVALID/quotes"):
 			// Quote succeeds for INVALID
-			_, _ = w.Write([]byte(`{"INVALID":{"symbol":"INVALID","lastPrice":100.0}}`))
+			_, _ = w.Write([]byte(invalidAnalyzeQuoteEntryResponse))
 		case strings.Contains(r.URL.Path, "/pricehistory"):
 			// Return valid candles for AAPL, empty for INVALID (TA will fail)
 			sym := r.URL.Query().Get("symbol")


### PR DESCRIPTION
## Summary
- Move `analyze` quote fetching onto the schwab-go marketdata client path used by quote, instrument, and market commands.
- Update analyze command fixtures to use schwab-go quote envelopes while preserving partial-result behavior.

## Verification
- `make lint`
- `/usr/local/go/bin/go test -v ./internal/commands -run TestNewAnalyzeCmd`
- `/usr/local/go/bin/go test -v ./...`
- `/usr/local/go/bin/go build ./...`
- `make smoke-ci`
- `coderabbit review --agent --base origin/main -c .coderabbit.yaml` (0 findings)