### PR TITLE
fix(analyze): preserve TA-only partial output

### DIFF
--- a/internal/commands/analyze.go
+++ b/internal/commands/analyze.go
@@ -81,10 +81,14 @@ func writeAnalyzeResults(
 		result, err := buildAnalyzeResult(ctx, c, symbol, interval, points)
 		if err != nil {
 			// Keep the single-symbol output contract aligned with the multi-symbol
-			// path below. Young IPOs and thin history can make TA fail even when the
-			// quote is useful, so return a partial envelope instead of discarding the
-			// successful quote and turning the whole command into a hard failure.
-			if result.Quote != nil {
+			// path below. Young IPOs, thin history, or transient quote failures can
+			// leave one side useful, so return a partial envelope instead of discarding
+			// the successful data and turning the whole command into a hard failure.
+			// Symbol-not-found stays fatal because TA can still succeed from historical
+			// candles even when the quote endpoint proves the requested symbol is not
+			// available as a current quote.
+			var symErr *apperr.SymbolNotFoundError
+			if !errors.As(err, &symErr) && hasAnalyzeData(result) {
 				meta := output.NewMetadata()
 				meta.Requested = 1
 				meta.Returned = 1

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -328,6 +328,79 @@ func TestNewAnalyzeCmd_QuoteResponseMissingSymbol(t *testing.T) {
 	require.ErrorAs(t, err, &symErr)
 }
 
+func TestNewAnalyzeCmd_SingleSymbolQuoteFailsTASucceeds(t *testing.T) {
+	// Arrange - single-symbol analyze should preserve successful TA output when a
+	// non-symbol quote failure happens. This matches multi-symbol partial output
+	// behavior without weakening the SymbolNotFoundError hard-fail cases above.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(r.URL.Path, "/quotes"):
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"temporary quote failure"}`))
+		case strings.Contains(r.URL.Path, "/pricehistory"):
+			_, _ = w.Write([]byte(mockCandleListJSON("AAPL", 252)))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "AAPL")
+	require.NoError(t, err)
+
+	// Assert
+	var envelope output.Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok, "data should be a map")
+	require.Contains(t, data, "AAPL")
+
+	symbolData, ok := data["AAPL"].(map[string]any)
+	require.True(t, ok, "AAPL entry should be a map")
+	assert.Nil(t, symbolData["quote"], "quote should be nil when quote fetch fails")
+	assert.NotNil(t, symbolData["analysis"], "analysis should be present when TA succeeds")
+
+	require.Len(t, envelope.Errors, 1)
+	assert.Contains(t, envelope.Errors[0], "AAPL")
+	assert.Contains(t, envelope.Errors[0], "quote failed")
+	assert.Equal(t, 1, envelope.Metadata.Requested)
+	assert.Equal(t, 1, envelope.Metadata.Returned)
+}
+
+func TestNewAnalyzeCmd_SingleSymbolBothFail(t *testing.T) {
+	// Arrange - when neither quote nor TA produces usable data, analyze should
+	// return the command-level error instead of writing an empty partial envelope.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(r.URL.Path, "/quotes"):
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"temporary quote failure"}`))
+		case strings.Contains(r.URL.Path, "/pricehistory"):
+			_, _ = w.Write([]byte(`{"symbol":"AAPL","empty":true,"candles":[]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "AAPL")
+
+	// Assert
+	require.Error(t, err)
+	assert.Empty(t, buf.String(), "analyze should not write a partial envelope when both data sources fail")
+}
+
 func TestNewAnalyzeCmd_InvalidInterval(t *testing.T) {
 	// Arrange
 	ref := &client.Ref{}

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -397,7 +397,8 @@ func TestNewAnalyzeCmd_SingleSymbolBothFail(t *testing.T) {
 	_, err := runTestCommand(t, cmd, "AAPL")
 
 	// Assert
-	require.Error(t, err)
+	var httpErr *apperr.HTTPError
+	require.ErrorAs(t, err, &httpErr)
 	assert.Empty(t, buf.String(), "analyze should not write a partial envelope when both data sources fail")
 }
 


### PR DESCRIPTION
## Summary
- Preserve single-symbol `analyze` partial output when quote retrieval fails but TA succeeds.
- Keep `SymbolNotFoundError` as a hard failure so missing symbols do not return stale-looking TA-only output.
- Add regressions for TA-only partial output and total quote plus TA failure.

## Verification
- `/usr/local/go/bin/go test ./internal/commands -run 'TestNewAnalyzeCmd_(SingleSymbolQuoteFailsTASucceeds|SingleSymbolBothFail|SingleSymbolTAInsufficientCandles|QuoteHTTPNotFound|QuoteResponseMissingSymbol|PartialFailure_TAFails|SingleSymbol)$' -count=1 -v`
- `/usr/local/go/bin/go test ./...`
- `make build`
- `make lint`
- `coderabbit review --agent --base origin/main -c .coderabbit.yaml` found one test assertion issue, fixed in `ac57551`; not rerun to preserve one local CodeRabbit run per PR.

Follow-up to Copilot feedback on #151.