### PR TITLE
Fix expected-move output fields and rounding

### DIFF
--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -103,19 +103,28 @@ type hvOutput struct {
 	MeanVol        float64 `json:"mean_vol"`
 }
 
+type expectedMoveRange struct {
+	Lower float64 `json:"lower"`
+	Upper float64 `json:"upper"`
+}
+
 type expectedMoveOutput struct {
-	Indicator       string  `json:"indicator"`
-	Symbol          string  `json:"symbol"`
-	UnderlyingPrice float64 `json:"underlying_price"`
-	Expiration      string  `json:"expiration"`
-	DTE             int     `json:"dte"`
-	StraddlePrice   float64 `json:"straddle_price"`
-	ExpectedMove    float64 `json:"expected_move"`
-	AdjustedMove    float64 `json:"adjusted_move"`
-	Upper1x         float64 `json:"upper_1x"`
-	Lower1x         float64 `json:"lower_1x"`
-	Upper2x         float64 `json:"upper_2x"`
-	Lower2x         float64 `json:"lower_2x"`
+	Indicator        string                       `json:"indicator"`
+	Symbol           string                       `json:"symbol"`
+	UnderlyingPrice  float64                      `json:"underlying_price"`
+	Expiration       string                       `json:"expiration"`
+	DTE              int                          `json:"dte"`
+	StraddlePrice    float64                      `json:"straddle_price"`
+	ExpectedMove     float64                      `json:"expected_move"`
+	ExpectedMovePct  float64                      `json:"expected_move_pct"`
+	AdjustedMove     float64                      `json:"adjusted_move"`
+	AdjustmentMethod string                       `json:"adjustment_method"`
+	CurrentIV        float64                      `json:"current_iv,omitempty"`
+	Ranges           map[string]expectedMoveRange `json:"ranges"`
+	Upper1x          float64                      `json:"upper_1x"`
+	Lower1x          float64                      `json:"lower_1x"`
+	Upper2x          float64                      `json:"upper_2x"`
+	Lower2x          float64                      `json:"lower_2x"`
 }
 
 type dashboardParameters struct {
@@ -200,6 +209,7 @@ const (
 	percentMultiplier             = 100.0
 	expectedMoveExpirationParts   = 2
 	quoteMidpointDivisor          = 2.0
+	roundingEpsilon               = 1e-9
 )
 
 // taOutput is the common envelope for single-value time series indicators (SMA, EMA, RSI, etc.).
@@ -1495,8 +1505,9 @@ func cobraTAExpectedMoveCommand(c *client.Ref, w io.Writer) *cobra.Command {
 		short: "Expected price move from ATM straddle pricing",
 		long: `Compute expected price move from ATM straddle pricing. Fetches the option
 chain, finds the nearest expiration to --dte (default 30), and prices the
-ATM straddle. Output includes 1x and 2x standard deviation ranges (upper
-and lower bounds).`,
+ATM straddle. The raw expected move is the straddle price. The adjusted move
+applies the standard 0.85x multiplier used by many options desks before
+building the 1x and 2x range bounds.`,
 		example: `  schwab-agent ta expected-move AAPL
   schwab-agent ta expected-move AAPL --dte 45`,
 		newOpts: func() *expectedMoveOpts { return &expectedMoveOpts{} },
@@ -1573,20 +1584,54 @@ func buildExpectedMoveOutput(
 	}
 
 	actualDTE, _ := strconv.Atoi(expParts[1])
+	ranges := map[string]expectedMoveRange{
+		"1x": {Lower: result.Lower1x, Upper: result.Upper1x},
+		"2x": {Lower: result.Lower2x, Upper: result.Upper2x},
+	}
+	currentIV := expectedMoveCurrentIV(callContracts[0], putContracts[0])
+	adjustmentMethod := fmt.Sprintf("raw ATM straddle price multiplied by %.2fx", ta.DefaultMultiplier)
+
 	return expectedMoveOutput{
-		Indicator:       "expected-move",
-		Symbol:          symbol,
-		UnderlyingPrice: underlyingPrice,
-		Expiration:      expDate,
-		DTE:             actualDTE,
-		StraddlePrice:   result.StraddlePrice,
-		ExpectedMove:    result.ExpectedMove,
-		AdjustedMove:    result.AdjustedMove,
-		Upper1x:         result.Upper1x,
-		Lower1x:         result.Lower1x,
-		Upper2x:         result.Upper2x,
-		Lower2x:         result.Lower2x,
+		Indicator:        "expected-move",
+		Symbol:           symbol,
+		UnderlyingPrice:  round2(underlyingPrice),
+		Expiration:       expDate,
+		DTE:              actualDTE,
+		StraddlePrice:    result.StraddlePrice,
+		ExpectedMove:     result.ExpectedMove,
+		ExpectedMovePct:  result.ExpectedMovePct,
+		AdjustedMove:     result.AdjustedMove,
+		AdjustmentMethod: adjustmentMethod,
+		CurrentIV:        currentIV,
+		Ranges:           ranges,
+		Upper1x:          result.Upper1x,
+		Lower1x:          result.Lower1x,
+		Upper2x:          result.Upper2x,
+		Lower2x:          result.Lower2x,
 	}, nil
+}
+
+func expectedMoveCurrentIV(callContract, putContract marketdata.OptionContract) float64 {
+	var vols []float64
+	if callContract.Volatility > 0 {
+		vols = append(vols, callContract.Volatility)
+	}
+	if putContract.Volatility > 0 {
+		vols = append(vols, putContract.Volatility)
+	}
+	if len(vols) == 0 {
+		return 0
+	}
+
+	total := 0.0
+	for _, vol := range vols {
+		total += vol
+	}
+	return round2(total / float64(len(vols)))
+}
+
+func round2(v float64) float64 {
+	return math.Round((v+roundingEpsilon)*percentMultiplier) / percentMultiplier
 }
 
 func expectedMoveUnderlyingPrice(chain *marketdata.OptionChain, symbol string) (float64, error) {

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -130,16 +130,16 @@ func mockOptionChainJSON(symbol string) string {
 		"underlyingPrice": 150.0,
 		"callExpDateMap": {
 			"2025-06-20:30": {
-				"148.0": [{"markPrice": 7.0, "bidPrice": 6.9, "askPrice": 7.1, "strikePrice": 148.0, "daysToExpiration": 30, "inTheMoney": true}],
-				"150.0": [{"markPrice": 5.0, "bidPrice": 4.9, "askPrice": 5.1, "strikePrice": 150.0, "daysToExpiration": 30, "inTheMoney": false}],
-				"152.0": [{"markPrice": 3.0, "bidPrice": 2.9, "askPrice": 3.1, "strikePrice": 152.0, "daysToExpiration": 30, "inTheMoney": false}]
+				"148.0": [{"markPrice": 7.0, "bidPrice": 6.9, "askPrice": 7.1, "strikePrice": 148.0, "daysToExpiration": 30, "volatility": 0.29, "inTheMoney": true}],
+				"150.0": [{"markPrice": 5.0, "bidPrice": 4.9, "askPrice": 5.1, "strikePrice": 150.0, "daysToExpiration": 30, "volatility": 0.31, "inTheMoney": false}],
+				"152.0": [{"markPrice": 3.0, "bidPrice": 2.9, "askPrice": 3.1, "strikePrice": 152.0, "daysToExpiration": 30, "volatility": 0.33, "inTheMoney": false}]
 			}
 		},
 		"putExpDateMap": {
 			"2025-06-20:30": {
-				"148.0": [{"markPrice": 2.5, "bidPrice": 2.4, "askPrice": 2.6, "strikePrice": 148.0, "daysToExpiration": 30, "inTheMoney": false}],
-				"150.0": [{"markPrice": 4.5, "bidPrice": 4.4, "askPrice": 4.6, "strikePrice": 150.0, "daysToExpiration": 30, "inTheMoney": false}],
-				"152.0": [{"markPrice": 6.5, "bidPrice": 6.4, "askPrice": 6.6, "strikePrice": 152.0, "daysToExpiration": 30, "inTheMoney": true}]
+				"148.0": [{"markPrice": 2.5, "bidPrice": 2.4, "askPrice": 2.6, "strikePrice": 148.0, "daysToExpiration": 30, "volatility": 0.30, "inTheMoney": false}],
+				"150.0": [{"markPrice": 4.5, "bidPrice": 4.4, "askPrice": 4.6, "strikePrice": 150.0, "daysToExpiration": 30, "volatility": 0.35, "inTheMoney": false}],
+				"152.0": [{"markPrice": 6.5, "bidPrice": 6.4, "askPrice": 6.6, "strikePrice": 152.0, "daysToExpiration": 30, "volatility": 0.34, "inTheMoney": true}]
 			}
 		}
 	}`, symbol)
@@ -1362,13 +1362,35 @@ func TestTAExpectedMove_ValidEnvelope(t *testing.T) {
 	assert.Contains(t, data, "dte")
 	assert.Contains(t, data, "straddle_price")
 	assert.Contains(t, data, "expected_move")
+	assert.Contains(t, data, "expected_move_pct")
 	assert.Contains(t, data, "adjusted_move")
+	assert.Contains(t, data, "adjustment_method")
+	assert.Contains(t, data, "current_iv")
+	assert.Contains(t, data, "ranges")
 	assert.Contains(t, data, "upper_1x")
 	assert.Contains(t, data, "lower_1x")
 	assert.Contains(t, data, "upper_2x")
 	assert.Contains(t, data, "lower_2x")
 	assert.InDelta(t, 9.5, data["straddle_price"], 0.01)
-	assert.InDelta(t, 8.075, data["adjusted_move"], 0.01)
+	assert.InDelta(t, 6.33, data["expected_move_pct"], 0.01)
+	assert.InDelta(t, 8.08, data["adjusted_move"], 0.01)
+	assert.Equal(t, "raw ATM straddle price multiplied by 0.85x", data["adjustment_method"])
+	assert.InDelta(t, 0.33, data["current_iv"], 0.01)
+
+	ranges, ok := data["ranges"].(map[string]any)
+	require.True(t, ok, "ranges should decode as a JSON object")
+	range1x, ok := ranges["1x"].(map[string]any)
+	require.True(t, ok, "ranges.1x should decode as a JSON object")
+	range2x, ok := ranges["2x"].(map[string]any)
+	require.True(t, ok, "ranges.2x should decode as a JSON object")
+	assert.InDelta(t, 141.93, range1x["lower"], 0.01)
+	assert.InDelta(t, 158.08, range1x["upper"], 0.01)
+	assert.InDelta(t, 133.85, range2x["lower"], 0.01)
+	assert.InDelta(t, 166.15, range2x["upper"], 0.01)
+	assert.InDelta(t, data["lower_1x"], range1x["lower"], 0.01)
+	assert.InDelta(t, data["upper_1x"], range1x["upper"], 0.01)
+	assert.InDelta(t, data["lower_2x"], range2x["lower"], 0.01)
+	assert.InDelta(t, data["upper_2x"], range2x["upper"], 0.01)
 }
 
 func TestTAExpectedMove_WithDTE(t *testing.T) {

--- a/internal/ta/expected_move.go
+++ b/internal/ta/expected_move.go
@@ -2,6 +2,7 @@ package ta
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/major/schwab-agent/internal/apperr"
 )
@@ -9,17 +10,23 @@ import (
 // DefaultMultiplier is the default straddle price adjustment factor.
 const DefaultMultiplier = 0.85
 
-const expectedMoveOuterBandMultiplier = 2.0
+const (
+	expectedMoveOuterBandMultiplier = 2.0
+	expectedMovePercentMultiplier   = 100.0
+	roundPrecision                  = 100.0
+	roundingEpsilon                 = 1e-9
+)
 
 // ExpectedMoveResult contains the calculated expected move values.
 type ExpectedMoveResult struct {
-	StraddlePrice float64 `json:"straddle_price"`
-	ExpectedMove  float64 `json:"expected_move"`
-	AdjustedMove  float64 `json:"adjusted_move"`
-	Upper1x       float64 `json:"upper_1x"`
-	Lower1x       float64 `json:"lower_1x"`
-	Upper2x       float64 `json:"upper_2x"`
-	Lower2x       float64 `json:"lower_2x"`
+	StraddlePrice   float64 `json:"straddle_price"`
+	ExpectedMove    float64 `json:"expected_move"`
+	ExpectedMovePct float64 `json:"expected_move_pct"`
+	AdjustedMove    float64 `json:"adjusted_move"`
+	Upper1x         float64 `json:"upper_1x"`
+	Lower1x         float64 `json:"lower_1x"`
+	Upper2x         float64 `json:"upper_2x"`
+	Lower2x         float64 `json:"lower_2x"`
 }
 
 // ExpectedMove calculates the expected move based on option prices and a multiplier.
@@ -73,12 +80,19 @@ func ExpectedMove(underlyingPrice, callPrice, putPrice, multiplier float64) (*Ex
 	lower2x := underlyingPrice - (expectedMoveOuterBandMultiplier * adjustedMove)
 
 	return &ExpectedMoveResult{
-		StraddlePrice: straddle,
-		ExpectedMove:  straddle,
-		AdjustedMove:  adjustedMove,
-		Upper1x:       upper1x,
-		Lower1x:       lower1x,
-		Upper2x:       upper2x,
-		Lower2x:       lower2x,
+		StraddlePrice: round2(straddle),
+		// ExpectedMove intentionally mirrors the raw ATM straddle price for API
+		// compatibility. AdjustedMove carries the 0.85x desk-practice multiplier.
+		ExpectedMove:    round2(straddle),
+		ExpectedMovePct: round2((straddle / underlyingPrice) * expectedMovePercentMultiplier),
+		AdjustedMove:    round2(adjustedMove),
+		Upper1x:         round2(upper1x),
+		Lower1x:         round2(lower1x),
+		Upper2x:         round2(upper2x),
+		Lower2x:         round2(lower2x),
 	}, nil
+}
+
+func round2(v float64) float64 {
+	return math.Round((v+roundingEpsilon)*roundPrecision) / roundPrecision
 }

--- a/internal/ta/expected_move_test.go
+++ b/internal/ta/expected_move_test.go
@@ -23,9 +23,10 @@ func TestExpectedMove_Correct(t *testing.T) {
 	require.NoError(t, err)
 	assert.InDelta(t, 9.50, result.StraddlePrice, 0.001)
 	assert.InDelta(t, 9.50, result.ExpectedMove, 0.001)
-	assert.InDelta(t, 8.075, result.AdjustedMove, 0.001)
-	assert.InDelta(t, 158.075, result.Upper1x, 0.001)
-	assert.InDelta(t, 141.925, result.Lower1x, 0.001)
+	assert.InDelta(t, 6.33, result.ExpectedMovePct, 0.001)
+	assert.InDelta(t, 8.08, result.AdjustedMove, 0.001)
+	assert.InDelta(t, 158.08, result.Upper1x, 0.001)
+	assert.InDelta(t, 141.93, result.Lower1x, 0.001)
 	assert.InDelta(t, 166.15, result.Upper2x, 0.001)
 	assert.InDelta(t, 133.85, result.Lower2x, 0.001)
 }


### PR DESCRIPTION
## Summary
- Round `ta expected-move` output values to 2 decimals.
- Add `expected_move_pct`, `adjustment_method`, `current_iv`, and grouped `ranges` output.
- Keep legacy flat range fields and test them against the grouped ranges.

Fixes #140

## Test plan
- `coderabbit review --agent --base origin/main -c .coderabbit.yaml`
- `go test ./...`
- `go build ./...`
- `golangci-lint run ./...`