### PR TITLE
feat: filter option chains by delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ schwab-agent option expirations AAPL
 # Discover option contracts (calls and puts near the money)
 schwab-agent option chain AAPL --type CALL --dte 30 --strike-count 5
 
+# Find OTM puts near a target delta with compact agent-friendly columns
+schwab-agent option chain AMD --type PUT --strike-range OTM --expiration 2026-06-19 --delta-min -0.25 --delta-max -0.15 --fields strike,delta,bid,ask,mid,openInterest,totalVolume,volatility,daysToExpiration
+
 # Get a single option contract with underlying quote and OCC symbol context
 schwab-agent option contract AAPL --expiration 2025-06-20 --strike 200 --call
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -759,14 +759,16 @@ Usage:
 Examples:
   schwab-agent option chain AAPL
   schwab-agent option chain AAPL --type CALL --dte 30
-  schwab-agent option chain AAPL --expiration 2026-06-19 --fields strike,bid,ask,delta
+  schwab-agent option chain AMD --type PUT --strike-range OTM --expiration 2026-06-19 --delta-min -0.25 --delta-max -0.15 --fields strike,delta,bid,ask,mid,openInterest,totalVolume,volatility,daysToExpiration
   schwab-agent option chain AAPL --strike-count 5
   schwab-agent option chain AAPL --strike-min 190 --strike-max 210
 
 Flags:
+      --delta-max float      Maximum option delta (inclusive)
+      --delta-min float      Minimum option delta (inclusive)
       --dte int               Target days to expiration
       --expiration string     Exact expiration date (YYYY-MM-DD)
-      --fields string         Comma-separated field names for column projection
+      --fields string         Comma-separated field names for column projection (e.g., strike, delta, bid, ask, mid, openInterest, totalVolume, volatility, daysToExpiration)
       --order-type string     alias for --type (order type)
       --strike float          Exact strike price
       --strike-count int      Number of strikes around ATM
@@ -2544,4 +2546,3 @@ Global Flags:
       --token string                    Path to token file
   -v, --verbose                         Enable debug logging to stderr
 ```
-

--- a/internal/commands/option_chain.go
+++ b/internal/commands/option_chain.go
@@ -23,6 +23,12 @@ const (
 	// hoursPerDay converts [time.Duration] hours to calendar days.
 	hoursPerDay = 24
 
+	// midpointDivisor averages bid and ask for the agent-facing mid column.
+	midpointDivisor = 2
+
+	// fieldVolatility is the shared JSON/output field name for volatility values.
+	fieldVolatility = "volatility"
+
 	// thirdFridayMinDay and thirdFridayMaxDay bound the calendar days where
 	// the third Friday of a month can fall.
 	thirdFridayMinDay = 15
@@ -53,18 +59,19 @@ var chainDefaultColumns = []string{
 //nolint:gochecknoglobals,goconst // package-level constant slice; field names are clearer inline
 var chainValidFields = []string{
 	"expiry", "strike", "cp", "symbol",
-	"bid", "ask", "mark", "last",
+	"bid", "ask", "mid", "mark", "last",
 	"delta", "gamma", "theta", "vega", "rho",
-	"iv", "oi", "volume", "itm", "dte",
+	"iv", fieldVolatility, "oi", "openInterest", "volume", "totalVolume", "itm", "dte", "daysToExpiration",
 }
 
 // chainRow holds the sort key and extracted field values for a single contract.
 // Sorting happens on expiry+strike+putCall before the row values are emitted.
 type chainRow struct {
-	expiry  string
-	strike  float64
-	putCall string
-	values  []any
+	expiry   string
+	strike   float64
+	putCall  string
+	contract *models.OptionContract
+	values   []any
 }
 
 // flattenChainRows collects all contracts from an OptionChain's CallExpDateMap
@@ -139,10 +146,11 @@ func extractContractRow(c *models.OptionContract, expiry string, columns []strin
 	}
 
 	return chainRow{
-		expiry:  expiry,
-		strike:  strike,
-		putCall: putCall,
-		values:  values,
+		expiry:   expiry,
+		strike:   strike,
+		putCall:  putCall,
+		contract: c,
+		values:   values,
 	}
 }
 
@@ -162,6 +170,8 @@ func contractFieldValue(c *models.OptionContract, field, expiry string) any {
 		return nilableFloat64(c.Bid)
 	case "ask":
 		return nilableFloat64(c.Ask)
+	case "mid":
+		return nilableMidpoint(c.Bid, c.Ask)
 	case "mark":
 		return nilableFloat64(c.Mark)
 	case "last":
@@ -176,17 +186,19 @@ func contractFieldValue(c *models.OptionContract, field, expiry string) any {
 		return nilableFloat64(c.Vega)
 	case "rho":
 		return nilableFloat64(c.Rho)
-	case "iv":
+	case "iv", fieldVolatility:
 		return nilableFloat64(c.Volatility)
-	case "oi":
+	case "oi", "openInterest":
 		return nilableInt64(c.OpenInterest)
-	case "volume":
+	case "volume", "totalVolume":
 		return nilableInt64(c.TotalVolume)
 	case "itm":
 		return nilableBool(c.InTheMoney)
 	case "dte":
 		// Compute DTE from expiry string and current time.
 		return computeDTE(expiry, time.Now())
+	case "daysToExpiration":
+		return nilableInt(c.DaysToExpiration)
 	default:
 		return nil
 	}
@@ -377,6 +389,24 @@ func nilableFloat64(p *float64) any {
 	return *p
 }
 
+// nilableMidpoint returns the bid/ask midpoint when both sides are present.
+// The Schwab chain has a mark field, but issue 139 specifically called out a
+// mid column for agent workflows, so compute the simple spread midpoint here.
+func nilableMidpoint(bid, ask *float64) any {
+	if bid == nil || ask == nil {
+		return nil
+	}
+	return (*bid + *ask) / midpointDivisor
+}
+
+// nilableInt returns *p as any if non-nil, or nil if the pointer is nil.
+func nilableInt(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
 // nilableInt64 returns *p as any if non-nil, or nil if the pointer is nil.
 func nilableInt64(p *int64) any {
 	if p == nil {
@@ -412,11 +442,15 @@ func newOptionChainCmd(ref *client.Ref, w io.Writer) *cobra.Command {
 		Use:   "chain <symbol>",
 		Short: "Get compact option chain for a symbol",
 		Long: `Get a compact option chain with configurable columns, expiration selection,
-and strike filtering. Returns rows sorted by expiration, strike, then call
-before put. Use --dte or --expiration to narrow to one expiration cycle.
-Use --fields to select specific columns.`,
+strike filtering, and delta filtering. Returns rows sorted by expiration,
+strike, then call before put. Use --dte or --expiration to narrow to one
+expiration cycle. Use --delta-min/--delta-max to keep contracts within an
+inclusive raw API delta range, and --fields to select specific columns.`,
 		Example: `  schwab-agent option chain AAPL
   schwab-agent option chain AAPL --type CALL --dte 30
+  schwab-agent option chain AMD --type PUT --strike-range OTM --expiration 2026-06-19 \
+    --delta-min -0.25 --delta-max -0.15 \
+    --fields strike,delta,bid,ask,mid,openInterest,totalVolume,volatility,daysToExpiration
   schwab-agent option chain AAPL --expiration 2026-06-19 --fields strike,bid,ask,delta
   schwab-agent option chain AAPL --strike-count 5
   schwab-agent option chain AAPL --strike-min 190 --strike-max 210`,
@@ -442,6 +476,11 @@ func runOptionChain(
 	opts *optionChainOpts,
 	args []string,
 ) error {
+	// Record zero-sensitive delta flags before validation so --delta-min 0 and
+	// --delta-max 0 filter correctly instead of looking like omitted flags.
+	opts.deltaMinSet = cmd.Flags().Changed("delta-min")
+	opts.deltaMaxSet = cmd.Flags().Changed("delta-max")
+
 	if err := validateCobraOptions(cmd.Context(), opts); err != nil {
 		return err
 	}
@@ -493,6 +532,10 @@ func runOptionChain(
 
 	// Apply local strike selectors after flattening.
 	rows = applyStrikeSelectors(rows, opts, chain)
+
+	// Apply local delta bounds after strike selectors so legacy strike-count
+	// behavior still chooses ATM-adjacent strikes before greek filtering.
+	rows = filterRowsByDelta(rows, opts)
 
 	// Determine expiration label for output. Falls back to the first row's
 	// expiry when no explicit selector was provided.
@@ -627,6 +670,40 @@ func filterRowsByExpiration(rows []chainRow, expiration string) []chainRow {
 		}
 	}
 	return filtered
+}
+
+// filterRowsByDelta keeps rows whose API delta is within the requested bounds.
+// Missing deltas cannot satisfy a delta filter because treating absent greeks as
+// zero would incorrectly include contracts when agents ask for --delta-min 0 or
+// --delta-max 0.
+func filterRowsByDelta(rows []chainRow, opts *optionChainOpts) []chainRow {
+	if !opts.deltaMinSet && !opts.deltaMaxSet {
+		return rows
+	}
+
+	filtered := make([]chainRow, 0, len(rows))
+	for _, r := range rows {
+		if chainRowPassesDelta(r, opts) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+// chainRowPassesDelta applies inclusive delta bounds to one chain row.
+func chainRowPassesDelta(r chainRow, opts *optionChainOpts) bool {
+	if r.contract == nil || r.contract.Delta == nil {
+		return false
+	}
+
+	delta := *r.contract.Delta
+	if opts.deltaMinSet && delta < opts.DeltaMin {
+		return false
+	}
+	if opts.deltaMaxSet && delta > opts.DeltaMax {
+		return false
+	}
+	return true
 }
 
 // applyStrikeSelectors applies local strike filters after flattening.

--- a/internal/commands/option_chain_helpers_test.go
+++ b/internal/commands/option_chain_helpers_test.go
@@ -89,6 +89,22 @@ func TestOptionChainFieldExtractionAndSorting(t *testing.T) {
 	assert.Equal(t, []string{"CALL", "PUT", "CALL"}, []string{rows[0].putCall, rows[1].putCall, rows[2].putCall})
 }
 
+func TestOptionChainAgentFieldAliases(t *testing.T) {
+	contract := fullOptionContractForTest()
+	columns := []string{"mid", "volatility", "openInterest", "totalVolume", "daysToExpiration"}
+
+	row := extractContractRow(contract, "2026-06-19", columns)
+
+	assert.InEpsilon(t, 1.15, row.values[0], 0.0001)
+	assert.InEpsilon(t, 25.0, row.values[1], 0.0001)
+	assert.Equal(t, int64(100), row.values[2])
+	assert.Equal(t, int64(25), row.values[3])
+	assert.Equal(t, 42, row.values[4])
+
+	missingSide := &models.OptionContract{Bid: new(1.0)}
+	assert.Nil(t, contractFieldValue(missingSide, "mid", "2026-06-19"))
+}
+
 func TestOptionChainExpirationHelpers(t *testing.T) {
 	chain := &models.OptionChain{
 		CallExpDateMap: map[string]map[string][]*models.OptionContract{
@@ -175,6 +191,35 @@ func TestOptionChainStrikeFilters(t *testing.T) {
 	assert.Equal(t, rows, applyStrikeSelectors(rows, &optionChainOpts{StrikeRange: strikeRangeNTM}, chain))
 }
 
+func TestOptionChainDeltaFilters(t *testing.T) {
+	rows := []chainRow{
+		{strike: 90, contract: &models.OptionContract{Delta: new(-0.30)}},
+		{strike: 92, contract: &models.OptionContract{Delta: new(-0.25)}},
+		{strike: 95, contract: &models.OptionContract{Delta: new(-0.20)}},
+		{strike: 98, contract: &models.OptionContract{Delta: new(-0.15)}},
+		{strike: 100, contract: &models.OptionContract{Delta: new(-0.10)}},
+		{strike: 105, contract: &models.OptionContract{}},
+	}
+
+	assert.Equal(t, rows, filterRowsByDelta(rows, &optionChainOpts{}))
+
+	filtered := filterRowsByDelta(rows, &optionChainOpts{
+		DeltaMin:    -0.25,
+		DeltaMax:    -0.15,
+		deltaMinSet: true,
+		deltaMaxSet: true,
+	})
+	require.Len(t, filtered, 3)
+	assert.Equal(t, []float64{92, 95, 98}, []float64{filtered[0].strike, filtered[1].strike, filtered[2].strike})
+
+	zeroFiltered := filterRowsByDelta([]chainRow{
+		{strike: 100, contract: &models.OptionContract{Delta: new(0.0)}},
+		{strike: 105, contract: &models.OptionContract{Delta: new(0.10)}},
+	}, &optionChainOpts{DeltaMax: 0, deltaMaxSet: true})
+	require.Len(t, zeroFiltered, 1)
+	assert.InEpsilon(t, 100.0, zeroFiltered[0].strike, 0.0001)
+}
+
 func TestPorcelainChainParams(t *testing.T) {
 	params := porcelainChainParams("AAPL", &optionChainOpts{
 		Type:        chainContractTypeCall,
@@ -200,6 +245,10 @@ func TestOptionChainOptsValidationAdditionalConflicts(t *testing.T) {
 	}{
 		{name: "invalid type", opts: optionChainOpts{Type: chainContractType("BAD")}},
 		{name: "dte expiration", opts: optionChainOpts{DTE: 30, Expiration: "2026-06-19"}},
+		{
+			name: "delta min greater than max",
+			opts: optionChainOpts{DeltaMin: 0.5, DeltaMax: 0.2, deltaMinSet: true, deltaMaxSet: true},
+		},
 		{name: "negative count", opts: optionChainOpts{StrikeCount: -1}},
 		{name: "count min", opts: optionChainOpts{StrikeCount: 2, StrikeMin: 100}},
 		{name: "strike combined", opts: optionChainOpts{Strike: 100, StrikeRange: strikeRangeNTM}},
@@ -258,26 +307,28 @@ func fullOptionContractForTest() *models.OptionContract {
 	vega := 0.3
 	rho := 0.4
 	iv := 25.0
+	daysToExpiration := 42
 	openInterest := int64(100)
 	volume := int64(25)
 	inTheMoney := true
 
 	return &models.OptionContract{
-		Symbol:       &symbol,
-		PutCall:      &putCall,
-		StrikePrice:  &strike,
-		Bid:          &bid,
-		Ask:          &ask,
-		Mark:         &mark,
-		Last:         &last,
-		Delta:        &delta,
-		Gamma:        &gamma,
-		Theta:        &theta,
-		Vega:         &vega,
-		Rho:          &rho,
-		Volatility:   &iv,
-		OpenInterest: &openInterest,
-		TotalVolume:  &volume,
-		InTheMoney:   &inTheMoney,
+		Symbol:           &symbol,
+		PutCall:          &putCall,
+		StrikePrice:      &strike,
+		Bid:              &bid,
+		Ask:              &ask,
+		Mark:             &mark,
+		Last:             &last,
+		Delta:            &delta,
+		Gamma:            &gamma,
+		Theta:            &theta,
+		Vega:             &vega,
+		Rho:              &rho,
+		Volatility:       &iv,
+		DaysToExpiration: &daysToExpiration,
+		OpenInterest:     &openInterest,
+		TotalVolume:      &volume,
+		InTheMoney:       &inTheMoney,
 	}
 }

--- a/internal/commands/option_chain_opts.go
+++ b/internal/commands/option_chain_opts.go
@@ -10,16 +10,25 @@ import (
 // optionChainOpts holds the flags for the porcelain option chain command.
 // Struct tags drive defineCobraFlags registration. Type and StrikeRange use
 // named enum types so Cobra validates allowed values at flag-parse time.
+//
+// The *Set fields are not flags; they track whether the corresponding flag was
+// explicitly provided via cmd.Flags().Changed(). Delta=0 is meaningful for far
+// OTM contracts, so a zero-valued bound cannot also mean "unset".
 type optionChainOpts struct {
 	Type        chainContractType `flag:"type"         flagdescr:"Contract type: CALL, PUT, or ALL"                    default:"ALL"`
 	DTE         int               `flag:"dte"          flagdescr:"Target days to expiration"`
 	Expiration  string            `flag:"expiration"   flagdescr:"Exact expiration date (YYYY-MM-DD)"`
+	DeltaMin    float64           `flag:"delta-min"    flagdescr:"Minimum delta (raw API value; puts are negative)"`
+	DeltaMax    float64           `flag:"delta-max"    flagdescr:"Maximum delta (raw API value; puts are negative)"`
 	Fields      string            `flag:"fields"       flagdescr:"Comma-separated field names for column projection"`
 	StrikeCount int               `flag:"strike-count" flagdescr:"Number of strikes around ATM"`
 	Strike      float64           `flag:"strike"       flagdescr:"Exact strike price"`
 	StrikeMin   float64           `flag:"strike-min"   flagdescr:"Minimum strike price"`
 	StrikeMax   float64           `flag:"strike-max"   flagdescr:"Maximum strike price"`
 	StrikeRange strikeRange       `flag:"strike-range" flagdescr:"Moneyness filter: ITM, NTM, OTM, SAK, SBK, SNK, ALL"`
+
+	deltaMinSet bool
+	deltaMaxSet bool
 }
 
 // Validate implements cobraValidatable so validateCobraOptions can delegate
@@ -69,6 +78,14 @@ func validateOptionChainOpts(opts *optionChainOpts) []error {
 	if opts.DTE > 0 && opts.Expiration != "" {
 		errs = append(errs, apperr.NewValidationError(
 			"dte and expiration are mutually exclusive; use one or the other", nil,
+		))
+	}
+
+	// DeltaMin must not exceed DeltaMax when both bounds are explicitly set.
+	// For puts, delta values are negative: delta-min=-0.30, delta-max=-0.20 is valid.
+	if opts.deltaMinSet && opts.deltaMaxSet && opts.DeltaMin > opts.DeltaMax {
+		errs = append(errs, apperr.NewValidationError(
+			fmt.Sprintf("delta-min (%g) must be <= delta-max (%g)", opts.DeltaMin, opts.DeltaMax), nil,
 		))
 	}
 

--- a/internal/commands/option_chain_test.go
+++ b/internal/commands/option_chain_test.go
@@ -435,9 +435,9 @@ func TestOptionChainFieldProjection(t *testing.T) {
 	// validFields is the allowlist from the design doc.
 	validFields := []string{
 		"expiry", "strike", "cp", "symbol",
-		"bid", "ask", "mark", "last",
+		"bid", "ask", "mid", "mark", "last",
 		"delta", "gamma", "theta", "vega", "rho",
-		"iv", "oi", "volume", "itm", "dte",
+		"iv", "volatility", "oi", "openInterest", "volume", "totalVolume", "itm", "dte", "daysToExpiration",
 	}
 
 	tests := []struct {
@@ -767,5 +767,181 @@ func TestOptionChainCommand(t *testing.T) {
 
 		// Assert
 		require.NoError(t, err)
+	})
+
+	t.Run("delta filters combine with type range expiration and custom fields", func(t *testing.T) {
+		// Arrange - mock server verifies server-side narrowing flags while the
+		// command applies delta filtering locally after compact row projection.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if r.URL.Path == "/marketdata/v1/chains" {
+				assert.Equal(t, "AMD", r.URL.Query().Get("symbol"))
+				assert.Equal(t, "PUT", r.URL.Query().Get("contractType"))
+				assert.Equal(t, "OTM", r.URL.Query().Get("range"))
+				assert.Equal(t, "2026-06-19", r.URL.Query().Get("fromDate"))
+				assert.Equal(t, "2026-06-19", r.URL.Query().Get("toDate"))
+
+				body := chainAPIResponse(100.0,
+					nil,
+					map[string]map[string][]*models.OptionContract{
+						"2026-06-19:43": {
+							"90.0": {{
+								PutCall: new("PUT"), Symbol: new("AMD   260619P00090000"),
+								ExpirationDate: new("2026-06-19"), StrikePrice: new(90.0), DaysToExpiration: new(43),
+								Bid: new(1.0), Ask: new(1.2), Delta: new(-0.30), Volatility: new(0.42),
+								OpenInterest: new(int64(100)), TotalVolume: new(int64(20)),
+							}},
+							"92.0": {{
+								PutCall: new("PUT"), Symbol: new("AMD   260619P00092000"),
+								ExpirationDate: new("2026-06-19"), StrikePrice: new(92.0), DaysToExpiration: new(43),
+								Bid: new(1.2), Ask: new(1.4), Delta: new(-0.25), Volatility: new(0.41),
+								OpenInterest: new(int64(150)), TotalVolume: new(int64(25)),
+							}},
+							"95.0": {{
+								PutCall: new("PUT"), Symbol: new("AMD   260619P00095000"),
+								ExpirationDate: new("2026-06-19"), StrikePrice: new(95.0), DaysToExpiration: new(43),
+								Bid: new(1.5), Ask: new(1.7), Delta: new(-0.20), Volatility: new(0.40),
+								OpenInterest: new(int64(200)), TotalVolume: new(int64(30)),
+							}},
+							"96.0": {{
+								PutCall: new("PUT"), Symbol: new("AMD   260619P00096000"),
+								ExpirationDate: new("2026-06-19"), StrikePrice: new(96.0), DaysToExpiration: new(43),
+								Bid: new(1.8), Ask: new(2.0), Delta: new(-0.15), Volatility: new(0.39),
+								OpenInterest: new(int64(250)), TotalVolume: new(int64(35)),
+							}},
+							"97.0": {{
+								PutCall: new("PUT"), Symbol: new("AMD   260619P00097000"),
+								ExpirationDate: new("2026-06-19"), StrikePrice: new(97.0), DaysToExpiration: new(43),
+								Bid: new(2.0), Ask: new(2.2), Delta: new(-0.10), Volatility: new(0.38),
+								OpenInterest: new(int64(300)), TotalVolume: new(int64(40)),
+							}},
+							"99.0": {{
+								PutCall: new("PUT"), Symbol: new("AMD   260619P00099000"),
+								ExpirationDate: new("2026-06-19"), StrikePrice: new(99.0), DaysToExpiration: new(43),
+								Bid: new(2.5), Ask: new(2.7), Volatility: new(0.36),
+								OpenInterest: new(int64(400)), TotalVolume: new(int64(50)),
+							}},
+						},
+					},
+				)
+				_, _ = w.Write([]byte(body))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		var buf bytes.Buffer
+		cmd := NewOptionCmd(testClient(t, server), &buf)
+
+		// Act
+		_, err := runTestCommand(
+			t,
+			cmd,
+			"chain", "AMD",
+			"--type", "PUT",
+			"--strike-range", "OTM",
+			"--expiration", "2026-06-19",
+			"--delta-min", "-0.25",
+			"--delta-max", "-0.15",
+			"--fields", "strike,delta,bid,ask,mid,openInterest,totalVolume,volatility,daysToExpiration",
+		)
+
+		// Assert
+		require.NoError(t, err)
+
+		var envelope output.Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+		data, ok := envelope.Data.(map[string]any)
+		require.True(t, ok)
+
+		assert.Equal(
+			t,
+			[]any{
+				"strike", "delta", "bid", "ask", "mid",
+				"openInterest", "totalVolume", "volatility", "daysToExpiration",
+			},
+			data["columns"],
+		)
+
+		rows, ok := data["rows"].([]any)
+		require.True(t, ok)
+		require.Len(t, rows, 3)
+		row, ok := rows[1].([]any)
+		require.True(t, ok)
+		assert.Equal(
+			t,
+			[]any{95.0, -0.20, 1.5, 1.7, 1.6, float64(200), float64(30), 0.40, float64(43)},
+			row,
+		)
+
+		firstRow, ok := rows[0].([]any)
+		require.True(t, ok)
+		lastRow, ok := rows[2].([]any)
+		require.True(t, ok)
+		assert.InEpsilon(t, -0.25, firstRow[1], 0.0001)
+		assert.InEpsilon(t, -0.15, lastRow[1], 0.0001)
+		assert.Equal(t, 3, envelope.Metadata.Returned)
+	})
+
+	t.Run("delta zero bound is honored", func(t *testing.T) {
+		// Arrange - --delta-max 0 should keep only non-positive deltas. This
+		// proves zero is an explicit bound, not the default unset value.
+		body := chainAPIResponse(100.0,
+			map[string]map[string][]*models.OptionContract{
+				"2026-06-19:43": {
+					"100.0": {{
+						PutCall:     new("CALL"),
+						Symbol:      new("AAPL  260619C00100000"),
+						StrikePrice: new(100.0),
+						Delta:       new(0.0),
+					}},
+					"105.0": {{
+						PutCall:     new("CALL"),
+						Symbol:      new("AAPL  260619C00105000"),
+						StrikePrice: new(105.0),
+						Delta:       new(0.10),
+					}},
+				},
+			},
+			nil,
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+		defer server.Close()
+
+		var buf bytes.Buffer
+		cmd := NewOptionCmd(testClient(t, server), &buf)
+
+		// Act
+		_, err := runTestCommand(t, cmd, "chain", "AAPL", "--delta-max", "0", "--fields", "strike,delta")
+
+		// Assert
+		require.NoError(t, err)
+		var envelope output.Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+		data, ok := envelope.Data.(map[string]any)
+		require.True(t, ok)
+		rows, ok := data["rows"].([]any)
+		require.True(t, ok)
+		require.Len(t, rows, 1)
+	})
+
+	t.Run("delta min greater than max fails validation", func(t *testing.T) {
+		// Arrange
+		server := jsonServer(`{}`)
+		defer server.Close()
+
+		var buf bytes.Buffer
+		cmd := NewOptionCmd(testClient(t, server), &buf)
+
+		// Act
+		_, err := runTestCommand(t, cmd, "chain", "AAPL", "--delta-min", "0.50", "--delta-max", "0.20")
+
+		// Assert
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delta-min (0.5) must be <= delta-max (0.2)")
 	})
 }

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -1006,7 +1006,7 @@ func dashboardSignals(latest map[string]any) (map[string]any, error) {
 	return map[string]any{
 		"trend":                   trendSignal(closePrice, sma21, sma50, sma200),
 		"momentum":                momentumSignal(rsi14, macdHist),
-		"volatility":              volatilitySignal(atrPercent),
+		fieldVolatility:           volatilitySignal(atrPercent),
 		dashboardKeyVolume:        volumeSignal(relativeVolume),
 		"close_above_sma_21":      closePrice > sma21,
 		"close_above_sma_50":      closePrice > sma50,

--- a/llms.txt
+++ b/llms.txt
@@ -813,14 +813,16 @@ Usage:
 Examples:
   schwab-agent option chain AAPL
   schwab-agent option chain AAPL --type CALL --dte 30
-  schwab-agent option chain AAPL --expiration 2026-06-19 --fields strike,bid,ask,delta
+  schwab-agent option chain AMD --type PUT --strike-range OTM --expiration 2026-06-19 --delta-min -0.25 --delta-max -0.15 --fields strike,delta,bid,ask,mid,openInterest,totalVolume,volatility,daysToExpiration
   schwab-agent option chain AAPL --strike-count 5
   schwab-agent option chain AAPL --strike-min 190 --strike-max 210
 
 Flags:
+      --delta-max float      Maximum option delta (inclusive)
+      --delta-min float      Minimum option delta (inclusive)
       --dte int               Target days to expiration
       --expiration string     Exact expiration date (YYYY-MM-DD)
-      --fields string         Comma-separated field names for column projection
+      --fields string         Comma-separated field names for column projection (e.g., strike, delta, bid, ask, mid, openInterest, totalVolume, volatility, daysToExpiration)
       --order-type string     alias for --type (order type)
       --strike float          Exact strike price
       --strike-count int      Number of strikes around ATM
@@ -2598,4 +2600,3 @@ Global Flags:
       --token string                    Path to token file
   -v, --verbose                         Enable debug logging to stderr
 ```
-

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -316,7 +316,10 @@ run_help_contains_test "order preview equity shows save-preview flag" "--save-pr
 run_help_contains_test "order place shows from-preview flag" "--from-preview" order place
 
 run_help_contains_test "option chain shows --dte flag" "--dte" option chain
+run_help_contains_test "option chain shows --delta-min flag" "--delta-min" option chain
+run_help_contains_test "option chain shows --delta-max flag" "--delta-max" option chain
 run_help_contains_test "option chain shows --fields flag" "--fields" option chain
+run_help_contains_test "option chain shows compact delta example" "--fields strike,delta,bid,ask,mid,openInterest,totalVolume,volatility,daysToExpiration" option chain
 run_help_contains_test "option chain shows --strike-count flag" "--strike-count" option chain
 run_help_contains_test "option contract shows --expiration flag" "--expiration" option contract
 run_help_contains_test "option contract shows --call flag" "--call" option contract


### PR DESCRIPTION
## Summary
- Add `option chain --delta-min` and `--delta-max` for inclusive local delta filtering, with explicit zero-bound handling and missing-delta exclusion.
- Add compact agent-friendly field aliases: `mid`, `openInterest`, `totalVolume`, `volatility`, and `daysToExpiration`.
- Update command docs, agent references, smoke help checks, and option-chain tests for combined filters.

Closes #139.

## Verification
- `go test ./...`
- `make lint`
- `make build`
- `HOME=/tmp/schwab-agent-smoke-home make smoke-ci`
- `coderabbit review --agent --base origin/main -c .coderabbit.yaml`
- Oracle/post-implementation review: PASS, no blockers