### PR TITLE
refactor: route client calls through schwab-go

### DIFF
--- a/internal/client/AGENTS.md
+++ b/internal/client/AGENTS.md
@@ -2,7 +2,7 @@
 
 > Leave generous comments when fixing bugs or working around API quirks. Anything that might save a future developer from re-discovering the same issue is worth writing down.
 
-HTTP client for the Charles Schwab API. Wraps the remaining non-schwab-go endpoints with typed Go methods. 16 Go files (8 source + 8 test).
+Compatibility facade for Schwab API access. Route endpoint methods through `github.com/major/schwab-go` when that library preserves this CLI's output and error contracts. Keep local compatibility decoders only for documented schwab-go gaps. 16 Go files (8 source + 8 test).
 
 ## Client Construction
 
@@ -18,24 +18,25 @@ c := client.NewClient("bearer-token",
 
 Production code injects the client via the Before hook in `main.go`. Tests use `client.NewClient("test-token", client.WithBaseURL(server.URL))`.
 
-WithTLSConfig applies a custom TLS configuration to the resty client's transport (e.g., InsecureSkipVerify for local proxy setups). Pass nil for default TLS behavior. The resty client handles connection pooling and lifecycle; call c.Close() to release idle connections. Close() is wired via an After hook in main.go.
+WithTLSConfig applies a custom TLS configuration to both schwab-go clients and the remaining resty compatibility transport (e.g., InsecureSkipVerify for local proxy setups). Pass nil for default TLS behavior. The resty client handles connection pooling for compatibility calls; call c.Close() to release idle connections. Close() is wired via an After hook in main.go.
 
 ## Adding a New Endpoint
 
 1. Create `<resource>.go` with methods on `*Client`
-2. Use the appropriate HTTP helper: `doGet`, `doPost`, `doDelete`, or call `doRequest` directly when the endpoint needs a method-specific response header or status-code quirk
-3. Create `<resource>_test.go` with httptest-based tests
-4. Define any new request/response types in `internal/models/`
+2. Prefer the appropriate schwab-go trader or marketdata method, then adapt back into `internal/models` only when output parity is proven by tests
+3. Use `doGet`, `doPost`, `doDelete`, or direct resty only for documented schwab-go gaps such as response headers, incompatible request/response models, or missing optional filter behavior
+4. Create `<resource>_test.go` with httptest-based tests
+5. Define any new request/response types in `internal/models/`
 
 ## HTTP Helpers
 
-Core method `doRequest` uses resty v3 internally. It sets the Bearer token via request middleware (reads c.token at request time for token refresh support), validates Content-Type before JSON decoding, and maps status codes to typed errors. Thin wrappers:
+Core method `doRequest` is the remaining resty v3 compatibility path. It sets the Bearer token via request middleware (reads c.token at request time for token refresh support), validates Content-Type before JSON decoding, and maps status codes to typed errors. Thin wrappers:
 
 - `doGet(ctx, path, params, result)`: GET with query params
 - `doPost(ctx, path, body, result)`: POST with JSON body
 - `doDelete(ctx, path, result)`: DELETE
 
-Content-Type header is set by resty only when a request body is present (not on GET). Accept: application/json is set globally on the resty client.
+Content-Type header is set by resty only when a request body is present (not on GET). Accept: application/json is set globally on the resty client. New migrated calls should use `newTraderClient()` or `newMarketDataClient()` so schwab-go owns request construction.
 
 ## Error Mapping
 
@@ -47,7 +48,7 @@ Content-Type header is set by resty only when a request body is present (not on 
 | 400, 422 (on order endpoints) | `OrderRejectedError` |
 | Other 4xx/5xx | `HTTPError` (includes status code + body) |
 
-The `PlaceOrder` method has custom status handling (bypasses `doRequest`) to extract the order ID from the Location header and map 400/422 to `OrderRejectedError`.
+The `PlaceOrder` and `ReplaceOrder` methods have custom status handling (bypasses `doRequest`) to extract the order ID from the Location header and map 400/422 to `OrderRejectedError`. Keep this until schwab-go exposes order mutation response headers or order IDs.
 
 ## Endpoint Methods
 
@@ -55,12 +56,12 @@ Each file maps to one Schwab API resource:
 
 | File | Methods | API Path Prefix |
 |---|---|---|
-| accounts.go | `Accounts()`, `Account()` | `/trader/v1/accounts` |
-| chains.go | `OptionChain()`, `ExpirationChainForSymbol()` | `/marketdata/v1/chains`, `/marketdata/v1/expirationchain` |
-| orders.go | `ListOrders()`, `AllOrders()`, `GetOrder()`, `PlaceOrder()`, `PreviewOrder()`, `ReplaceOrder()`, `CancelOrder()` | `/trader/v1/accounts/{hash}/orders` |
-| preferences.go | `UserPreference()` | `/trader/v1/userPreference` |
-| quotes.go | `Quote()`, `Quotes()` | `/marketdata/v1/quotes` |
-| transactions.go | `Transactions()`, `Transaction()` | `/trader/v1/accounts/{hash}/transactions` |
+| accounts.go | `AccountNumbers()` via schwab-go; `Accounts()`, `Account()` compatibility decoder | `/trader/v1/accounts` |
+| chains.go | `ExpirationChainForSymbol()` via schwab-go; `OptionChain()` compatibility decoder | `/marketdata/v1/chains`, `/marketdata/v1/expirationchain` |
+| orders.go | `ListOrders()`, `AllOrders()`, `GetOrder()`, `CancelOrder()` via schwab-go; `PlaceOrder()`, `PreviewOrder()`, `ReplaceOrder()` compatibility paths | `/trader/v1/accounts/{hash}/orders` |
+| preferences.go | `UserPreference()` compatibility decoder | `/trader/v1/userPreference` |
+| quotes.go | `Quote()`, `Quotes()` via schwab-go | `/marketdata/v1/quotes` |
+| transactions.go | `Transactions()`, `Transaction()` compatibility decoder | `/trader/v1/accounts/{hash}/transactions` |
 
 `client.go` contains shared client construction and HTTP helpers. `params.go` contains reusable query parameter helpers, not endpoint methods.
 

--- a/internal/client/chains.go
+++ b/internal/client/chains.go
@@ -58,9 +58,11 @@ func (c *Client) OptionChain(
 
 // ExpirationChainForSymbol retrieves the expiration chain for a symbol.
 func (c *Client) ExpirationChainForSymbol(ctx context.Context, symbol string) (*ExpirationChain, error) {
-	params := map[string]string{queryParamSymbol: symbol}
-	var result ExpirationChain
-	err := c.doGet(ctx, "/marketdata/v1/expirationchain", params, &result)
+	chain, err := c.newMarketDataClient().GetExpirationChain(ctx, symbol)
+	if err != nil {
+		return nil, schwabAPIErrorToHTTPError(err)
+	}
+	result, err := adaptSchwabGoModel[ExpirationChain](chain)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,7 +1,8 @@
-// Package client provides an authenticated HTTP client for the Schwab API.
+// Package client provides the CLI's Schwab API facade.
 //
-// All requests include Bearer token authentication, JSON content headers,
-// and automatic error mapping for non-2xx responses.
+// Endpoint methods route through schwab-go where that library exposes the
+// behavior the CLI needs, then adapt responses back into this repository's
+// stable output models and typed error hierarchy.
 package client
 
 import (
@@ -110,6 +111,31 @@ func (c *Client) newTraderClient() *trader.Client {
 		schwab.WithUserAgent(c.userAgent),
 		schwab.WithTLSConfig(c.tlsConfig),
 	)
+}
+
+func (c *Client) newMarketDataClient() *marketdata.Client {
+	// Build on demand for the same token-refresh reason as newTraderClient.
+	// Keeping construction here prevents command packages from depending on
+	// transport details while still letting schwab-go own request construction.
+	return marketdata.NewClient(
+		schwab.WithToken(c.token),
+		schwab.WithBaseURL(c.baseURL),
+		schwab.WithResponseBodyLimit(maxResponseSize),
+		schwab.WithUserAgent(c.userAgent),
+		schwab.WithTLSConfig(c.tlsConfig),
+	)
+}
+
+func adaptSchwabGoModel[T any](source any) (T, error) {
+	var target T
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		return target, fmt.Errorf("encode schwab-go response: %w", err)
+	}
+	if unmarshalErr := json.Unmarshal(encoded, &target); unmarshalErr != nil {
+		return target, fmt.Errorf("decode schwab-go response into local model: %w", unmarshalErr)
+	}
+	return target, nil
 }
 
 func schwabAPIErrorToHTTPError(err error) error {

--- a/internal/client/orders.go
+++ b/internal/client/orders.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/url"
 	pathpkg "path"
 	"strconv"
 	"strings"
+
+	"github.com/major/schwab-go/schwab/trader"
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
@@ -22,20 +23,13 @@ type OrderListParams struct {
 	ToEnteredTime   string
 }
 
-// toQueryParams converts date fields to a map for doGet.
-//
-// The Schwab API requires fromEnteredTime and toEnteredTime as mandatory query
-// parameters in ISO 8601 format. When not provided, fromEnteredTime defaults
-// to 60 days ago and toEnteredTime defaults to now (matching the Python
-// schwab-py client behavior).
-//
-// Status is intentionally omitted here because the Schwab API accepts only a
-// single status value per request. Multiple statuses require separate API calls
-// with merged results, handled by fetchOrders.
-func (p OrderListParams) toQueryParams() map[string]string {
-	params := make(map[string]string)
-	params["fromEnteredTime"], params["toEnteredTime"] = defaultDateRange(p.FromEnteredTime, p.ToEnteredTime)
-	return params
+func (p OrderListParams) toSchwabGoParams(status string) *trader.OrderListParams {
+	fromEnteredTime, toEnteredTime := defaultDateRange(p.FromEnteredTime, p.ToEnteredTime)
+	return &trader.OrderListParams{
+		FromEnteredTime: fromEnteredTime,
+		ToEnteredTime:   toEnteredTime,
+		Status:          trader.OrderStatus(status),
+	}
 }
 
 // PlaceOrderResponse contains the result of a successful order placement.
@@ -87,19 +81,30 @@ func orderIDFromLocation(location string) (int64, error) {
 // status is provided, a single filtered request is made. When multiple are
 // provided, one request per status is made and results are merged, deduplicating
 // by OrderID.
-func (c *Client) fetchOrders(ctx context.Context, path string, params OrderListParams) ([]models.Order, error) {
-	baseQuery := params.toQueryParams()
-
+func (c *Client) fetchOrders(
+	ctx context.Context,
+	accountHash string,
+	allAccounts bool,
+	params OrderListParams,
+) ([]models.Order, error) {
+	traderClient := c.newTraderClient()
 	// Zero or one status: single API call.
 	if len(params.Statuses) <= 1 {
+		var status string
 		if len(params.Statuses) == 1 {
-			baseQuery["status"] = params.Statuses[0]
+			status = params.Statuses[0]
 		}
-		var result []models.Order
-		if err := c.doGet(ctx, path, baseQuery, &result); err != nil {
+		batch, err := c.fetchSchwabGoOrders(
+			ctx,
+			traderClient,
+			accountHash,
+			allAccounts,
+			params.toSchwabGoParams(status),
+		)
+		if err != nil {
 			return nil, err
 		}
-		return result, nil
+		return adaptSchwabGoModel[[]models.Order](batch)
 	}
 
 	// Multiple statuses: fan out one call per status, merge and dedup.
@@ -112,43 +117,72 @@ func (c *Client) fetchOrders(ctx context.Context, path string, params OrderListP
 	seen := make(map[int64]bool)
 	merged := make([]models.Order, 0)
 	for _, status := range params.Statuses {
-		query := make(map[string]string, len(baseQuery)+1)
-		maps.Copy(query, baseQuery)
-		query["status"] = status
-
-		var batch []models.Order
-		if err := c.doGet(ctx, path, query, &batch); err != nil {
+		batch, err := c.fetchSchwabGoOrders(
+			ctx,
+			traderClient,
+			accountHash,
+			allAccounts,
+			params.toSchwabGoParams(status),
+		)
+		if err != nil {
 			return nil, err
 		}
-		for i := range batch {
-			if batch[i].OrderID != nil {
-				if seen[*batch[i].OrderID] {
+		localBatch, err := adaptSchwabGoModel[[]models.Order](batch)
+		if err != nil {
+			return nil, err
+		}
+		for i := range localBatch {
+			if localBatch[i].OrderID != nil {
+				if seen[*localBatch[i].OrderID] {
 					continue
 				}
-				seen[*batch[i].OrderID] = true
+				seen[*localBatch[i].OrderID] = true
 			}
-			merged = append(merged, batch[i])
+			merged = append(merged, localBatch[i])
 		}
 	}
 	return merged, nil
 }
 
+func (c *Client) fetchSchwabGoOrders(
+	ctx context.Context,
+	traderClient *trader.Client,
+	accountHash string,
+	allAccounts bool,
+	params *trader.OrderListParams,
+) ([]trader.Order, error) {
+	if allAccounts {
+		orders, err := traderClient.GetAllOrders(ctx, params)
+		if err != nil {
+			return nil, schwabAPIErrorToHTTPError(err)
+		}
+		return orders, nil
+	}
+	orders, err := traderClient.GetOrders(ctx, accountHash, params)
+	if err != nil {
+		return nil, schwabAPIErrorToHTTPError(err)
+	}
+	return orders, nil
+}
+
 // ListOrders retrieves orders for a specific account, filtered by the given params.
 func (c *Client) ListOrders(ctx context.Context, hashValue string, params OrderListParams) ([]models.Order, error) {
-	path := fmt.Sprintf("/trader/v1/accounts/%s/orders", hashValue)
-	return c.fetchOrders(ctx, path, params)
+	return c.fetchOrders(ctx, hashValue, false, params)
 }
 
 // AllOrders retrieves orders across all accounts, filtered by the given params.
 func (c *Client) AllOrders(ctx context.Context, params OrderListParams) ([]models.Order, error) {
-	return c.fetchOrders(ctx, "/trader/v1/orders", params)
+	return c.fetchOrders(ctx, "", true, params)
 }
 
 // GetOrder retrieves a specific order by account hash and order ID.
 func (c *Client) GetOrder(ctx context.Context, hashValue string, orderID int64) (*models.Order, error) {
-	path := fmt.Sprintf("/trader/v1/accounts/%s/orders/%d", hashValue, orderID)
-	var result models.Order
-	if err := c.doGet(ctx, path, nil, &result); err != nil {
+	order, err := c.newTraderClient().GetOrder(ctx, hashValue, orderID)
+	if err != nil {
+		return nil, schwabAPIErrorToHTTPError(err)
+	}
+	result, err := adaptSchwabGoModel[models.Order](order)
+	if err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -289,6 +323,8 @@ func (c *Client) ReplaceOrder(
 
 // CancelOrder cancels an existing order.
 func (c *Client) CancelOrder(ctx context.Context, hashValue string, orderID int64) error {
-	path := fmt.Sprintf("/trader/v1/accounts/%s/orders/%d", hashValue, orderID)
-	return c.doDelete(ctx, path, nil)
+	if err := c.newTraderClient().CancelOrder(ctx, hashValue, orderID); err != nil {
+		return schwabAPIErrorToHTTPError(err)
+	}
+	return nil
 }

--- a/internal/client/quotes.go
+++ b/internal/client/quotes.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
 	"strings"
+
+	"github.com/major/schwab-go/schwab/marketdata"
 
 	"github.com/major/schwab-agent/internal/apperr"
 	"github.com/major/schwab-agent/internal/models"
@@ -31,33 +32,46 @@ func quoteParams(p QuoteParams) map[string]string {
 	return m
 }
 
+func quoteFields(p QuoteParams) string {
+	if len(p.Fields) == 0 {
+		return ""
+	}
+	return strings.Join(p.Fields, ",")
+}
+
+func quoteResponseToModels(response *marketdata.QuoteResponse) (map[string]*models.QuoteEquity, error) {
+	if response == nil {
+		return map[string]*models.QuoteEquity{}, nil
+	}
+	return adaptSchwabGoModel[map[string]*models.QuoteEquity](response)
+}
+
 // Quotes retrieves quotes for multiple symbols.
 // Symbols are passed as a comma-separated query parameter.
 func (c *Client) Quotes(ctx context.Context, symbols []string, p QuoteParams) (map[string]*models.QuoteEquity, error) {
-	params := map[string]string{"symbols": strings.Join(symbols, ",")}
-	maps.Copy(params, quoteParams(p))
-	var result map[string]*models.QuoteEquity
-	err := c.doGet(ctx, "/marketdata/v1/quotes", params, &result)
+	response, _, err := c.newMarketDataClient().GetQuotes(ctx, symbols, quoteFields(p), p.Indicative)
 	if err != nil {
-		return nil, err
+		return nil, schwabAPIErrorToHTTPError(err)
 	}
-	// The Schwab API includes an "errors" key in the response map for
-	// invalid symbols. Remove it so only real quote entries remain.
-	delete(result, "errors")
-	return result, nil
+	return quoteResponseToModels(response)
 }
 
 // Quote retrieves a quote for a single symbol.
 // Returns SymbolNotFoundError on 404.
 func (c *Client) Quote(ctx context.Context, symbol string, p QuoteParams) (*models.QuoteEquity, error) {
-	path := fmt.Sprintf("/marketdata/v1/%s/quotes", symbol)
-	var result map[string]*models.QuoteEquity
-	err := c.doGet(ctx, path, quoteParams(p), &result)
+	// Use GetQuotes rather than schwab-go's GetQuote because the multi-symbol
+	// helper preserves the indicative flag this CLI has historically accepted for
+	// single-symbol requests too.
+	response, _, err := c.newMarketDataClient().GetQuotes(ctx, []string{symbol}, quoteFields(p), p.Indicative)
 	if err != nil {
-		// Convert 404 HTTPError to SymbolNotFoundError
-		if httpErr, ok := errors.AsType[*apperr.HTTPError](err); ok && httpErr.StatusCode == http.StatusNotFound {
+		mappedErr := schwabAPIErrorToHTTPError(err)
+		if httpErr, ok := errors.AsType[*apperr.HTTPError](mappedErr); ok && httpErr.StatusCode == http.StatusNotFound {
 			return nil, apperr.NewSymbolNotFoundError(fmt.Sprintf("symbol %s not found", symbol), err)
 		}
+		return nil, mappedErr
+	}
+	result, err := quoteResponseToModels(response)
+	if err != nil {
 		return nil, err
 	}
 	q, ok := result[symbol]

--- a/internal/client/quotes_test.go
+++ b/internal/client/quotes_test.go
@@ -90,7 +90,8 @@ func TestQuotes_EmptyResult(t *testing.T) {
 func TestQuote_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/marketdata/v1/AAPL/quotes", r.URL.Path)
+		assert.Equal(t, "/marketdata/v1/quotes", r.URL.Path)
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbols"))
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/commands/option_ticket_test.go
+++ b/internal/commands/option_ticket_test.go
@@ -20,7 +20,10 @@ func TestNewOptionCmdTicketGet(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/marketdata/v1/AAPL/quotes":
+		case "/marketdata/v1/quotes":
+			if got := r.URL.Query().Get("symbols"); got != "AAPL" {
+				t.Errorf("quote symbols query = %q, want %q", got, "AAPL")
+			}
 			_, _ = w.Write([]byte(`{
 				"AAPL": {
 					"symbol": "AAPL",
@@ -121,7 +124,10 @@ func TestNewOptionCmdTicketGetMissingContract(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch r.URL.Path {
-		case "/marketdata/v1/AAPL/quotes":
+		case "/marketdata/v1/quotes":
+			if got := r.URL.Query().Get("symbols"); got != "AAPL" {
+				t.Errorf("quote symbols query = %q, want %q", got, "AAPL")
+			}
 			_, _ = w.Write([]byte(`{"AAPL": {"symbol": "AAPL", "quote": {"lastPrice": 199.50}}}`))
 		case "/marketdata/v1/chains":
 			_, _ = w.Write([]byte(`{"symbol": "AAPL", "putExpDateMap": {}}`))


### PR DESCRIPTION
## Summary
- Route quotes, expiration chains, order reads, and order cancellation through schwab-go while preserving the existing client facade.
- Keep documented compatibility paths where schwab-go does not yet preserve CLI output, filters, or order response IDs.
- Update command and client tests for the migrated quote endpoint behavior.

## Verification
- Local CodeRabbit review initially reported 0 findings. Retry skipped per request after a rate limit.
- `make test`
- `make lint`
- `make build`
- `make smoke-ci`

## Notes
- Remaining schwab-go gaps are tracked in major/schwab-go#54 through major/schwab-go#60.
- Local untracked research note `OPTIONS_CHAIN_PORCELAIN_RESEARCH.md` is not included.