### PR TITLE
refactor: delegate auth flow to schwab-go

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ Go CLI tool for AI agents to trade via Charles Schwab APIs. Single binary, JSON-
 - **Module**: `github.com/major/schwab-agent`
 - **Go version**: 1.26 (check `/usr/local/go/bin/go version` for newer installs)
 - **Entry point**: `cmd/schwab-agent/main.go`
-- **Dependencies**: spf13/cobra v1.10.2 (CLI framework), pkg/browser (OAuth flow), resty.dev/v3 (HTTP client, used by both internal/client/ and internal/auth/), stretchr/testify (test assertions)
+- **Dependencies**: spf13/cobra v1.10.2 (CLI framework), pkg/browser (OAuth flow), schwab-go (API and auth helpers), resty.dev/v3 (internal/client HTTP client), stretchr/testify (test assertions)
 
 ## Architecture
 
 ```text
 cmd/schwab-agent/       Entry point, buildApp(), PersistentPreRunE auth hook
 internal/
-  auth/                 OAuth2 flow (resty v3 for token exchange), token lifecycle, config (JSON + env vars)
+  auth/                 App config plus thin adapters around schwab-go auth helpers
   client/               Schwab API HTTP client (see internal/client/AGENTS.md)
   commands/             CLI command handlers (see internal/commands/AGENTS.md)
   apperr/               Typed error hierarchy with exit codes
@@ -168,7 +168,7 @@ Empty sections are omitted automatically.
 3. **Command references**: `SKILL.md` and `llms.txt` are maintained by hand alongside CLI changes, while runtime discovery uses Cobra help output. The binary does not expose `--jsonschema`.
 4. **Workflow knowledge in help text**: Command Long descriptions and Example fields embed the workflow knowledge that was previously in separate skill files
 5. **No testdata/**: All test data generated inline or via helper functions
-6. **TLSConfig over HTTPClient**: `Config.TLSConfig()` returns a `*tls.Config` instead of the old `*http.Client` factory. Both the API client (`WithTLSConfig`) and auth token exchange (`newOAuthClient`) use this to support insecure proxy setups. The callback server still uses raw net/http (server-side code).
+6. **TLSConfig over HTTPClient**: `Config.TLSConfig()` returns a `*tls.Config` instead of the old `*http.Client` factory. Both the API client (`WithTLSConfig`) and schwab-go auth adapter HTTP client (`oauthHTTPClient`) use this to support insecure proxy setups. The OAuth callback server is delegated to schwab-go auth.
 7. **Cobra tag migration pattern**: Command flags defined via project-owned struct tags (`flag`, `flagdescr`, `default`, `flagshort`) with `defineCobraFlags()` in command setup. RunE handlers read bound opts structs directly and call `validateCobraOptions()` for optional validation hooks. Root persistent flags and Cobra relationship checks stay as raw Cobra calls.
 8. **Flag alias pattern**: `registerOrderFlagAliases()` adds `--instruction` (alias for `--action`) and `--order-type` (alias for `--type`) to qualifying order commands. `resolveOrderFlagAliasesViaFlags()` runs before handlers read option structs, copying alias values to canonical flags via `cmd.Flags().Set()`. `RegisterOrderFlagAliasesOnTree(root)` walks the full command tree post-setup to register aliases on all qualifying subcommands.
 9. **Order replace option subcommand**: `order replace` parent retains its equity RunE. The `option` subcommand uses `buildOCCSymbol()` to construct the OCC symbol from `--underlying`, `--expiration`, `--strike`, `--call`/`--put` flags.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Tests use `httptest.NewServer()` for API mocking, testify for assertions, and `t
 ```text
 cmd/schwab-agent/       Entry point, command tree construction
 internal/
-  auth/                 OAuth2 flow, token lifecycle, config
+  auth/                 Config and token adapters around schwab-go auth
   client/               Schwab API HTTP client
   commands/             CLI command handlers
   apperr/               Typed error hierarchy with exit codes

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -257,7 +257,7 @@ func TestBeforeHook_ReturnsAuthExpiredErrorForStaleRefreshToken(t *testing.T) {
 			AccessToken:  "expired-access-token",
 			RefreshToken: "stale-refresh-token",
 			ExpiresIn:    1800,
-			ExpiresAt:    float64(time.Now().Add(-time.Hour).Unix()),
+			ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
 		},
 	})
 
@@ -303,19 +303,24 @@ func TestBeforeHook_RefreshesExpiredToken(t *testing.T) {
 
 	configPath := filepath.Join(tmpDir, "schwab-agent", "config.json")
 	tokenPath := filepath.Join(tmpDir, "schwab-agent", "token.json")
-	writeTestConfig(t, configPath)
+	require.NoError(t, auth.SaveConfig(configPath, &auth.Config{
+		ClientID:        "test-client",
+		ClientSecret:    "test-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURLInsecure: true,
+	}))
 	writeTestToken(t, tokenPath, &auth.TokenFile{
 		CreationTimestamp: time.Now().Add(-time.Hour).Unix(),
 		Token: auth.TokenData{
 			AccessToken:  "expired-access-token",
 			RefreshToken: "refresh-token",
 			ExpiresIn:    1800,
-			ExpiresAt:    float64(time.Now().Add(-time.Hour).Unix()),
+			ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
 		},
 	})
 
 	var refreshCalls atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/oauth/token":
 			refreshCalls.Add(1)
@@ -338,8 +343,8 @@ func TestBeforeHook_RefreshesExpiredToken(t *testing.T) {
 
 	deps := commands.DefaultRootDeps()
 	deps.TokenRefreshEndpoint = func(_ *auth.Config) string { return server.URL + "/oauth/token" }
-	deps.NewClient = func(token string, _ ...client.Option) *client.Client {
-		return client.NewClient(token, client.WithBaseURL(server.URL))
+	deps.NewClient = func(token string, opts ...client.Option) *client.Client {
+		return client.NewClient(token, append(opts, client.WithBaseURL(server.URL))...)
 	}
 
 	_, err := runAppWithDeps(
@@ -359,7 +364,7 @@ func TestBeforeHook_RefreshesExpiredToken(t *testing.T) {
 	refreshed, loadErr := auth.LoadToken(tokenPath)
 	require.NoError(t, loadErr)
 	assert.Equal(t, "fresh-access-token", refreshed.Token.AccessToken)
-	assert.Greater(t, refreshed.Token.ExpiresAt, float64(time.Now().Unix()))
+	assert.Greater(t, refreshed.Token.ExpiresAt, time.Now().Unix())
 }
 
 func TestBeforeHook_UsesConfiguredProxyForRefreshAndAPIRequests(t *testing.T) {
@@ -374,7 +379,7 @@ func TestBeforeHook_UsesConfiguredProxyForRefreshAndAPIRequests(t *testing.T) {
 			AccessToken:  "expired-access-token",
 			RefreshToken: "refresh-token",
 			ExpiresIn:    1800,
-			ExpiresAt:    float64(time.Now().Add(-time.Hour).Unix()),
+			ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
 		},
 	})
 
@@ -425,7 +430,7 @@ func TestBeforeHook_UsesConfiguredProxyForRefreshAndAPIRequests(t *testing.T) {
 	refreshed, loadErr := auth.LoadToken(tokenPath)
 	require.NoError(t, loadErr)
 	assert.Equal(t, "fresh-access-token", refreshed.Token.AccessToken)
-	assert.Greater(t, refreshed.Token.ExpiresAt, float64(time.Now().Unix()))
+	assert.Greater(t, refreshed.Token.ExpiresAt, time.Now().Unix())
 }
 
 func freshToken() *auth.TokenFile {
@@ -435,7 +440,7 @@ func freshToken() *auth.TokenFile {
 			AccessToken:  "fresh-access-token",
 			RefreshToken: "refresh-token",
 			ExpiresIn:    1800,
-			ExpiresAt:    float64(time.Now().Add(30 * time.Minute).Unix()),
+			ExpiresAt:    time.Now().Add(30 * time.Minute).Unix(),
 		},
 	}
 }

--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -2,13 +2,13 @@
 
 > Leave generous comments when fixing bugs or working around API quirks. Anything that might save a future developer from re-discovering the same issue is worth writing down.
 
-OAuth2 flow, token lifecycle, and config management for Schwab API authentication.
+OAuth2 config adapters and token lifecycle helpers for Schwab API authentication. Generic OAuth mechanics should live in `github.com/major/schwab-go/schwab/auth`; this package keeps schwab-agent-specific config, output, and compatibility behavior.
 
 ## Token Exchange
 
-`ExchangeCode()` and `RefreshAccessToken()` use resty v3 via the `newOAuthClient` helper. Both create a short-lived resty client with `defer client.Close()`. Requests are form-urlencoded POSTs with HTTP Basic Auth (client ID + secret). The token endpoint URL is derived from `Config.BaseURL`.
+`ExchangeCode()`, `RefreshAccessToken()`, `RunLogin()`, token load/save, authorization URL construction, and the HTTPS callback server delegate to `github.com/major/schwab-go/schwab/auth`. Keep this package as a thin adapter around schwab-go plus app-specific error mapping.
 
-`newOAuthClient` applies `Config.TLSConfig()` so insecure proxy setups work for token requests the same way they do for API requests.
+`Config.schwabAuthConfig(tokenEndpoint)` adapts schwab-agent config to schwab-go auth config. Production code derives the OAuth base URL from `Config.APIBaseURL()`. Tests may pass an injected token endpoint, which is normalized to an OAuth base URL by trimming a trailing `/token`.
 
 ## TLSConfig
 
@@ -17,11 +17,11 @@ OAuth2 flow, token lifecycle, and config management for Schwab API authenticatio
 - Returns nil when `base_url_insecure` is false (default TLS behavior).
 - Returns `&tls.Config{InsecureSkipVerify: true}` when `base_url_insecure` is true.
 
-Both the auth token exchange (`newOAuthClient`) and the API client (`client.WithTLSConfig`) call this method, so insecure mode is applied consistently across all outbound connections.
+Both auth token exchange/refresh (`oauthHTTPClient`) and the API client (`client.WithTLSConfig`) call this method, so insecure mode is applied consistently across all outbound connections.
 
 ## Callback Server
 
-`StartCallbackServer` and `startCallbackServer` use raw `net/http` - this is intentional. The callback server is inbound server-side code that receives Schwab's OAuth redirect, not an outbound HTTP client. It is not a resty migration candidate.
+`StartCallbackServer` wraps `schwab-go/schwab/auth.StartCallbackServer`. Do not re-add local certificate generation, callback handlers, or `sync.Once` request processing unless schwab-go cannot support a required behavior.
 
 ## Config
 
@@ -29,6 +29,5 @@ JSON at `~/.config/schwab-agent/config.json`. Fields: `client_id`, `client_secre
 
 ## Testing
 
-- `httptest.NewServer` for plain HTTP token endpoint mocking.
-- `httptest.NewTLSServer` for TLS token endpoint mocking (tests the insecure path).
+- Use `httptest.NewTLSServer` for token endpoint mocking and set `BaseURLInsecure: true`; schwab-go auth config intentionally requires HTTPS OAuth URLs.
 - `sendCallbackRequest` helper uses a raw `http.Client` - this is test infrastructure for exercising the callback server, not production code.

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -6,12 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	schwabauth "github.com/major/schwab-go/schwab/auth"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
@@ -83,6 +86,70 @@ func (cfg *Config) TLSConfig() *tls.Config {
 	return &tls.Config{
 		InsecureSkipVerify: true, //nolint:gosec // base_url_insecure is an explicit opt-in for local self-signed proxies.
 	}
+}
+
+// schwabAuthConfig adapts schwab-agent's app-owned config to schwab-go's
+// OAuth-only config. The optional tokenEndpoint keeps old tests and injected
+// dependencies able to point directly at a token endpoint while production code
+// derives OAuth endpoints from base_url.
+func (cfg *Config) schwabAuthConfig(tokenEndpoint string) (schwabauth.Config, error) {
+	if cfg == nil {
+		return schwabauth.Config{}, errors.New("auth config is required")
+	}
+
+	oauthBaseURL := tokenEndpointOAuthBaseURL(tokenEndpoint)
+	if oauthBaseURL == "" {
+		var err error
+		oauthBaseURL, err = schwabauth.OAuthBaseURLFromAPIBaseURL(cfg.APIBaseURL())
+		if err != nil {
+			return schwabauth.Config{}, fmt.Errorf("derive OAuth base URL: %w", err)
+		}
+	}
+
+	callbackURL := cfg.CallbackURL
+	if callbackURL == "" {
+		callbackURL = defaultCallbackURL
+	}
+
+	schwabCfg := schwabauth.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		CallbackURL:  callbackURL,
+		OAuthBaseURL: oauthBaseURL,
+	}
+	if err := schwabCfg.Validate(); err != nil {
+		return schwabauth.Config{}, fmt.Errorf("validate schwab auth config: %w", err)
+	}
+
+	return schwabCfg, nil
+}
+
+// oauthHTTPClient returns the HTTP client used by schwab-go for outbound OAuth
+// token exchange and refresh requests. Keeping this adapter preserves
+// schwab-agent's base_url_insecure proxy behavior while letting schwab-go own
+// request construction, response parsing, and refresh-token age checks.
+func (cfg *Config) oauthHTTPClient() *http.Client {
+	if cfg == nil {
+		return &http.Client{Timeout: oauthHTTPTimeout}
+	}
+
+	client := &http.Client{Timeout: oauthHTTPTimeout}
+	if tlsCfg := cfg.TLSConfig(); tlsCfg != nil {
+		// Clone DefaultTransport so insecure proxy testing only changes TLS
+		// verification. This keeps proxy env vars, connection pooling, keep-alives,
+		// and other standard transport defaults intact for schwab-go OAuth calls.
+		transport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			client.Transport = &http.Transport{TLSClientConfig: tlsCfg}
+			return client
+		}
+
+		transport = transport.Clone()
+		transport.TLSClientConfig = tlsCfg
+		client.Transport = transport
+	}
+
+	return client
 }
 
 // resolveAPIPath joins an API path onto the normalized base URL while

--- a/internal/auth/config_test.go
+++ b/internal/auth/config_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/tls"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,12 @@ import (
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
 
 func TestMain(m *testing.M) {
 	envVars := []string{
@@ -277,6 +284,61 @@ func TestConfig_TLSConfig_InsecureFlag(t *testing.T) {
 
 	// Touch the tls import so the intent of the transport assertion is explicit.
 	_ = tls.VersionTLS13
+}
+
+func TestConfigSchwabAuthConfig_NilConfigReturnsError(t *testing.T) {
+	var cfg *Config
+
+	schwabCfg, err := cfg.schwabAuthConfig("")
+
+	assert.Empty(t, schwabCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth config is required")
+}
+
+func TestConfigSchwabAuthConfig_InvalidBaseURLReturnsError(t *testing.T) {
+	cfg := &Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		BaseURL:      "://bad",
+	}
+
+	schwabCfg, err := cfg.schwabAuthConfig("")
+
+	assert.Empty(t, schwabCfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "derive OAuth base URL")
+}
+
+func TestConfigOAuthHTTPClient_NilConfigUsesDefaultTimeout(t *testing.T) {
+	var cfg *Config
+
+	client := cfg.oauthHTTPClient()
+
+	require.NotNil(t, client)
+	assert.Equal(t, oauthHTTPTimeout, client.Timeout)
+	assert.Nil(t, client.Transport)
+}
+
+func TestConfigOAuthHTTPClient_InsecureFallbackWhenDefaultTransportIsCustom(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		//nolint:reassign // Restore the process-wide default after exercising the custom RoundTripper fallback branch.
+		http.DefaultTransport = originalTransport
+	})
+
+	//nolint:reassign // The fallback exists only for unusual custom DefaultTransport setups, so the test must replace it temporarily.
+	http.DefaultTransport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, http.ErrUseLastResponse
+	})
+	cfg := &Config{BaseURLInsecure: true}
+
+	client := cfg.oauthHTTPClient()
+
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok, "oauthHTTPClient() transport type = %T, want *http.Transport", client.Transport)
+	require.NotNil(t, transport.TLSClientConfig)
+	assert.True(t, transport.TLSClientConfig.InsecureSkipVerify)
 }
 
 func TestLoadConfig_MissingClientID_ReturnsValidationError(t *testing.T) {

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -2,391 +2,155 @@ package auth
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/hex"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
-	"log/slog"
-	"math/big"
-	"net"
-	"net/http"
 	"net/url"
-	"os"
 	"strings"
-	"sync"
 	"time"
 
+	schwabauth "github.com/major/schwab-go/schwab/auth"
 	"github.com/pkg/browser"
-	"resty.dev/v3"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
 
 const (
-	callbackLoopbackHost = "127.0.0.1"
-
-	// defaultCallbackAddr limits the local callback server to loopback.
-	defaultCallbackAddr = callbackLoopbackHost + ":8182"
-
-	// callbackSuccessHTML is the browser response shown after login completes.
-	callbackSuccessHTML = "<html><body><p>Authentication successful! You can close this tab.</p></body></html>"
-)
-
-const (
 	// oauthHTTPTimeout is the timeout for OAuth token exchange and refresh requests.
-	// Separate from the API client timeout since these hit a different endpoint and
-	// are critical path for authentication. 30 seconds is generous but prevents
-	// indefinite hangs if Schwab's OAuth endpoint is unresponsive.
 	oauthHTTPTimeout = 30 * time.Second
 
 	// callbackServerTimeout bounds how long the local HTTPS callback server waits.
 	callbackServerTimeout = 300 * time.Second
-
-	// oauthStateBytes keeps the CSRF state at 256 bits before hex encoding.
-	oauthStateBytes = 32
-
-	callbackReadHeaderTimeout = 10 * time.Second
-	callbackShutdownTimeout   = 5 * time.Second
-	callbackCertificateBits   = 2048
-	callbackCertificateTTL    = 24 * time.Hour
 )
-
-// newOAuthClient creates a resty client configured for OAuth token requests.
-// The caller must defer client.Close() to release idle connections.
-func newOAuthClient(cfg *Config, timeout time.Duration) *resty.Client {
-	c := resty.New().SetTimeout(timeout)
-	if tlsCfg := cfg.TLSConfig(); tlsCfg != nil {
-		c.SetTLSClientConfig(tlsCfg)
-	}
-	return c
-}
 
 // AuthorizeURL builds the Schwab authorization URL and returns it with a random state value.
 func AuthorizeURL(cfg *Config) (string, string, error) {
-	state, err := randomOAuthState()
+	schwabCfg, err := cfg.schwabAuthConfig("")
 	if err != nil {
-		return "", "", apperr.NewAuthCallbackError("failed to generate OAuth state", err)
+		return "", "", mapSchwabAuthError("failed to build OAuth authorization URL", err)
 	}
 
-	query := url.Values{}
-	query.Set("client_id", cfg.ClientID)
-	query.Set("redirect_uri", cfg.CallbackURL)
-	query.Set("response_type", "code")
-	query.Set("scope", "api")
-	query.Set("state", state)
+	authorizeURL, state, err := schwabauth.AuthorizeURL(schwabCfg)
+	if err != nil {
+		return "", "", mapSchwabAuthError("failed to build OAuth authorization URL", err)
+	}
 
-	return cfg.OAuthAuthorizeURL() + "?" + query.Encode(), state, nil
+	return authorizeURL, state, nil
 }
 
 // ExchangeCode exchanges an OAuth authorization code for a token file.
-// The now parameter controls the timestamp used for token expiry calculation,
-// making the function deterministic for tests.
+//
+// The now parameter is retained for the test seam this package already exposed.
+// schwab-go owns the exchange request and response parsing, then this adapter
+// normalizes the saved timestamps when tests pass a deterministic clock.
 func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*TokenFile, error) {
-	if tokenEndpoint == "" {
-		tokenEndpoint = cfg.OAuthTokenURL()
-	}
-
-	client := newOAuthClient(cfg, oauthHTTPTimeout)
-	defer client.Close()
-
-	resp, err := client.R().
-		SetBasicAuth(cfg.ClientID, cfg.ClientSecret).
-		SetFormData(map[string]string{
-			"grant_type":   "authorization_code",
-			"code":         code,
-			"redirect_uri": cfg.CallbackURL,
-		}).
-		Post(tokenEndpoint)
+	schwabCfg, err := cfg.schwabAuthConfig(tokenEndpoint)
 	if err != nil {
-		return nil, apperr.NewAuthCallbackError("token exchange request failed", err)
+		return nil, mapSchwabAuthError("failed to prepare token exchange", err)
 	}
 
-	if resp.StatusCode() != http.StatusOK {
-		return nil, apperr.NewAuthCallbackError(
-			fmt.Sprintf("token exchange failed with status %d", resp.StatusCode()),
-			fmt.Errorf("response body: %s", strings.TrimSpace(string(resp.Bytes()))),
-		)
+	tokenFile, err := schwabauth.ExchangeCode(context.Background(), schwabCfg, code, cfg.oauthHTTPClient())
+	if err != nil {
+		return nil, apperr.NewAuthCallbackError("token exchange failed", err)
 	}
 
-	var token TokenData
-	if unmarshalErr := json.Unmarshal(resp.Bytes(), &token); unmarshalErr != nil {
-		return nil, apperr.NewAuthCallbackError("failed to parse token exchange response", unmarshalErr)
+	if !now.IsZero() {
+		nowUnix := now.Unix()
+		tokenFile.CreationTimestamp = nowUnix
+		if tokenFile.Token.ExpiresIn > 0 {
+			tokenFile.Token.ExpiresAt = nowUnix + int64(tokenFile.Token.ExpiresIn)
+		}
 	}
 
-	nowUnix := now.Unix()
-	token.ExpiresAt = float64(nowUnix) + float64(token.ExpiresIn)
-
-	return &TokenFile{
-		CreationTimestamp: nowUnix,
-		Token:             token,
-	}, nil
+	return &tokenFile, nil
 }
 
 // StartCallbackServer starts a loopback-only HTTPS callback server and waits for one callback.
 func StartCallbackServer(addr, expectedState string) (string, error) {
-	return startCallbackServer(addr, expectedState, nil)
+	callbackURL := addr
+	if !strings.Contains(callbackURL, "://") {
+		callbackURL = "https://" + callbackURL
+	}
+	if parsedURL, err := url.Parse(callbackURL); err == nil && parsedURL.Path == "" {
+		parsedURL.Path = "/"
+		callbackURL = parsedURL.String()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), callbackServerTimeout)
+	defer cancel()
+
+	results, errs, shutdown, err := schwabauth.StartCallbackServer(ctx, callbackURL)
+	if err != nil {
+		return "", mapSchwabAuthError("failed to start OAuth callback server", err)
+	}
+	defer shutdown()
+
+	select {
+	case result := <-results:
+		if result.State != expectedState {
+			return "", apperr.NewAuthCallbackError(
+				"OAuth callback state mismatch",
+				fmt.Errorf("expected state %q, got %q", expectedState, result.State),
+			)
+		}
+		return result.Code, nil
+	case callbackErr := <-errs:
+		return "", mapSchwabAuthError("OAuth callback failed", callbackErr)
+	case <-ctx.Done():
+		return "", apperr.NewAuthCallbackError("timed out waiting for OAuth callback after 300 seconds", ctx.Err())
+	}
 }
 
 // RunLogin performs the full OAuth login flow and persists the resulting token.
 func RunLogin(cfg *Config, tokenPath, tokenEndpoint string, openBrowser bool, w io.Writer) error {
-	authURL, state, err := AuthorizeURL(cfg)
+	schwabCfg, err := cfg.schwabAuthConfig(tokenEndpoint)
 	if err != nil {
-		return err
+		return mapSchwabAuthError("failed to prepare OAuth login", err)
 	}
 
-	callbackAddr, err := callbackAddress(cfg)
-	if err != nil {
-		return err
-	}
-
-	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	readyCh := make(chan struct{})
-	resultCh := make(chan callbackResult, 1)
-
-	go func() {
-		code, callbackErr := startCallbackServer(callbackAddr, state, readyCh)
-		resultCh <- callbackResult{code: code, err: callbackErr}
-	}()
-
-	<-readyCh
-	logger.Info("OAuth callback server listening", "addr", callbackAddr)
-
-	if openBrowser {
-		logger.Info("Opening browser for Schwab login")
-		if openErr := browser.OpenURL(authURL); openErr != nil {
-			return apperr.NewAuthCallbackError("failed to open browser", openErr)
+	urlHandler := func(authorizeURL string) error {
+		if openBrowser {
+			if openErr := browser.OpenURL(authorizeURL); openErr != nil {
+				return apperr.NewAuthCallbackError("failed to open browser", openErr)
+			}
+			return nil
 		}
-	} else {
-		logger.Info("Open this URL to authenticate", "url", authURL)
-		if _, writeErr := fmt.Fprintln(w, authURL); writeErr != nil {
+
+		if _, writeErr := fmt.Fprintln(w, authorizeURL); writeErr != nil {
 			return fmt.Errorf("failed to write authorization URL: %w", writeErr)
 		}
+		return nil
 	}
 
-	logger.Info("Waiting for OAuth callback")
-	result := <-resultCh
-	if result.err != nil {
-		return result.err
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), callbackServerTimeout)
+	defer cancel()
 
-	logger.Info("Exchanging authorization code for token")
-	tokenFile, err := ExchangeCode(cfg, result.code, tokenEndpoint, time.Now())
+	_, err = schwabauth.Login(
+		ctx,
+		schwabCfg,
+		schwabauth.NewFileTokenStore(tokenPath),
+		urlHandler,
+		schwabauth.WithLoginHTTPClient(cfg.oauthHTTPClient()),
+	)
 	if err != nil {
-		return err
+		return mapSchwabAuthError("OAuth login failed", err)
 	}
 
-	if saveErr := SaveToken(tokenPath, tokenFile); saveErr != nil {
-		return fmt.Errorf("failed to save token: %w", saveErr)
-	}
-
-	logger.Info("Saved OAuth token", "path", tokenPath)
 	return nil
 }
 
-// callbackResult carries the callback server outcome.
-type callbackResult struct {
-	code string
-	err  error
-}
-
-// randomOAuthState creates a 32-byte random hex state value.
-// Returns an error if the system CSPRNG is unavailable instead of panicking,
-// since this runs in a CLI tool where a clean error message beats a stack trace.
-func randomOAuthState() (string, error) {
-	buf := make([]byte, oauthStateBytes)
-	if _, err := rand.Read(buf); err != nil {
-		return "", fmt.Errorf("failed to generate OAuth state: %w", err)
+func mapSchwabAuthError(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if schwabauth.IsCallback(err) {
+		return apperr.NewAuthCallbackError(message, err)
+	}
+	if schwabauth.IsExpired(err) {
+		return apperr.NewAuthExpiredError(message, err)
+	}
+	if schwabauth.IsRequired(err) {
+		return apperr.NewAuthRequiredError(message, err)
 	}
 
-	return hex.EncodeToString(buf), nil
-}
-
-// callbackAddress extracts and validates the callback server address from config.
-func callbackAddress(cfg *Config) (string, error) {
-	parsedURL, err := url.Parse(cfg.CallbackURL)
-	if err != nil {
-		return "", apperr.NewAuthCallbackError("invalid callback URL", err)
-	}
-
-	host := parsedURL.Host
-	if host == "" {
-		return "", apperr.NewAuthCallbackError("callback URL must include a host and port", nil)
-	}
-
-	validatedAddr, err := validateCallbackAddr(host)
-	if err != nil {
-		return "", err
-	}
-
-	return validatedAddr, nil
-}
-
-// startCallbackServer is the implementation behind StartCallbackServer with an optional readiness signal.
-func startCallbackServer(addr, expectedState string, readyCh chan<- struct{}) (string, error) {
-	validatedAddr, err := validateCallbackAddr(addr)
-	if err != nil {
-		if readyCh != nil {
-			close(readyCh)
-		}
-		return "", err
-	}
-
-	certificate, err := generateSelfSignedCertificate()
-	if err != nil {
-		if readyCh != nil {
-			close(readyCh)
-		}
-		return "", apperr.NewAuthCallbackError("failed to generate callback TLS certificate", err)
-	}
-
-	listenConfig := &net.ListenConfig{}
-	listener, err := listenConfig.Listen(context.Background(), "tcp", validatedAddr)
-	if err != nil {
-		if readyCh != nil {
-			close(readyCh)
-		}
-		return "", apperr.NewAuthCallbackError("failed to listen for OAuth callback", err)
-	}
-
-	tlsListener := tls.NewListener(listener, &tls.Config{Certificates: []tls.Certificate{certificate}})
-	defer tlsListener.Close()
-
-	resultCh := make(chan callbackResult, 1)
-	var once sync.Once
-
-	server := &http.Server{
-		Handler:           callbackHandler(expectedState, resultCh, &once),
-		ReadHeaderTimeout: callbackReadHeaderTimeout,
-	}
-
-	go func() {
-		serveErr := server.Serve(tlsListener)
-		if serveErr != nil && serveErr != http.ErrServerClosed {
-			once.Do(func() {
-				resultCh <- callbackResult{
-					err: apperr.NewAuthCallbackError("OAuth callback server failed", serveErr),
-				}
-			})
-		}
-	}()
-
-	if readyCh != nil {
-		close(readyCh)
-	}
-
-	timer := time.NewTimer(callbackServerTimeout)
-	defer timer.Stop()
-
-	select {
-	case result := <-resultCh:
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), callbackShutdownTimeout)
-		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-		return result.code, result.err
-	case <-timer.C:
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), callbackShutdownTimeout)
-		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-		return "", apperr.NewAuthCallbackError("timed out waiting for OAuth callback after 300 seconds", nil)
-	}
-}
-
-// callbackHandler validates the callback request and forwards the result.
-func callbackHandler(expectedState string, resultCh chan<- callbackResult, once *sync.Once) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		code := r.URL.Query().Get("code")
-		state := r.URL.Query().Get("state")
-
-		if state != expectedState {
-			http.Error(w, "state mismatch", http.StatusBadRequest)
-			once.Do(func() {
-				resultCh <- callbackResult{
-					err: apperr.NewAuthCallbackError(
-						"OAuth callback state mismatch",
-						fmt.Errorf("expected state %q, got %q", expectedState, state),
-					),
-				}
-			})
-			return
-		}
-
-		if code == "" {
-			http.Error(w, "missing code", http.StatusBadRequest)
-			once.Do(func() {
-				resultCh <- callbackResult{
-					err: apperr.NewAuthCallbackError("OAuth callback missing code", nil),
-				}
-			})
-			return
-		}
-
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = io.WriteString(w, callbackSuccessHTML)
-
-		once.Do(func() {
-			resultCh <- callbackResult{code: code}
-		})
-	})
-}
-
-// validateCallbackAddr ensures the callback server binds only to 127.0.0.1.
-func validateCallbackAddr(addr string) (string, error) {
-	if addr == "" {
-		return defaultCallbackAddr, nil
-	}
-
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return "", apperr.NewAuthCallbackError("callback address must include host and port", err)
-	}
-
-	if host != callbackLoopbackHost {
-		return "", apperr.NewAuthCallbackError("callback server must bind to 127.0.0.1 only", nil)
-	}
-
-	return addr, nil
-}
-
-// generateSelfSignedCertificate creates an in-memory TLS certificate for the loopback callback server.
-func generateSelfSignedCertificate() (tls.Certificate, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, callbackCertificateBits)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to generate private key: %w", err)
-	}
-
-	now := time.Now()
-	template := &x509.Certificate{
-		SerialNumber: big.NewInt(now.UnixNano()),
-		Subject: pkix.Name{
-			CommonName: callbackLoopbackHost,
-		},
-		NotBefore:             now.Add(-1 * time.Minute),
-		NotAfter:              now.Add(callbackCertificateTTL),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		DNSNames:              []string{"localhost"},
-		IPAddresses:           []net.IP{net.ParseIP(callbackLoopbackHost)},
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to create certificate: %w", err)
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
-
-	certificate, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("failed to load TLS key pair: %w", err)
-	}
-
-	return certificate, nil
+	return fmt.Errorf("%s: %w", message, err)
 }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -66,13 +67,9 @@ func ExchangeCode(cfg *Config, code, tokenEndpoint string, now time.Time) (*Toke
 
 // StartCallbackServer starts a loopback-only HTTPS callback server and waits for one callback.
 func StartCallbackServer(addr, expectedState string) (string, error) {
-	callbackURL := addr
-	if !strings.Contains(callbackURL, "://") {
-		callbackURL = "https://" + callbackURL
-	}
-	if parsedURL, err := url.Parse(callbackURL); err == nil && parsedURL.Path == "" {
-		parsedURL.Path = "/"
-		callbackURL = parsedURL.String()
+	callbackURL, err := normalizeLoopbackCallbackURL(addr)
+	if err != nil {
+		return "", apperr.NewAuthCallbackError("invalid OAuth callback URL", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), callbackServerTimeout)
@@ -98,6 +95,32 @@ func StartCallbackServer(addr, expectedState string) (string, error) {
 	case <-ctx.Done():
 		return "", apperr.NewAuthCallbackError("timed out waiting for OAuth callback after 300 seconds", ctx.Err())
 	}
+}
+
+func normalizeLoopbackCallbackURL(addr string) (string, error) {
+	callbackURL := strings.TrimSpace(addr)
+	if !strings.Contains(callbackURL, "://") {
+		callbackURL = "https://" + callbackURL
+	}
+
+	parsedURL, err := url.Parse(callbackURL)
+	if err != nil {
+		return "", fmt.Errorf("parse callback URL: %w", err)
+	}
+	if parsedURL.Scheme != "https" {
+		return "", errors.New("callback URL must use https")
+	}
+	if parsedURL.Hostname() != "127.0.0.1" {
+		return "", fmt.Errorf("callback server must bind to 127.0.0.1 only, got %q", parsedURL.Hostname())
+	}
+	if parsedURL.Port() == "" {
+		return "", errors.New("callback URL must include an explicit port")
+	}
+	if parsedURL.Path == "" {
+		parsedURL.Path = "/"
+	}
+
+	return parsedURL.String(), nil
 }
 
 // RunLogin performs the full OAuth login flow and persists the resulting token.

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"bytes"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -28,6 +27,11 @@ import (
 type synchronizedBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
+}
+
+type callbackResult struct {
+	code string
+	err  error
 }
 
 // Write appends data to the buffer safely.
@@ -68,7 +72,7 @@ func TestAuthorizeURL_ReturnsExpectedParametersAndState(t *testing.T) {
 	assert.Equal(t, "test-client", parsedURL.Query().Get("client_id"))
 	assert.Equal(t, "https://127.0.0.1:8182", parsedURL.Query().Get("redirect_uri"))
 	assert.Equal(t, "code", parsedURL.Query().Get("response_type"))
-	assert.Equal(t, "api", parsedURL.Query().Get("scope"))
+	assert.Empty(t, parsedURL.Query().Get("scope"))
 	assert.Len(t, state, 64)
 	_, err = hex.DecodeString(state)
 	require.NoError(t, err)
@@ -98,7 +102,8 @@ func TestExchangeCode_Success_UsesBasicAuthAndReturnsTokenFile(t *testing.T) {
 	// Arrange
 	fixedNow := time.Date(2026, time.April, 21, 12, 0, 0, 0, time.UTC)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
 
@@ -131,9 +136,10 @@ func TestExchangeCode_Success_UsesBasicAuthAndReturnsTokenFile(t *testing.T) {
 	defer server.Close()
 
 	cfg := &Config{
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		CallbackURL:  "https://127.0.0.1:8182",
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURLInsecure: true,
 	}
 
 	// Act
@@ -148,21 +154,23 @@ func TestExchangeCode_Success_UsesBasicAuthAndReturnsTokenFile(t *testing.T) {
 	assert.Equal(t, "Bearer", tokenFile.Token.TokenType)
 	assert.Equal(t, 1800, tokenFile.Token.ExpiresIn)
 	assert.Equal(t, "api", tokenFile.Token.Scope)
-	assert.InDelta(t, float64(fixedNow.Unix()+1800), tokenFile.Token.ExpiresAt, 0.001)
+	assert.Equal(t, fixedNow.Unix()+1800, tokenFile.Token.ExpiresAt)
 }
 
 func TestExchangeCode_Failure_ReturnsAuthCallbackError(t *testing.T) {
 	// Arrange
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":"invalid_request"}`))
 	}))
 	defer server.Close()
 
 	cfg := &Config{
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		CallbackURL:  "https://127.0.0.1:8182",
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://127.0.0.1:8182",
+		BaseURLInsecure: true,
 	}
 
 	// Act
@@ -230,7 +238,7 @@ func TestStartCallbackServer_Success_ReturnsCode(t *testing.T) {
 	require.NoError(t, result.err)
 	assert.Equal(t, "valid-code", result.code)
 	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Contains(t, responseBody, "Authentication successful! You can close this tab.")
+	assert.Contains(t, responseBody, "Login successful. You can close this tab.")
 }
 
 func TestStartCallbackServer_StateMismatch_ReturnsAuthCallbackError(t *testing.T) {
@@ -252,8 +260,12 @@ func TestStartCallbackServer_StateMismatch_ReturnsAuthCallbackError(t *testing.T
 	require.Error(t, result.err)
 	var callbackErr *apperr.AuthCallbackError
 	require.ErrorAs(t, result.err, &callbackErr)
-	assert.Equal(t, http.StatusBadRequest, statusCode)
-	assert.Contains(t, responseBody, "state mismatch")
+	// schwab-go writes the browser response before schwab-agent validates the
+	// returned state. The CLI still receives AuthCallbackError, but the browser
+	// sees schwab-go's generic success page until upstream exposes response
+	// control for state validation failures.
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Contains(t, responseBody, "Login successful. You can close this tab.")
 }
 
 func TestRunLogin_PrintsURLAndSavesToken(t *testing.T) {
@@ -262,12 +274,14 @@ func TestRunLogin_PrintsURLAndSavesToken(t *testing.T) {
 	tokenPath := filepath.Join(tmpDir, "token.json")
 	callbackAddr := freeLoopbackAddress(t)
 	cfg := &Config{
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		CallbackURL:  "https://" + callbackAddr,
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://" + callbackAddr,
+		BaseURLInsecure: true,
 	}
 
-	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		if !assert.NoError(t, r.ParseForm()) {
 			return
 		}
@@ -305,7 +319,7 @@ func TestRunLogin_PrintsURLAndSavesToken(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
-	assert.Contains(t, writer.String(), cfg.OAuthAuthorizeURL())
+	assert.Contains(t, writer.String(), "/authorize")
 
 	tokenFile, err := LoadToken(tokenPath)
 	require.NoError(t, err)
@@ -313,37 +327,7 @@ func TestRunLogin_PrintsURLAndSavesToken(t *testing.T) {
 	assert.LessOrEqual(t, tokenFile.CreationTimestamp, after)
 	assert.Equal(t, "saved-access-token", tokenFile.Token.AccessToken)
 	assert.Equal(t, "saved-refresh-token", tokenFile.Token.RefreshToken)
-	assert.InDelta(t, float64(tokenFile.CreationTimestamp+900), tokenFile.Token.ExpiresAt, 1)
-}
-
-func TestValidateCallbackAddr_EdgeCases(t *testing.T) {
-	t.Run("empty addr returns default", func(t *testing.T) {
-		addr, err := validateCallbackAddr("")
-		require.NoError(t, err)
-		assert.Equal(t, defaultCallbackAddr, addr)
-	})
-
-	t.Run("missing port returns error", func(t *testing.T) {
-		_, err := validateCallbackAddr("127.0.0.1")
-		require.Error(t, err)
-		var callbackErr *apperr.AuthCallbackError
-		require.ErrorAs(t, err, &callbackErr)
-		assert.Contains(t, err.Error(), "host and port")
-	})
-
-	t.Run("non-loopback host returns error", func(t *testing.T) {
-		_, err := validateCallbackAddr("192.168.1.1:8182")
-		require.Error(t, err)
-		var callbackErr *apperr.AuthCallbackError
-		require.ErrorAs(t, err, &callbackErr)
-		assert.Contains(t, err.Error(), "127.0.0.1")
-	})
-
-	t.Run("valid loopback addr passes through", func(t *testing.T) {
-		addr, err := validateCallbackAddr("127.0.0.1:9999")
-		require.NoError(t, err)
-		assert.Equal(t, "127.0.0.1:9999", addr)
-	})
+	assert.InDelta(t, tokenFile.CreationTimestamp+900, tokenFile.Token.ExpiresAt, 1)
 }
 
 func TestStartCallbackServer_MissingCode_ReturnsAuthCallbackError(t *testing.T) {
@@ -365,141 +349,11 @@ func TestStartCallbackServer_MissingCode_ReturnsAuthCallbackError(t *testing.T) 
 	require.Error(t, result.err)
 	var callbackErr *apperr.AuthCallbackError
 	require.ErrorAs(t, result.err, &callbackErr)
-	assert.Contains(t, result.err.Error(), "missing code")
+	// The exact delegated schwab-go callback error text may change; this assertion
+	// verifies schwab-agent still maps it into the stable app callback category.
+	assert.Contains(t, result.err.Error(), "OAuth callback failed")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Contains(t, responseBody, "missing code")
-}
-
-func TestCallbackHandler_Idempotency_OnlyProcessesFirstRequest(t *testing.T) {
-	// Arrange
-	resultCh := make(chan callbackResult, 1)
-	var once sync.Once
-	handler := callbackHandler("test-state", resultCh, &once)
-
-	// Act - first request with valid code
-	req1 := httptest.NewRequest(http.MethodGet, "/?code=first-code&state=test-state", http.NoBody)
-	w1 := httptest.NewRecorder()
-	handler.ServeHTTP(w1, req1)
-
-	// Act - second request with different code (sync.Once prevents processing)
-	req2 := httptest.NewRequest(http.MethodGet, "/?code=second-code&state=test-state", http.NoBody)
-	w2 := httptest.NewRecorder()
-	handler.ServeHTTP(w2, req2)
-
-	// Assert - only the first code was captured
-	result := <-resultCh
-	assert.Equal(t, "first-code", result.code)
-	require.NoError(t, result.err)
-
-	// Both requests got success HTML since the response is written before once.Do
-	assert.Equal(t, http.StatusOK, w1.Code)
-	assert.Contains(t, w1.Body.String(), "Authentication successful")
-	assert.Equal(t, http.StatusOK, w2.Code)
-
-	// Channel should be empty - second request did not send a result
-	select {
-	case r := <-resultCh:
-		require.Failf(t, "unexpected channel result", "second request should not have sent a result, got: %+v", r)
-	default:
-		// expected: sync.Once prevented second write
-	}
-}
-
-func TestCallbackAddress(t *testing.T) {
-	tests := []struct {
-		name        string
-		callbackURL string
-		wantAddr    string
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:        "valid loopback URL with port",
-			callbackURL: "https://127.0.0.1:8182",
-			wantAddr:    "127.0.0.1:8182",
-		},
-		{
-			name:        "valid loopback URL with different port",
-			callbackURL: "https://127.0.0.1:9999",
-			wantAddr:    "127.0.0.1:9999",
-		},
-		{
-			name:        "missing host returns error",
-			callbackURL: "/just-a-path",
-			wantErr:     true,
-			errContains: "host and port",
-		},
-		{
-			name:        "non-loopback host returns error",
-			callbackURL: "https://192.168.1.1:8182",
-			wantErr:     true,
-			errContains: "127.0.0.1",
-		},
-		{
-			name:        "missing port returns error",
-			callbackURL: "https://127.0.0.1",
-			wantErr:     true,
-			errContains: "host and port",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := &Config{CallbackURL: tt.callbackURL}
-
-			addr, err := callbackAddress(cfg)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				var callbackErr *apperr.AuthCallbackError
-				assert.ErrorAs(t, err, &callbackErr)
-				if tt.errContains != "" {
-					assert.Contains(t, err.Error(), tt.errContains)
-				}
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantAddr, addr)
-		})
-	}
-}
-
-func TestGenerateSelfSignedCertificate_ReturnsValidCertificate(t *testing.T) {
-	// Act
-	cert, err := generateSelfSignedCertificate()
-
-	// Assert
-	require.NoError(t, err)
-	require.Len(t, cert.Certificate, 1, "should contain exactly one certificate")
-
-	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
-	require.NoError(t, err)
-
-	// Subject and SANs
-	assert.Equal(t, "127.0.0.1", x509Cert.Subject.CommonName)
-	assert.Contains(t, x509Cert.DNSNames, "localhost")
-
-	// IP SAN check: net.ParseIP returns a 16-byte representation, so compare
-	// using Equal method rather than direct slice comparison.
-	foundIP := false
-	for _, ip := range x509Cert.IPAddresses {
-		if ip.Equal(net.ParseIP("127.0.0.1")) {
-			foundIP = true
-			break
-		}
-	}
-	assert.True(t, foundIP, "certificate should include 127.0.0.1 in IP SANs")
-
-	// Validity window
-	now := time.Now()
-	assert.True(t, x509Cert.NotBefore.Before(now), "NotBefore should be in the past")
-	assert.True(t, x509Cert.NotAfter.After(now), "NotAfter should be in the future")
-
-	// Key usage
-	assert.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, x509Cert.KeyUsage)
-	assert.Contains(t, x509Cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
-	assert.True(t, x509Cert.BasicConstraintsValid)
 }
 
 // freeLoopbackAddress reserves and returns an available loopback port for tests.

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -388,7 +388,19 @@ func TestStartCallbackServer_InvalidAddressReturnsAuthCallbackError(t *testing.T
 	require.Error(t, err)
 	var callbackErr *apperr.AuthCallbackError
 	require.ErrorAs(t, err, &callbackErr)
-	assert.Contains(t, err.Error(), "failed to start OAuth callback server")
+	assert.Contains(t, err.Error(), "invalid OAuth callback URL")
+	assert.Contains(t, errors.Unwrap(err).Error(), "127.0.0.1")
+}
+
+func TestStartCallbackServer_NonHTTPSAddressReturnsAuthCallbackError(t *testing.T) {
+	code, err := StartCallbackServer("http://127.0.0.1:8182", "expected-state")
+
+	assert.Empty(t, code)
+	require.Error(t, err)
+	var callbackErr *apperr.AuthCallbackError
+	require.ErrorAs(t, err, &callbackErr)
+	assert.Contains(t, err.Error(), "invalid OAuth callback URL")
+	assert.Contains(t, errors.Unwrap(err).Error(), "must use https")
 }
 
 func TestRunLogin_InvalidConfigReturnsError(t *testing.T) {

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	schwabauth "github.com/major/schwab-go/schwab/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -96,6 +98,21 @@ func TestAuthorizeURL_UsesDerivedBaseURL(t *testing.T) {
 		"https://proxy.example.com/prefix/v1/oauth/authorize",
 		parsedURL.Scheme+"://"+parsedURL.Host+parsedURL.Path,
 	)
+}
+
+func TestAuthorizeURL_InvalidConfigReturnsError(t *testing.T) {
+	cfg := &Config{
+		ClientID:     "test-client",
+		ClientSecret: "unused",
+		BaseURL:      "http://proxy.example.com",
+	}
+
+	authURL, state, err := AuthorizeURL(cfg)
+
+	assert.Empty(t, authURL)
+	assert.Empty(t, state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to build OAuth authorization URL")
 }
 
 func TestExchangeCode_Success_UsesBasicAuthAndReturnsTokenFile(t *testing.T) {
@@ -182,6 +199,14 @@ func TestExchangeCode_Failure_ReturnsAuthCallbackError(t *testing.T) {
 	var callbackErr *apperr.AuthCallbackError
 	require.ErrorAs(t, err, &callbackErr)
 	assert.Contains(t, err.Error(), "token exchange failed")
+}
+
+func TestExchangeCode_InvalidConfigReturnsError(t *testing.T) {
+	tokenFile, err := ExchangeCode(nil, "auth-code", "", time.Now())
+
+	assert.Nil(t, tokenFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prepare token exchange")
 }
 
 func TestExchangeCode_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {
@@ -354,6 +379,145 @@ func TestStartCallbackServer_MissingCode_ReturnsAuthCallbackError(t *testing.T) 
 	assert.Contains(t, result.err.Error(), "OAuth callback failed")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Contains(t, responseBody, "missing code")
+}
+
+func TestStartCallbackServer_InvalidAddressReturnsAuthCallbackError(t *testing.T) {
+	code, err := StartCallbackServer("https://localhost:8182", "expected-state")
+
+	assert.Empty(t, code)
+	require.Error(t, err)
+	var callbackErr *apperr.AuthCallbackError
+	require.ErrorAs(t, err, &callbackErr)
+	assert.Contains(t, err.Error(), "failed to start OAuth callback server")
+}
+
+func TestRunLogin_InvalidConfigReturnsError(t *testing.T) {
+	err := RunLogin(nil, filepath.Join(t.TempDir(), "token.json"), "", false, io.Discard)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to prepare OAuth login")
+}
+
+func TestRunLogin_WriteAuthorizationURLFailureReturnsError(t *testing.T) {
+	callbackAddr := freeLoopbackAddress(t)
+	cfg := &Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CallbackURL:  "https://" + callbackAddr,
+	}
+
+	err := RunLogin(cfg, filepath.Join(t.TempDir(), "token.json"), "", false, errWriter{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write authorization URL")
+}
+
+func TestRunLogin_TokenExchangeFailureReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	tokenPath := filepath.Join(tmpDir, "token.json")
+	callbackAddr := freeLoopbackAddress(t)
+	cfg := &Config{
+		ClientID:        "client-id",
+		ClientSecret:    "client-secret",
+		CallbackURL:     "https://" + callbackAddr,
+		BaseURLInsecure: true,
+	}
+
+	tokenServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{"error": "invalid_request"}))
+	}))
+	defer tokenServer.Close()
+
+	writer := &synchronizedBuffer{}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunLogin(cfg, tokenPath, tokenServer.URL, false, writer)
+	}()
+
+	authURL := waitForAuthURL(t, writer)
+	parsedURL, err := url.Parse(strings.TrimSpace(authURL))
+	require.NoError(t, err)
+	_, statusCode := sendCallbackRequest(t, callbackAddr, "login-code", parsedURL.Query().Get("state"))
+	err = <-errCh
+
+	assert.Equal(t, http.StatusOK, statusCode)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OAuth login failed")
+}
+
+func TestMapSchwabAuthError_ReturnsExpectedAppErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		check     func(*testing.T, error)
+		wantError bool
+	}{
+		{
+			name:      "nil",
+			err:       nil,
+			wantError: false,
+		},
+		{
+			name: "callback",
+			err:  &schwabauth.AuthCallbackError{Msg: "callback failed"},
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var callbackErr *apperr.AuthCallbackError
+				require.ErrorAs(t, err, &callbackErr)
+			},
+			wantError: true,
+		},
+		{
+			name: "expired",
+			err:  &schwabauth.AuthExpiredError{Msg: "expired"},
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var expiredErr *apperr.AuthExpiredError
+				require.ErrorAs(t, err, &expiredErr)
+			},
+			wantError: true,
+		},
+		{
+			name: "required",
+			err:  &schwabauth.AuthRequiredError{Msg: "required"},
+			check: func(t *testing.T, err error) {
+				t.Helper()
+				var requiredErr *apperr.AuthRequiredError
+				require.ErrorAs(t, err, &requiredErr)
+			},
+			wantError: true,
+		},
+		{
+			name:      "generic",
+			err:       errors.New("plain error"),
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapSchwabAuthError("wrapped", tt.err)
+
+			if !tt.wantError {
+				assert.NoError(t, got)
+				return
+			}
+
+			require.Error(t, got)
+			assert.Contains(t, got.Error(), "wrapped")
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("writer failed")
 }
 
 // freeLoopbackAddress reserves and returns an available loopback port for tests.

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -1,79 +1,52 @@
 package auth
 
 import (
-	"encoding/json"
+	"context"
+	"errors"
 	"fmt"
-	"net/http"
-	"os"
-	"path/filepath"
+	"strings"
 	"time"
+
+	schwabauth "github.com/major/schwab-go/schwab/auth"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
 
-const (
-	oauthGrantTypeRefreshToken = "refresh_token"
+// refreshTokenMaxAge is 6.5 days in seconds, matching schwab-go and schwab-py's default.
+const refreshTokenMaxAge = 561600
 
-	// refreshTokenMaxAge is 6.5 days in seconds, matching schwab-py's default.
-	refreshTokenMaxAge = 561600
+// TokenFile is the on-disk token format shared with schwab-go.
+type TokenFile = schwabauth.TokenFile
 
-	// accessTokenLeeway is 5 minutes in seconds, matching schwab-py's leeway.
-	accessTokenLeeway = 300
-)
-
-// TokenFile is the on-disk format matching schwab-py.
-type TokenFile struct {
-	CreationTimestamp int64     `json:"creation_timestamp"`
-	Token             TokenData `json:"token"`
-}
-
-// TokenData holds the OAuth token fields.
-type TokenData struct {
-	AccessToken  string  `json:"access_token"`
-	TokenType    string  `json:"token_type"`
-	ExpiresIn    int     `json:"expires_in"`
-	RefreshToken string  `json:"refresh_token"`
-	Scope        string  `json:"scope"`
-	ExpiresAt    float64 `json:"expires_at"`
-}
+// TokenData holds the OAuth token fields shared with schwab-go.
+type TokenData = schwabauth.TokenData
 
 // LoadToken reads and parses the token file.
 // Returns AuthRequiredError if the file doesn't exist.
 func LoadToken(tokenPath string) (*TokenFile, error) {
-	data, err := os.ReadFile(tokenPath)
+	token, err := schwabauth.NewFileTokenStore(tokenPath).Load(context.Background())
 	if err != nil {
-		if os.IsNotExist(err) {
+		if schwabauth.IsRequired(err) {
 			return nil, apperr.NewAuthRequiredError(
 				"token file not found: run `schwab-agent auth login` to authenticate",
 				err,
 			)
 		}
-		return nil, fmt.Errorf("failed to read token file: %w", err)
+		return nil, fmt.Errorf("failed to load token file: %w", err)
 	}
 
-	var tf TokenFile
-	if unmarshalErr := json.Unmarshal(data, &tf); unmarshalErr != nil {
-		return nil, fmt.Errorf("failed to parse token file: %w", unmarshalErr)
-	}
-
-	return &tf, nil
+	return &token, nil
 }
 
 // SaveToken writes the token file with 0600 permissions.
 // Creates the parent directory with 0700 if missing.
 func SaveToken(tokenPath string, tf *TokenFile) error {
-	parentDir := filepath.Dir(tokenPath)
-	if err := os.MkdirAll(parentDir, 0o700); err != nil {
-		return fmt.Errorf("failed to create token directory: %w", err)
+	if tf == nil {
+		return errors.New("token file is required")
 	}
 
-	data, err := json.MarshalIndent(tf, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal token: %w", err)
-	}
-
-	if writeErr := os.WriteFile(tokenPath, data, 0o600); writeErr != nil {
-		return fmt.Errorf("failed to write token file: %w", writeErr)
+	if err := schwabauth.NewFileTokenStore(tokenPath).Save(context.Background(), *tf); err != nil {
+		return fmt.Errorf("failed to save token file: %w", err)
 	}
 
 	return nil
@@ -82,18 +55,21 @@ func SaveToken(tokenPath string, tf *TokenFile) error {
 // IsAccessTokenExpired checks if the access token is expired (with 300s leeway).
 // Returns true if [time.Now] is past ExpiresAt minus the leeway.
 func IsAccessTokenExpired(tf *TokenFile) bool {
-	return float64(time.Now().Unix()) >= tf.Token.ExpiresAt-accessTokenLeeway
+	if tf == nil {
+		return true
+	}
+
+	return schwabauth.IsAccessTokenExpired(*tf)
 }
 
 // IsRefreshTokenStale checks if the refresh token is stale (> 6.5 days old).
 // Returns true if [time.Now] is past creation_timestamp plus the max age.
 func IsRefreshTokenStale(tf *TokenFile) bool {
-	return time.Now().Unix() >= tf.CreationTimestamp+refreshTokenMaxAge
-}
+	if tf == nil {
+		return true
+	}
 
-// tokenErrorResponse represents the error body from the token endpoint.
-type tokenErrorResponse struct {
-	Error string `json:"error"`
+	return time.Now().Unix() >= tf.CreationTimestamp+refreshTokenMaxAge
 }
 
 // RefreshAccessToken exchanges the refresh token for a new access token.
@@ -101,48 +77,34 @@ type tokenErrorResponse struct {
 // Returns AuthExpiredError if the refresh fails with invalid_grant.
 // The endpoint parameter allows overriding the token URL for testing.
 func RefreshAccessToken(cfg *Config, tf *TokenFile, endpoint string) (*TokenFile, error) {
-	if endpoint == "" {
-		endpoint = cfg.OAuthTokenURL()
+	if tf == nil {
+		return nil, errors.New("token file is required")
 	}
 
-	client := newOAuthClient(cfg, oauthHTTPTimeout)
-	defer client.Close()
-
-	resp, err := client.R().
-		SetBasicAuth(cfg.ClientID, cfg.ClientSecret).
-		SetFormData(map[string]string{
-			"grant_type":               oauthGrantTypeRefreshToken,
-			oauthGrantTypeRefreshToken: tf.Token.RefreshToken,
-		}).
-		Post(endpoint)
+	schwabCfg, err := cfg.schwabAuthConfig(endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("token refresh request failed: %w", err)
+		return nil, err
 	}
 
-	// Handle non-2xx responses
-	if resp.StatusCode() != http.StatusOK {
-		var errResp tokenErrorResponse
-		if json.Unmarshal(resp.Bytes(), &errResp) == nil && errResp.Error == "invalid_grant" {
+	refreshed, err := schwabauth.RefreshTokenFile(context.Background(), schwabCfg, *tf, cfg.oauthHTTPClient())
+	if err != nil {
+		if schwabauth.IsExpired(err) || strings.Contains(err.Error(), "invalid_grant") {
 			return nil, apperr.NewAuthExpiredError(
 				"refresh token expired: run `schwab-agent auth login` to re-authenticate",
-				nil,
+				err,
 			)
 		}
-		return nil, fmt.Errorf("token refresh failed with status %d: %s", resp.StatusCode(), string(resp.Bytes()))
+		return nil, fmt.Errorf("refresh access token: %w", err)
 	}
 
-	// Parse new token data
-	var newToken TokenData
-	if unmarshalErr := json.Unmarshal(resp.Bytes(), &newToken); unmarshalErr != nil {
-		return nil, fmt.Errorf("failed to parse token response: %w", unmarshalErr)
+	return &refreshed, nil
+}
+
+func tokenEndpointOAuthBaseURL(endpoint string) string {
+	trimmedEndpoint := strings.TrimSpace(endpoint)
+	if trimmedEndpoint == "" {
+		return ""
 	}
 
-	// Compute ExpiresAt: exchange time + expires_in
-	newToken.ExpiresAt = float64(time.Now().Unix()) + float64(newToken.ExpiresIn)
-
-	// Preserve original creation_timestamp
-	return &TokenFile{
-		CreationTimestamp: tf.CreationTimestamp,
-		Token:             newToken,
-	}, nil
+	return strings.TrimSuffix(strings.TrimRight(trimmedEndpoint, "/"), "/token")
 }

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // makeTokenFile creates a TokenFile with sensible defaults for testing.
-func makeTokenFile(creationTimestamp int64, expiresAt float64) *TokenFile {
+func makeTokenFile(creationTimestamp int64, expiresAt int64) *TokenFile {
 	return &TokenFile{
 		CreationTimestamp: creationTimestamp,
 		Token: TokenData{
@@ -59,7 +59,7 @@ func TestLoadToken_ValidFile_ReturnsTokenFile(t *testing.T) {
 	tokenPath := filepath.Join(tmpDir, "token.json")
 
 	now := time.Now()
-	tf := makeTokenFile(now.Unix(), float64(now.Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(now.Unix(), now.Add(30*time.Minute).Unix())
 
 	data, err := json.Marshal(tf)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestLoadToken_ValidFile_ReturnsTokenFile(t *testing.T) {
 	assert.Equal(t, tf.Token.AccessToken, loaded.Token.AccessToken)
 	assert.Equal(t, tf.Token.RefreshToken, loaded.Token.RefreshToken)
 	assert.Equal(t, tf.Token.ExpiresIn, loaded.Token.ExpiresIn)
-	assert.InDelta(t, tf.Token.ExpiresAt, loaded.Token.ExpiresAt, 0.001)
+	assert.Equal(t, tf.Token.ExpiresAt, loaded.Token.ExpiresAt)
 	assert.Equal(t, tf.Token.Scope, loaded.Token.Scope)
 	assert.Equal(t, tf.Token.TokenType, loaded.Token.TokenType)
 }
@@ -93,7 +93,7 @@ func TestLoadToken_InvalidJSON_ReturnsError(t *testing.T) {
 	// Assert
 	assert.Nil(t, tf)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse token file")
+	assert.Contains(t, err.Error(), "failed to load token file")
 }
 
 func TestLoadToken_PermissionDenied_ReturnsError(t *testing.T) {
@@ -122,7 +122,7 @@ func TestSaveToken_CreatesFileWithCorrectPermissions(t *testing.T) {
 	tokenPath := filepath.Join(tmpDir, "token.json")
 
 	now := time.Now()
-	tf := makeTokenFile(now.Unix(), float64(now.Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(now.Unix(), now.Add(30*time.Minute).Unix())
 
 	// Act
 	err := SaveToken(tokenPath, tf)
@@ -142,7 +142,7 @@ func TestSaveToken_CreatesParentDirWithCorrectPermissions(t *testing.T) {
 	tokenPath := filepath.Join(tmpDir, "subdir", "nested", "token.json")
 
 	now := time.Now()
-	tf := makeTokenFile(now.Unix(), float64(now.Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(now.Unix(), now.Add(30*time.Minute).Unix())
 
 	// Act
 	err := SaveToken(tokenPath, tf)
@@ -163,7 +163,7 @@ func TestSaveToken_RoundTrip_PreservesData(t *testing.T) {
 	tokenPath := filepath.Join(tmpDir, "token.json")
 
 	now := time.Now()
-	original := makeTokenFile(now.Unix(), float64(now.Add(30*time.Minute).Unix()))
+	original := makeTokenFile(now.Unix(), now.Add(30*time.Minute).Unix())
 
 	// Act
 	err := SaveToken(tokenPath, original)
@@ -177,7 +177,7 @@ func TestSaveToken_RoundTrip_PreservesData(t *testing.T) {
 	assert.Equal(t, original.Token.AccessToken, loaded.Token.AccessToken)
 	assert.Equal(t, original.Token.RefreshToken, loaded.Token.RefreshToken)
 	assert.Equal(t, original.Token.ExpiresIn, loaded.Token.ExpiresIn)
-	assert.InDelta(t, original.Token.ExpiresAt, loaded.Token.ExpiresAt, 0.001)
+	assert.Equal(t, original.Token.ExpiresAt, loaded.Token.ExpiresAt)
 	assert.Equal(t, original.Token.Scope, loaded.Token.Scope)
 	assert.Equal(t, original.Token.TokenType, loaded.Token.TokenType)
 }
@@ -188,10 +188,10 @@ func TestSaveToken_OverwritesExistingFile(t *testing.T) {
 	tokenPath := filepath.Join(tmpDir, "token.json")
 
 	now := time.Now()
-	first := makeTokenFile(now.Unix(), float64(now.Add(30*time.Minute).Unix()))
+	first := makeTokenFile(now.Unix(), now.Add(30*time.Minute).Unix())
 	require.NoError(t, SaveToken(tokenPath, first))
 
-	second := makeTokenFile(now.Unix(), float64(now.Add(60*time.Minute).Unix()))
+	second := makeTokenFile(now.Unix(), now.Add(60*time.Minute).Unix())
 	second.Token.AccessToken = "updated-access-token"
 
 	// Act
@@ -208,14 +208,14 @@ func TestSaveToken_OverwritesExistingFile(t *testing.T) {
 func TestSaveToken_MkdirAllFailure(t *testing.T) {
 	// Arrange: use a path under /dev/null which cannot be a directory parent.
 	badPath := "/dev/null/impossible/token.json"
-	tf := makeTokenFile(1713700000, 1713701800.0)
+	tf := makeTokenFile(1713700000, 1713701800)
 
 	// Act
 	err := SaveToken(badPath, tf)
 
 	// Assert
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create token directory")
+	assert.Contains(t, err.Error(), "failed to save token file")
 }
 
 func TestSaveToken_WriteFileFailure(t *testing.T) {
@@ -224,14 +224,14 @@ func TestSaveToken_WriteFileFailure(t *testing.T) {
 	readOnlyDir := filepath.Join(tmpDir, "readonly")
 	require.NoError(t, os.MkdirAll(readOnlyDir, 0o500))
 	tokenPath := filepath.Join(readOnlyDir, "token.json")
-	tf := makeTokenFile(1713700000, 1713701800.0)
+	tf := makeTokenFile(1713700000, 1713701800)
 
 	// Act
 	err := SaveToken(tokenPath, tf)
 
 	// Assert
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to write token file")
+	assert.Contains(t, err.Error(), "failed to save token file")
 }
 
 // --- IsAccessTokenExpired tests ---
@@ -240,7 +240,7 @@ func TestIsAccessTokenExpired_FutureExpiry_ReturnsFalse(t *testing.T) {
 	// Token expires 30 minutes from now (well beyond 5-min leeway)
 	tf := makeTokenFile(
 		time.Now().Unix(),
-		float64(time.Now().Add(30*time.Minute).Unix()),
+		time.Now().Add(30*time.Minute).Unix(),
 	)
 
 	assert.False(t, IsAccessTokenExpired(tf))
@@ -250,7 +250,7 @@ func TestIsAccessTokenExpired_PastExpiry_ReturnsTrue(t *testing.T) {
 	// Token expired 10 minutes ago
 	tf := makeTokenFile(
 		time.Now().Unix(),
-		float64(time.Now().Add(-10*time.Minute).Unix()),
+		time.Now().Add(-10*time.Minute).Unix(),
 	)
 
 	assert.True(t, IsAccessTokenExpired(tf))
@@ -260,7 +260,7 @@ func TestIsAccessTokenExpired_WithinLeeway_ReturnsTrue(t *testing.T) {
 	// Token expires in 4 minutes (within 5-min leeway)
 	tf := makeTokenFile(
 		time.Now().Unix(),
-		float64(time.Now().Add(4*time.Minute).Unix()),
+		time.Now().Add(4*time.Minute).Unix(),
 	)
 
 	assert.True(t, IsAccessTokenExpired(tf))
@@ -270,7 +270,7 @@ func TestIsAccessTokenExpired_ExactlyAtLeeway_ReturnsTrue(t *testing.T) {
 	// Token expires in exactly 5 minutes (at the boundary, should be expired)
 	tf := makeTokenFile(
 		time.Now().Unix(),
-		float64(time.Now().Add(5*time.Minute).Unix()),
+		time.Now().Add(5*time.Minute).Unix(),
 	)
 
 	// ExpiresAt - 300 == now, so now >= ExpiresAt - 300 is true
@@ -281,7 +281,7 @@ func TestIsAccessTokenExpired_JustBeyondLeeway_ReturnsFalse(t *testing.T) {
 	// Token expires in 5 minutes and 10 seconds (beyond the leeway)
 	tf := makeTokenFile(
 		time.Now().Unix(),
-		float64(time.Now().Add(5*time.Minute+10*time.Second).Unix()),
+		time.Now().Add(5*time.Minute+10*time.Second).Unix(),
 	)
 
 	assert.False(t, IsAccessTokenExpired(tf))
@@ -291,7 +291,7 @@ func TestIsAccessTokenExpired_JustBeyondLeeway_ReturnsFalse(t *testing.T) {
 
 func TestIsRefreshTokenStale_RecentToken_ReturnsFalse(t *testing.T) {
 	// Token created now
-	tf := makeTokenFile(time.Now().Unix(), float64(time.Now().Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(time.Now().Unix(), time.Now().Add(30*time.Minute).Unix())
 
 	assert.False(t, IsRefreshTokenStale(tf))
 }
@@ -299,7 +299,7 @@ func TestIsRefreshTokenStale_RecentToken_ReturnsFalse(t *testing.T) {
 func TestIsRefreshTokenStale_After6Days_ReturnsFalse(t *testing.T) {
 	// Token created 6 days ago (< 6.5 days)
 	sixDaysAgo := time.Now().Add(-6 * 24 * time.Hour).Unix()
-	tf := makeTokenFile(sixDaysAgo, float64(time.Now().Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(sixDaysAgo, time.Now().Add(30*time.Minute).Unix())
 
 	assert.False(t, IsRefreshTokenStale(tf))
 }
@@ -307,7 +307,7 @@ func TestIsRefreshTokenStale_After6Days_ReturnsFalse(t *testing.T) {
 func TestIsRefreshTokenStale_After7Days_ReturnsTrue(t *testing.T) {
 	// Token created 7 days ago (> 6.5 days = 561600 seconds)
 	sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour).Unix()
-	tf := makeTokenFile(sevenDaysAgo, float64(time.Now().Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(sevenDaysAgo, time.Now().Add(30*time.Minute).Unix())
 
 	assert.True(t, IsRefreshTokenStale(tf))
 }
@@ -315,7 +315,7 @@ func TestIsRefreshTokenStale_After7Days_ReturnsTrue(t *testing.T) {
 func TestIsRefreshTokenStale_ExactlyAt561600Seconds_ReturnsTrue(t *testing.T) {
 	// Token created exactly 561600 seconds ago (at the boundary)
 	staleTime := time.Now().Unix() - 561600
-	tf := makeTokenFile(staleTime, float64(time.Now().Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(staleTime, time.Now().Add(30*time.Minute).Unix())
 
 	assert.True(t, IsRefreshTokenStale(tf))
 }
@@ -323,7 +323,7 @@ func TestIsRefreshTokenStale_ExactlyAt561600Seconds_ReturnsTrue(t *testing.T) {
 func TestIsRefreshTokenStale_JustBefore561600Seconds_ReturnsFalse(t *testing.T) {
 	// Token created 561599 seconds ago (just under the threshold)
 	notStaleTime := time.Now().Unix() - 561599
-	tf := makeTokenFile(notStaleTime, float64(time.Now().Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(notStaleTime, time.Now().Add(30*time.Minute).Unix())
 
 	assert.False(t, IsRefreshTokenStale(tf))
 }
@@ -332,7 +332,8 @@ func TestIsRefreshTokenStale_JustBefore561600Seconds_ReturnsFalse(t *testing.T) 
 
 func TestRefreshAccessToken_Success_ReturnsNewTokenFile(t *testing.T) {
 	// Arrange
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		// Verify request method
 		assert.Equal(t, http.MethodPost, r.Method)
 
@@ -369,13 +370,10 @@ func TestRefreshAccessToken_Success_ReturnsNewTokenFile(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &Config{
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-	}
+	cfg := &Config{ClientID: "test-client", ClientSecret: "test-secret", BaseURLInsecure: true}
 
 	originalCreation := time.Now().Add(-1 * time.Hour).Unix()
-	tf := makeTokenFile(originalCreation, float64(time.Now().Add(-5*time.Minute).Unix()))
+	tf := makeTokenFile(originalCreation, time.Now().Add(-5*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, server.URL)
@@ -394,7 +392,7 @@ func TestRefreshAccessToken_Success_ReturnsNewTokenFile(t *testing.T) {
 	assert.Equal(t, originalCreation, newTF.CreationTimestamp)
 
 	// ExpiresAt should be computed (approximately now + ExpiresIn)
-	assert.InDelta(t, float64(time.Now().Unix()+1800), newTF.Token.ExpiresAt, 5.0)
+	assert.InDelta(t, time.Now().Unix()+1800, newTF.Token.ExpiresAt, 5.0)
 }
 
 func TestRefreshAccessToken_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {
@@ -424,7 +422,7 @@ func TestRefreshAccessToken_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {
 		BaseURLInsecure: true,
 	}
 
-	tf := makeTokenFile(time.Now().Add(-1*time.Hour).Unix(), float64(time.Now().Add(-5*time.Minute).Unix()))
+	tf := makeTokenFile(time.Now().Add(-1*time.Hour).Unix(), time.Now().Add(-5*time.Minute).Unix())
 
 	newTF, err := RefreshAccessToken(cfg, tf, "")
 	require.NoError(t, err)
@@ -435,7 +433,8 @@ func TestRefreshAccessToken_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {
 
 func TestRefreshAccessToken_PreservesCreationTimestamp(t *testing.T) {
 	// Arrange
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  "refreshed-token",
@@ -447,11 +446,11 @@ func TestRefreshAccessToken_PreservesCreationTimestamp(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
+	cfg := &Config{ClientID: "id", ClientSecret: "secret", BaseURLInsecure: true}
 
 	// Creation was 3 days ago
 	threeDaysAgo := time.Now().Add(-3 * 24 * time.Hour).Unix()
-	tf := makeTokenFile(threeDaysAgo, float64(time.Now().Add(-1*time.Minute).Unix()))
+	tf := makeTokenFile(threeDaysAgo, time.Now().Add(-1*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, server.URL)
@@ -463,7 +462,8 @@ func TestRefreshAccessToken_PreservesCreationTimestamp(t *testing.T) {
 
 func TestRefreshAccessToken_InvalidGrant_ReturnsAuthExpiredError(t *testing.T) {
 	// Arrange
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		w.WriteHeader(http.StatusBadRequest)
 		assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{
 			"error": "invalid_grant",
@@ -471,8 +471,8 @@ func TestRefreshAccessToken_InvalidGrant_ReturnsAuthExpiredError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
-	tf := makeTokenFile(time.Now().Unix(), float64(time.Now().Add(30*time.Minute).Unix()))
+	cfg := &Config{ClientID: "id", ClientSecret: "secret", BaseURLInsecure: true}
+	tf := makeTokenFile(time.Now().Unix(), time.Now().Add(30*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, server.URL)
@@ -488,14 +488,15 @@ func TestRefreshAccessToken_InvalidGrant_ReturnsAuthExpiredError(t *testing.T) {
 
 func TestRefreshAccessToken_ServerError_ReturnsError(t *testing.T) {
 	// Arrange
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, "internal server error")
 	}))
 	defer server.Close()
 
-	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
-	tf := makeTokenFile(time.Now().Unix(), float64(time.Now().Add(30*time.Minute).Unix()))
+	cfg := &Config{ClientID: "id", ClientSecret: "secret", BaseURLInsecure: true}
+	tf := makeTokenFile(time.Now().Unix(), time.Now().Add(30*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, server.URL)
@@ -503,19 +504,20 @@ func TestRefreshAccessToken_ServerError_ReturnsError(t *testing.T) {
 	// Assert
 	assert.Nil(t, newTF)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token refresh failed")
+	assert.Contains(t, err.Error(), "refresh access token")
 }
 
 func TestRefreshAccessToken_InvalidResponseJSON_ReturnsError(t *testing.T) {
 	// Arrange
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, "not valid json")
 	}))
 	defer server.Close()
 
-	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
-	tf := makeTokenFile(time.Now().Unix(), float64(time.Now().Add(30*time.Minute).Unix()))
+	cfg := &Config{ClientID: "id", ClientSecret: "secret", BaseURLInsecure: true}
+	tf := makeTokenFile(time.Now().Unix(), time.Now().Add(30*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, server.URL)
@@ -523,13 +525,13 @@ func TestRefreshAccessToken_InvalidResponseJSON_ReturnsError(t *testing.T) {
 	// Assert
 	assert.Nil(t, newTF)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse token response")
+	assert.Contains(t, err.Error(), "failed to parse token refresh response")
 }
 
 func TestRefreshAccessToken_NetworkError_ReturnsError(t *testing.T) {
 	// Arrange: use a URL that will fail to connect
 	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
-	tf := makeTokenFile(time.Now().Unix(), float64(time.Now().Add(30*time.Minute).Unix()))
+	tf := makeTokenFile(time.Now().Unix(), time.Now().Add(30*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, "http://127.0.0.1:0/nonexistent")
@@ -537,12 +539,13 @@ func TestRefreshAccessToken_NetworkError_ReturnsError(t *testing.T) {
 	// Assert
 	assert.Nil(t, newTF)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "token refresh request failed")
+	assert.Contains(t, err.Error(), "oauth_base_url")
 }
 
 func TestRefreshAccessToken_OtherHTTPError_ReturnsGenericError(t *testing.T) {
 	// Arrange: non-invalid_grant 400 response
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/token", r.URL.Path)
 		w.WriteHeader(http.StatusBadRequest)
 		assert.NoError(t, json.NewEncoder(w).Encode(map[string]string{
 			"error": "invalid_client",
@@ -550,8 +553,8 @@ func TestRefreshAccessToken_OtherHTTPError_ReturnsGenericError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
-	tf := makeTokenFile(time.Now().Unix(), float64(time.Now().Add(30*time.Minute).Unix()))
+	cfg := &Config{ClientID: "id", ClientSecret: "secret", BaseURLInsecure: true}
+	tf := makeTokenFile(time.Now().Unix(), time.Now().Add(30*time.Minute).Unix())
 
 	// Act
 	newTF, err := RefreshAccessToken(cfg, tf, server.URL)
@@ -567,10 +570,10 @@ func TestRefreshAccessToken_OtherHTTPError_ReturnsGenericError(t *testing.T) {
 
 // --- Token JSON format compatibility ---
 
-func TestTokenFile_JSONFormat_MatchesSchwabPy(t *testing.T) {
-	// Verify the JSON format matches schwab-py's expected structure:
+func TestTokenFile_JSONFormat_MatchesSchwabGo(t *testing.T) {
+	// Verify the JSON format matches schwab-go's expected structure:
 	// {"creation_timestamp": <int>, "token": {"access_token": ..., ...}}
-	tf := makeTokenFile(1713700000, 1713701800.0)
+	tf := makeTokenFile(1713700000, 1713701800)
 
 	data, err := json.Marshal(tf)
 	require.NoError(t, err)
@@ -595,8 +598,8 @@ func TestTokenFile_JSONFormat_MatchesSchwabPy(t *testing.T) {
 	assert.Contains(t, tokenMap, "expires_at")
 }
 
-func TestTokenFile_JSONRoundTrip_FromSchwabPyFormat(t *testing.T) {
-	// Simulate loading a token file written by schwab-py
+func TestTokenFile_JSONRoundTrip_FromSchwabGoFormat(t *testing.T) {
+	// Simulate loading a token file written by schwab-go.
 	schwabPyJSON := `{
 		"creation_timestamp": 1713700000,
 		"token": {
@@ -605,7 +608,7 @@ func TestTokenFile_JSONRoundTrip_FromSchwabPyFormat(t *testing.T) {
 			"expires_in": 1800,
 			"refresh_token": "py-refresh-token",
 			"scope": "api",
-			"expires_at": 1713701800.5
+			"expires_at": 1713701800
 		}
 	}`
 
@@ -619,5 +622,5 @@ func TestTokenFile_JSONRoundTrip_FromSchwabPyFormat(t *testing.T) {
 	assert.Equal(t, 1800, tf.Token.ExpiresIn)
 	assert.Equal(t, "py-refresh-token", tf.Token.RefreshToken)
 	assert.Equal(t, "api", tf.Token.Scope)
-	assert.InDelta(t, 1713701800.5, tf.Token.ExpiresAt, 0.001)
+	assert.Equal(t, int64(1713701800), tf.Token.ExpiresAt)
 }

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -218,6 +218,15 @@ func TestSaveToken_MkdirAllFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to save token file")
 }
 
+func TestSaveToken_NilTokenFileReturnsError(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token.json")
+
+	err := SaveToken(tokenPath, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token file is required")
+}
+
 func TestSaveToken_WriteFileFailure(t *testing.T) {
 	// Arrange: create a read-only directory so WriteFile fails.
 	tmpDir := t.TempDir()
@@ -287,6 +296,10 @@ func TestIsAccessTokenExpired_JustBeyondLeeway_ReturnsFalse(t *testing.T) {
 	assert.False(t, IsAccessTokenExpired(tf))
 }
 
+func TestIsAccessTokenExpired_NilTokenFileReturnsTrue(t *testing.T) {
+	assert.True(t, IsAccessTokenExpired(nil))
+}
+
 // --- IsRefreshTokenStale tests ---
 
 func TestIsRefreshTokenStale_RecentToken_ReturnsFalse(t *testing.T) {
@@ -326,6 +339,10 @@ func TestIsRefreshTokenStale_JustBefore561600Seconds_ReturnsFalse(t *testing.T) 
 	tf := makeTokenFile(notStaleTime, time.Now().Add(30*time.Minute).Unix())
 
 	assert.False(t, IsRefreshTokenStale(tf))
+}
+
+func TestIsRefreshTokenStale_NilTokenFileReturnsTrue(t *testing.T) {
+	assert.True(t, IsRefreshTokenStale(nil))
 }
 
 // --- RefreshAccessToken tests ---
@@ -393,6 +410,16 @@ func TestRefreshAccessToken_Success_ReturnsNewTokenFile(t *testing.T) {
 
 	// ExpiresAt should be computed (approximately now + ExpiresIn)
 	assert.InDelta(t, time.Now().Unix()+1800, newTF.Token.ExpiresAt, 5.0)
+}
+
+func TestRefreshAccessToken_NilTokenFileReturnsError(t *testing.T) {
+	cfg := &Config{ClientID: "id", ClientSecret: "secret"}
+
+	newTF, err := RefreshAccessToken(cfg, nil, "")
+
+	assert.Nil(t, newTF)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token file is required")
 }
 
 func TestRefreshAccessToken_UsesDerivedTokenURLAndInsecureTLS(t *testing.T) {

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -124,12 +124,12 @@ func defaultAuthConfigPath() string {
 }
 
 // unixSecondsToRFC3339 converts Unix seconds into RFC3339, returning an empty string for zero.
-func unixSecondsToRFC3339(seconds float64) string {
+func unixSecondsToRFC3339(seconds int64) string {
 	if seconds <= 0 {
 		return ""
 	}
 
-	return time.Unix(int64(seconds), 0).UTC().Format(time.RFC3339)
+	return time.Unix(seconds, 0).UTC().Format(time.RFC3339)
 }
 
 // refreshExpiryRFC3339 converts the refresh token lifetime into RFC3339.

--- a/internal/commands/auth_test.go
+++ b/internal/commands/auth_test.go
@@ -101,7 +101,7 @@ func TestNewAuthCmd_StatusWritesExpectedEnvelope(t *testing.T) {
 			AccessToken:  "access-token",
 			RefreshToken: "refresh-token",
 			ExpiresIn:    1800,
-			ExpiresAt:    float64(expiresAt),
+			ExpiresAt:    expiresAt,
 		},
 	}))
 
@@ -140,7 +140,7 @@ func TestNewAuthCmd_RefreshCallsRefresh(t *testing.T) {
 		Token: auth.TokenData{
 			AccessToken:  "old-token",
 			RefreshToken: "refresh-token",
-			ExpiresAt:    float64(1_650_000_100),
+			ExpiresAt:    1_650_000_100,
 		},
 	}
 	require.NoError(t, auth.SaveToken(tokenPath, originalToken))
@@ -158,7 +158,7 @@ func TestNewAuthCmd_RefreshCallsRefresh(t *testing.T) {
 				Token: auth.TokenData{
 					AccessToken:  "new-token",
 					RefreshToken: tf.Token.RefreshToken,
-					ExpiresAt:    float64(1_650_004_200),
+					ExpiresAt:    1_650_004_200,
 				},
 			}, nil
 		},
@@ -239,7 +239,7 @@ func TestNewAuthCmd_LoginAutoSetsDefaultAccount(t *testing.T) {
 				return decodeErr
 			}
 
-			token.ExpiresAt = float64(expiresAt)
+			token.ExpiresAt = expiresAt
 
 			return auth.SaveToken(targetTokenPath, &auth.TokenFile{
 				CreationTimestamp: time.Now().UTC().Add(-1 * time.Hour).Unix(),
@@ -309,7 +309,7 @@ func TestNewAuthCmd_LoginUsesConfiguredProxy(t *testing.T) {
 					ExpiresIn:    1800,
 					RefreshToken: "refresh-token",
 					Scope:        "api",
-					ExpiresAt:    float64(time.Now().UTC().Add(30 * time.Minute).Unix()),
+					ExpiresAt:    time.Now().UTC().Add(30 * time.Minute).Unix(),
 				},
 			})
 		},
@@ -370,7 +370,7 @@ func decodeAuthEnvelope(t *testing.T, raw []byte) testEnvelope {
 func TestUnixSecondsToRFC3339(t *testing.T) {
 	tests := []struct {
 		name     string
-		seconds  float64
+		seconds  int64
 		expected string
 	}{
 		{"positive timestamp", 1_700_000_000, "2023-11-14T22:13:20Z"},
@@ -586,7 +586,7 @@ func TestNewAuthCmd_RefreshFails(t *testing.T) {
 		Token: auth.TokenData{
 			AccessToken:  "old-token",
 			RefreshToken: "refresh-token",
-			ExpiresAt:    float64(time.Now().Unix() - 100),
+			ExpiresAt:    time.Now().Unix() - 100,
 		},
 	}))
 


### PR DESCRIPTION
## Summary
- Delegate OAuth URL generation, token exchange, refresh, token file persistence, and callback handling to `github.com/major/schwab-go/schwab/auth`.
- Preserve schwab-agent config behavior, JSON output contracts, typed auth errors, `base_url_insecure` proxy support, and default-account login behavior.
- Update tests and docs for schwab-go token timestamp types and HTTPS OAuth mock servers.

## Validation
- CodeRabbit local review: `findings: 0`
- `make test`
- `make lint`
- `make build`
- Live `auth refresh` using a temp token copy
- Full browser `auth login` and follow-up `auth status`