### PR TITLE
Accept mid alias in option screen fields

### DIFF
--- a/internal/commands/option_screen.go
+++ b/internal/commands/option_screen.go
@@ -53,7 +53,7 @@ var screenDefaultColumns = []string{
 //nolint:gochecknoglobals,goconst // package-level constant slice; field names are clearer inline
 var screenValidFields = []string{
 	"expiry", "strike", "cp", "symbol",
-	"bid", "ask", "mark", "last",
+	"bid", "ask", "mid", "mark", "last",
 	"delta", "gamma", "theta", "vega", "rho",
 	"iv", "oi", "volume", "itm", fieldDTE,
 	fieldSpreadPct,
@@ -255,7 +255,22 @@ func resolveScreenColumns(fieldsFlag string) ([]string, error) {
 		}
 	}
 
-	return fields, nil
+	// option chain accepts both mark and mid. Screen exposes the Schwab mark
+	// price for either spelling so agent workflows can reuse chain projections
+	// and still receive identical output from --fields ...,mark and ...,mid.
+	normalizedFields := make([]string, 0, len(fields))
+	seenFields := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		if f == "mid" {
+			f = "mark"
+		}
+		if !seenFields[f] {
+			normalizedFields = append(normalizedFields, f)
+			seenFields[f] = true
+		}
+	}
+
+	return normalizedFields, nil
 }
 
 // buildScreenRows collects all contracts from a chain, computing DTE and

--- a/internal/commands/option_screen_test.go
+++ b/internal/commands/option_screen_test.go
@@ -549,6 +549,62 @@ func TestOptionScreenCommand(t *testing.T) {
 		assert.Len(t, row, 4)
 	})
 
+	t.Run("mid field aliases mark output", func(t *testing.T) {
+		// Arrange
+		server := screenServer(screenTestChain())
+		defer server.Close()
+
+		var markBuf bytes.Buffer
+		markCmd := NewOptionCmd(testClient(t, server), &markBuf)
+
+		var midBuf bytes.Buffer
+		midCmd := NewOptionCmd(testClient(t, server), &midBuf)
+
+		// Act
+		_, markErr := runTestCommand(t, markCmd, "screen", "AAPL", "--fields", "strike,delta,bid,ask,mark")
+		_, midErr := runTestCommand(t, midCmd, "screen", "AAPL", "--fields", "strike,delta,bid,ask,mid")
+
+		// Assert
+		require.NoError(t, markErr)
+		require.NoError(t, midErr)
+		assert.JSONEq(t, markBuf.String(), midBuf.String())
+
+		var envelope output.Envelope
+		require.NoError(t, json.Unmarshal(midBuf.Bytes(), &envelope))
+
+		data, ok := envelope.Data.(map[string]any)
+		require.True(t, ok)
+
+		cols, ok := data["columns"].([]any)
+		require.True(t, ok)
+		assert.Equal(t, []any{"strike", "delta", "bid", "ask", "mark"}, cols)
+	})
+
+	t.Run("mid and mark fields deduplicate after aliasing", func(t *testing.T) {
+		// Arrange
+		server := screenServer(screenTestChain())
+		defer server.Close()
+
+		var buf bytes.Buffer
+		cmd := NewOptionCmd(testClient(t, server), &buf)
+
+		// Act
+		_, err := runTestCommand(t, cmd, "screen", "AAPL", "--fields", "strike,mark,mid")
+
+		// Assert
+		require.NoError(t, err)
+
+		var envelope output.Envelope
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+
+		data, ok := envelope.Data.(map[string]any)
+		require.True(t, ok)
+
+		cols, ok := data["columns"].([]any)
+		require.True(t, ok)
+		assert.Equal(t, []any{"strike", "mark"}, cols)
+	})
+
 	t.Run("empty chain returns SymbolNotFoundError", func(t *testing.T) {
 		// Arrange
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary
- Accept `mid` in `option screen --fields` and normalize it to the existing `mark` column.
- Deduplicate `mark` when users provide both `mark` and `mid`.
- Add regression coverage for identical `mid`/`mark` output and alias deduplication.

Fixes #148

## Test plan
- `~/bin/coderabbit review --agent --base origin/main -c .coderabbit.yaml`
- `/usr/local/go/bin/go fmt ./internal/commands`
- `/usr/local/go/bin/go test ./internal/commands -run TestOptionScreenCommand -count=1 -v`
- `lsp_diagnostics` on `internal/commands/option_screen.go` and `internal/commands/option_screen_test.go`
- `/usr/local/go/bin/go test ./...`
- `make build`
- `make lint`
- `/usr/local/go/bin/go vet ./...`