### PR TITLE
fix(analyze): return partial output for TA history gaps

### DIFF
--- a/internal/commands/analyze.go
+++ b/internal/commands/analyze.go
@@ -77,11 +77,27 @@ func writeAnalyzeResults(
 	points int,
 ) error {
 	if len(symbols) == 1 {
-		result, err := buildAnalyzeResult(ctx, c, symbols[0], interval, points)
+		symbol := symbols[0]
+		result, err := buildAnalyzeResult(ctx, c, symbol, interval, points)
 		if err != nil {
+			// Keep the single-symbol output contract aligned with the multi-symbol
+			// path below. Young IPOs and thin history can make TA fail even when the
+			// quote is useful, so return a partial envelope instead of discarding the
+			// successful quote and turning the whole command into a hard failure.
+			if result.Quote != nil {
+				meta := output.NewMetadata()
+				meta.Requested = 1
+				meta.Returned = 1
+				return output.WritePartial(
+					w,
+					map[string]any{symbol: result},
+					[]string{fmt.Sprintf("%s: %v", symbol, err)},
+					meta,
+				)
+			}
 			return err
 		}
-		return output.WriteSuccess(w, map[string]any{symbols[0]: result}, output.NewMetadata())
+		return output.WriteSuccess(w, map[string]any{symbol: result}, output.NewMetadata())
 	}
 
 	data := make(map[string]any, len(symbols))
@@ -94,7 +110,7 @@ func writeAnalyzeResults(
 			// Check if result has any partial data (quote or analysis succeeded).
 			// If either field is non-nil, include the partial result and report the error.
 			// Only skip the symbol entirely if both fields are nil (total failure).
-			if result.Quote != nil || result.Analysis != nil {
+			if hasAnalyzeData(result) {
 				data[symbol] = result
 			}
 			partialErrors = append(partialErrors, fmt.Sprintf("%s: %v", symbol, err))
@@ -115,6 +131,10 @@ func writeAnalyzeResults(
 	}
 
 	return output.WriteSuccess(w, data, output.NewMetadata())
+}
+
+func hasAnalyzeData(result analyzeResult) bool {
+	return result.Quote != nil || result.Analysis != nil
 }
 
 // buildAnalyzeResult fetches a quote and computes the TA dashboard for a

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -245,6 +245,39 @@ func TestNewAnalyzeCmd_PartialFailure_TAFails(t *testing.T) {
 	assert.Equal(t, 2, envelope.Metadata.Returned)
 }
 
+func TestNewAnalyzeCmd_SingleSymbolTAInsufficientCandles(t *testing.T) {
+	// Arrange - issue #150: a young symbol can have a valid quote but fewer
+	// candles than ta dashboard needs. analyze should keep the quote and report a
+	// partial failure instead of returning a command-level validation error.
+	srv := analyzeServer(t, invalidAnalyzeQuoteEntryResponse, mockCandleListJSON("INVALID", 190))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "INVALID")
+	require.NoError(t, err)
+
+	// Assert
+	var envelope output.Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok, "data should be a map")
+	require.Contains(t, data, "INVALID")
+
+	symbolData, ok := data["INVALID"].(map[string]any)
+	require.True(t, ok, "INVALID entry should be a map")
+	assert.NotNil(t, symbolData["quote"], "quote should be present when quote fetch succeeds")
+	assert.Nil(t, symbolData["analysis"], "analysis should be nil when TA lacks enough candles")
+
+	require.Len(t, envelope.Errors, 1)
+	assert.Contains(t, envelope.Errors[0], "INVALID")
+	assert.Contains(t, envelope.Errors[0], "dashboard requires at least 252 candles, got 190")
+	assert.Equal(t, 1, envelope.Metadata.Requested)
+	assert.Equal(t, 1, envelope.Metadata.Returned)
+}
+
 func TestNewAnalyzeCmd_QuoteHTTPNotFound(t *testing.T) {
 	// Arrange - schwab-go turns a 404 quote response into an API error. analyze
 	// should preserve the existing quote command behavior by mapping that to the


### PR DESCRIPTION
Fix single-symbol `analyze` so a successful quote is still returned when TA dashboard cannot compute due to limited history.

- Return a partial envelope with `analysis: null` when quote succeeds but TA fails
- Preserve fatal behavior for single-symbol quote-not-found cases
- Add a regression test for the insufficient-candles path

Closes #150

Verification:
- go test ./internal/commands -run 'TestNewAnalyzeCmd_(SingleSymbolTAInsufficientCandles|QuoteHTTPNotFound|QuoteResponseMissingSymbol|PartialFailure_TAFails|SingleSymbol)$' -count=1 -v
- go test ./...
- make build
- make lint
- coderabbit review --agent --base origin/main -c .coderabbit.yaml