### PR TITLE
fix(order): round preview commission and fee totals to 2 decimal places

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/major/schwab-agent
 go 1.26.3
 
 require (
-	github.com/major/schwab-go v0.4.2
+	github.com/major/schwab-go v0.4.3-0.20260509021009-43d263892607
 	github.com/markcheno/go-talib v0.0.0-20250114000313-ec55a20c902f
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/major/schwab-go v0.4.2 h1:/8szMpgh39Q9njFYIIrNFZQorTe+728D3EEKdynfqsI=
 github.com/major/schwab-go v0.4.2/go.mod h1:YcQsncMJcvEJJDqtgwTQAuAk3nawkPlFZJSD16BQpao=
+github.com/major/schwab-go v0.4.3-0.20260509021009-43d263892607 h1:kBj+ftUxV7RtxWqoHF9aPfoBNng+ssD9MbmhVW1zPLo=
+github.com/major/schwab-go v0.4.3-0.20260509021009-43d263892607/go.mod h1:YcQsncMJcvEJJDqtgwTQAuAk3nawkPlFZJSD16BQpao=
 github.com/markcheno/go-talib v0.0.0-20250114000313-ec55a20c902f h1:iKq//xEUUaeRoXNcAshpK4W8eSm7HtgI0aNznWtX7lk=
 github.com/markcheno/go-talib v0.0.0-20250114000313-ec55a20c902f/go.mod h1:3YUtoVrKWu2ql+iAeRyepSz3fy6a+19hJzGS88+u4u0=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=

--- a/internal/commands/order_place.go
+++ b/internal/commands/order_place.go
@@ -368,7 +368,7 @@ func totalCommissionValues(detail *models.CommissionDetail) float64 {
 			total += *value.Value
 		}
 	}
-	return total
+	return round2(total)
 }
 
 func totalFeeValues(detail *models.FeeDetail) float64 {
@@ -381,7 +381,7 @@ func totalFeeValues(detail *models.FeeDetail) float64 {
 			total += *value.Value
 		}
 	}
-	return total
+	return round2(total)
 }
 
 func effectiveConfigFlag(cmd *cobra.Command, fallback string) (string, error) {


### PR DESCRIPTION
## Summary

- Round `totalCommission` and `totalFees` to 2 decimal places after summing per-leg values, eliminating float noise like `1.9500000000000002`
- Bump `schwab-go` to pick up the `deliverableUnits` type fix (schwab-go#67), unblocking `ta expected-move`

Closes #146