### PR TITLE
fix(analyze): degrade intraday TA dashboards

### DIFF
--- a/internal/commands/analyze.go
+++ b/internal/commands/analyze.go
@@ -40,6 +40,7 @@ type compactAnalyzeResult struct {
 	Quote     map[string]any `json:"quote,omitempty"`
 	Technical map[string]any `json:"technical,omitempty"`
 	Signals   map[string]any `json:"signals,omitempty"`
+	Warnings  []string       `json:"warnings,omitempty"`
 }
 
 type analyzeRequest struct {
@@ -352,6 +353,7 @@ func buildCompactAnalyzeResult(quote *marketdata.QuoteEntry, dashboard dashboard
 		Quote:     compactAnalyzeQuote(quote),
 		Technical: compactAnalyzeTechnical(dashboard),
 		Signals:   compactAnalyzeSignals(dashboard),
+		Warnings:  dashboard.Warnings,
 	}
 }
 
@@ -401,12 +403,16 @@ func compactAnalyzeSignals(dashboard dashboardOutput) map[string]any {
 	if dashboard.Signals == nil {
 		return nil
 	}
-	return map[string]any{
-		"trend":            dashboard.Signals["trend"],
-		"momentum":         dashboard.Signals["momentum"],
-		fieldVolatility:    dashboard.Signals[fieldVolatility],
-		dashboardKeyVolume: dashboard.Signals[dashboardKeyVolume],
+	compact := make(map[string]any)
+	for _, key := range []string{
+		"trend",
+		"momentum",
+		fieldVolatility,
+		dashboardKeyVolume,
+	} {
+		copyCompactField(compact, dashboard.Signals, key, key)
 	}
+	return compact
 }
 
 func copyCompactField(dst, src map[string]any, dstKey, srcKey string) {

--- a/internal/commands/analyze_test.go
+++ b/internal/commands/analyze_test.go
@@ -331,6 +331,37 @@ func TestNewAnalyzeCmd_CompactOutput(t *testing.T) {
 	assert.NotContains(t, symbolData, "analysis", "compact output should omit full dashboard")
 }
 
+func TestNewAnalyzeCmd_CompactOutputIncludesDashboardWarnings(t *testing.T) {
+	// Arrange - compact output must keep degradation warnings because it drops the
+	// full dashboard where callers would otherwise see skipped long-window fields.
+	quoteJSON := `{"NET":{"assetMainType":"EQUITY","symbol":"NET","quote":{"lastPrice":100.0}}}`
+	srv := analyzeServer(t, quoteJSON, mockCandleListJSON("NET", 260))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "NET", "--interval", "15min", "--points", "30", "--compact")
+	require.NoError(t, err)
+
+	// Assert
+	var envelope output.Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok, "data should be a map")
+	symbolData, ok := data["NET"].(map[string]any)
+	require.True(t, ok, "NET entry should be a compact map")
+
+	technical, ok := symbolData["technical"].(map[string]any)
+	require.True(t, ok, "compact technical fields should be present")
+	assert.Contains(t, technical, "distance_from_sma_200_percent")
+	assert.NotContains(t, technical, "range_252_high")
+
+	warnings, ok := symbolData["warnings"].([]any)
+	require.True(t, ok, "compact warnings should be present")
+	assertWarningContains(t, warnings, "skipped range_252_high", "260 candles", "need 281")
+}
+
 func TestNewAnalyzeCmd_PartialFailure_TAFails(t *testing.T) {
 	// Arrange - test partial failure: AAPL succeeds completely, INVALID has quote
 	// succeed but TA fail (empty candles). This verifies that partial data (quote
@@ -411,13 +442,94 @@ func TestNewAnalyzeCmd_SingleSymbolTAInsufficientCandles(t *testing.T) {
 	symbolData, ok := data["INVALID"].(map[string]any)
 	require.True(t, ok, "INVALID entry should be a map")
 	assert.NotNil(t, symbolData["quote"], "quote should be present when quote fetch succeeds")
-	assert.Nil(t, symbolData["analysis"], "analysis should be nil when TA lacks enough candles")
+	analysis, ok := symbolData["analysis"].(map[string]any)
+	require.True(t, ok, "analysis should be present when core dashboard candles are available")
+	assert.Empty(t, envelope.Errors)
+	assert.Contains(t, analysis, "warnings")
+	assert.NotContains(t, analysis["latest"], "sma_200")
+}
 
-	require.Len(t, envelope.Errors, 1)
-	assert.Contains(t, envelope.Errors[0], "INVALID")
-	assert.Contains(t, envelope.Errors[0], "dashboard requires at least 252 candles, got 190")
-	assert.Equal(t, 1, envelope.Metadata.Requested)
-	assert.Equal(t, 1, envelope.Metadata.Returned)
+func TestNewAnalyzeCmd_IntradayDashboardDegradesAtSchwabLimit(t *testing.T) {
+	// Arrange - issue #157: 15-minute history caps at 260 candles, below the 281
+	// candles needed for 30 rows of 252-candle range context. Analyze should still
+	// return computable indicators and warn about the skipped long-window fields.
+	historyRequests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(r.URL.Path, "/quotes"):
+			_, _ = w.Write([]byte(`{"NET":{"assetMainType":"EQUITY","symbol":"NET","quote":{"lastPrice":100.0}}}`))
+		case strings.Contains(r.URL.Path, "/pricehistory"):
+			historyRequests++
+			assert.Equal(t, "NET", r.URL.Query().Get("symbol"))
+			assert.Equal(
+				t,
+				"10",
+				r.URL.Query().Get("period"),
+				"15-minute dashboard should request Schwab's max day period",
+			)
+			assert.Equal(t, "15", r.URL.Query().Get("frequency"))
+			_, _ = w.Write([]byte(mockCandleListJSON("NET", 260)))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewAnalyzeCmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "NET", "--interval", "15min", "--points", "30", "--latest-only")
+	require.NoError(t, err)
+
+	// Assert
+	var envelope output.Envelope
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.Empty(t, envelope.Errors)
+	assert.Equal(t, 1, historyRequests)
+
+	data, ok := envelope.Data.(map[string]any)
+	require.True(t, ok, "data should be a map")
+	symbolData, ok := data["NET"].(map[string]any)
+	require.True(t, ok, "NET entry should be a map")
+	assert.NotNil(t, symbolData["quote"], "quote should be present")
+
+	analysis, ok := symbolData["analysis"].(map[string]any)
+	require.True(t, ok, "analysis should be present")
+	assert.NotContains(t, analysis, "values", "latest-only should still omit duplicate rows")
+
+	latest, ok := analysis["latest"].(map[string]any)
+	require.True(t, ok, "latest should be present")
+	assert.Contains(t, latest, "sma_200", "260 candles can still compute SMA 200 for the latest 30-row window")
+	assert.NotContains(t, latest, "range_252_high")
+	assert.NotContains(t, latest, "distance_from_range_252_high_percent")
+
+	warnings, ok := analysis["warnings"].([]any)
+	require.True(t, ok, "warnings should be present")
+	assertWarningContains(t, warnings, "skipped range_252_high", "260 candles", "need 281")
+}
+
+func assertWarningContains(t *testing.T, warnings []any, substrings ...string) {
+	t.Helper()
+	require.NotEmpty(t, warnings, "warnings should not be empty")
+	for _, warning := range warnings {
+		warningText, ok := warning.(string)
+		if !ok {
+			continue
+		}
+		matched := true
+		for _, substring := range substrings {
+			if !strings.Contains(warningText, substring) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return
+		}
+	}
+	t.Fatalf("warnings %v did not contain all substrings %v", warnings, substrings)
 }
 
 func TestNewAnalyzeCmd_QuoteHTTPNotFound(t *testing.T) {

--- a/internal/commands/ta.go
+++ b/internal/commands/ta.go
@@ -146,6 +146,7 @@ type dashboardOutput struct {
 	Symbol     string              `json:"symbol"`
 	Interval   string              `json:"interval"`
 	Parameters dashboardParameters `json:"parameters"`
+	Warnings   []string            `json:"warnings,omitempty"`
 	Latest     map[string]any      `json:"latest"`
 	Signals    map[string]any      `json:"signals"`
 	Values     []map[string]any    `json:"values,omitempty"`
@@ -174,6 +175,13 @@ type dashboardSeries struct {
 	BBandsMid   []float64
 	BBandsLower []float64
 	AvgVolume20 []float64
+}
+
+type dashboardRows struct {
+	Rows             []map[string]any
+	BaseStart        int
+	IncludesSMA200   bool
+	IncludesRange252 bool
 }
 
 const (
@@ -628,6 +636,7 @@ func buildTADashboard(
 	symbol, interval string,
 	points int,
 ) (dashboardOutput, error) {
+	requestedRows := dashboardRequestedRows(points)
 	inputs, err := fetchDashboardInputs(ctx, c, symbol, interval, points)
 	if err != nil {
 		return dashboardOutput{}, err
@@ -636,17 +645,26 @@ func buildTADashboard(
 	if err != nil {
 		return dashboardOutput{}, err
 	}
-	rows, err := buildDashboardRows(inputs, series)
+	rowSet, err := buildDashboardRows(inputs, series, points)
 	if err != nil {
 		return dashboardOutput{}, err
 	}
+	rows := rowSet.Rows
 
 	latest := cloneDashboardRow(rows[len(rows)-1])
 	signals, err := dashboardSignals(latest)
 	if err != nil {
 		return dashboardOutput{}, err
 	}
-	return newDashboardOutput(symbol, interval, points, latest, signals, rows), nil
+	warnings := dashboardWarnings(inputs, rowSet, requestedRows)
+	return newDashboardOutput(symbol, interval, points, warnings, latest, signals, rows), nil
+}
+
+func dashboardRequestedRows(points int) int {
+	if points > 0 {
+		return points
+	}
+	return 1
 }
 
 func fetchDashboardInputs(
@@ -655,13 +673,14 @@ func fetchDashboardInputs(
 	symbol, interval string,
 	points int,
 ) (dashboardInputs, error) {
-	requestedRows := 1
-	if points > 0 {
-		requestedRows = points
+	requestedRows := dashboardRequestedRows(points)
+	desiredCandles := dashboardLongRangePeriod + requestedRows - 1
+	requestCandles := desiredCandles
+	if maxCandles := ta.MaxCandlesForInterval(interval); maxCandles > 0 && requestCandles > maxCandles {
+		requestCandles = maxCandles
 	}
-	minCandles := dashboardLongRangePeriod + requestedRows - 1
 
-	candles, timestamps, err := fetchAndValidateCandles(ctx, c, symbol, interval, minCandles, "dashboard")
+	candles, timestamps, err := fetchDashboardCandles(ctx, c, symbol, interval, requestCandles)
 	if err != nil {
 		return dashboardInputs{}, err
 	}
@@ -684,6 +703,46 @@ func fetchDashboardInputs(
 	return inputs, nil
 }
 
+func fetchDashboardCandles(
+	ctx context.Context,
+	c *client.Ref,
+	symbol, interval string,
+	requestCandles int,
+) ([]marketdata.Candle, []string, error) {
+	periodType, periodVal, freqType, freq, err := ta.IntervalToHistoryParams(interval, requestCandles)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	params, err := newPriceHistoryParams(priceHistoryParamsInput{
+		PeriodType:    periodType,
+		Period:        periodVal,
+		FrequencyType: freqType,
+		Frequency:     freq,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result, err := c.MarketData.GetPriceHistory(ctx, symbol, params)
+	if err != nil {
+		return nil, nil, mapSchwabGoError(err)
+	}
+
+	// The dashboard is an aggregate view. Unlike simple indicators, it should keep
+	// shorter but still useful histories instead of failing just because optional
+	// long-window context, such as SMA 200 or the 252-candle range, is unavailable.
+	if validateErr := ta.ValidateMinCandles(result.Candles, dashboardSMAMediumPeriod, "dashboard"); validateErr != nil {
+		return nil, nil, validateErr
+	}
+
+	timestamps, err := ta.ExtractTimestamps(result.Candles)
+	if err != nil {
+		return nil, nil, err
+	}
+	return result.Candles, timestamps, nil
+}
+
 func buildDashboardSeries(inputs dashboardInputs) (dashboardSeries, error) {
 	series := dashboardSeries{}
 	var err error
@@ -693,8 +752,10 @@ func buildDashboardSeries(inputs dashboardInputs) (dashboardSeries, error) {
 	if series.SMA50, err = ta.SMA(inputs.Closes, dashboardSMAMediumPeriod); err != nil {
 		return dashboardSeries{}, err
 	}
-	if series.SMA200, err = ta.SMA(inputs.Closes, dashboardSMALongPeriod); err != nil {
-		return dashboardSeries{}, err
+	if len(inputs.Closes) >= dashboardSMALongPeriod {
+		if series.SMA200, err = ta.SMA(inputs.Closes, dashboardSMALongPeriod); err != nil {
+			return dashboardSeries{}, err
+		}
 	}
 	if series.RSI14, err = ta.RSI(inputs.Closes, dashboardRSIPeriod); err != nil {
 		return dashboardSeries{}, err
@@ -726,22 +787,45 @@ func buildDashboardSeries(inputs dashboardInputs) (dashboardSeries, error) {
 	return series, nil
 }
 
-func buildDashboardRows(inputs dashboardInputs, series dashboardSeries) ([]map[string]any, error) {
-	baseStart := dashboardLongRangePeriod - 1
+func buildDashboardRows(inputs dashboardInputs, series dashboardSeries, points int) (dashboardRows, error) {
+	baseStart := dashboardBaseStart(inputs, series, points)
 	rows := dashboardBaseRows(inputs, baseStart)
 	if err := addDashboardSeries(rows, series); err != nil {
-		return nil, err
+		return dashboardRows{}, err
 	}
-	if err := addDashboardDerivedFields(rows, inputs, baseStart); err != nil {
-		return nil, err
+	includesRange252 := baseStart >= dashboardLongRangePeriod-1
+	if err := addDashboardDerivedFields(rows, inputs, baseStart, includesRange252); err != nil {
+		return dashboardRows{}, err
 	}
 
-	return rows, nil
+	return dashboardRows{
+		Rows:             rows,
+		BaseStart:        baseStart,
+		IncludesSMA200:   len(series.SMA200) > 0,
+		IncludesRange252: includesRange252,
+	}, nil
+}
+
+func dashboardBaseStart(inputs dashboardInputs, series dashboardSeries, points int) int {
+	longestRequiredIndex := dashboardSMAMediumPeriod - 1
+	if len(series.SMA200) > 0 {
+		longestRequiredIndex = dashboardSMALongPeriod - 1
+	}
+	if points == 0 {
+		if len(inputs.Candles) >= dashboardLongRangePeriod {
+			return dashboardLongRangePeriod - 1
+		}
+		return longestRequiredIndex
+	}
+
+	requestedRows := dashboardRequestedRows(points)
+	return max(longestRequiredIndex, len(inputs.Candles)-requestedRows)
 }
 
 func newDashboardOutput(
 	symbol, interval string,
 	points int,
+	warnings []string,
 	latest, signals map[string]any,
 	rows []map[string]any,
 ) dashboardOutput {
@@ -762,9 +846,10 @@ func newDashboardOutput(
 			RangePeriod:  dashboardRangePeriod,
 			LongRange:    dashboardLongRangePeriod,
 		},
-		Latest:  latest,
-		Signals: signals,
-		Values:  limitDashboardRows(rows, points),
+		Warnings: warnings,
+		Latest:   latest,
+		Signals:  signals,
+		Values:   limitDashboardRows(rows, points),
 	}
 }
 
@@ -801,6 +886,9 @@ func addDashboardSeries(rows []map[string]any, series dashboardSeries) error {
 		dashboardKeyBBandsLower:   series.BBandsLower,
 		dashboardKeyAvgVolume20:   series.AvgVolume20,
 	} {
+		if values == nil {
+			continue
+		}
 		if err := addTailAlignedFloat(rows, key, values); err != nil {
 			return err
 		}
@@ -809,9 +897,14 @@ func addDashboardSeries(rows []map[string]any, series dashboardSeries) error {
 	return nil
 }
 
-func addDashboardDerivedFields(rows []map[string]any, inputs dashboardInputs, baseStart int) error {
+func addDashboardDerivedFields(
+	rows []map[string]any,
+	inputs dashboardInputs,
+	baseStart int,
+	includeLongRange bool,
+) error {
 	for i := range rows {
-		if err := addDashboardDerivedRow(rows[i], inputs, baseStart+i); err != nil {
+		if err := addDashboardDerivedRow(rows[i], inputs, baseStart+i, includeLongRange); err != nil {
 			return err
 		}
 	}
@@ -819,7 +912,7 @@ func addDashboardDerivedFields(rows []map[string]any, inputs dashboardInputs, ba
 	return nil
 }
 
-func addDashboardDerivedRow(row map[string]any, inputs dashboardInputs, candleIndex int) error {
+func addDashboardDerivedRow(row map[string]any, inputs dashboardInputs, candleIndex int, includeLongRange bool) error {
 	closePrice, err := dashboardRowFloat(row, dashboardKeyClose)
 	if err != nil {
 		return err
@@ -844,24 +937,24 @@ func addDashboardDerivedRow(row map[string]any, inputs dashboardInputs, candleIn
 	if err != nil {
 		return err
 	}
-	sma200Value, err := dashboardRowFloat(row, dashboardKeySMA200)
-	if err != nil {
-		return err
-	}
 
 	rangeHigh20, rangeLow20 := highLowWindow(inputs.Highs, inputs.Lows, candleIndex, dashboardRangePeriod)
-	rangeHigh252, rangeLow252 := highLowWindow(inputs.Highs, inputs.Lows, candleIndex, dashboardLongRangePeriod)
 	row[dashboardKeyATRPercent] = percentOf(atrValue, closePrice)
 	row[dashboardKeyRelativeVolume] = ratio(volume, avgVolume)
 	row[dashboardKeyRange20High] = rangeHigh20
 	row[dashboardKeyRange20Low] = rangeLow20
-	row[dashboardKeyRange252High] = rangeHigh252
-	row[dashboardKeyRange252Low] = rangeLow252
 	row[dashboardKeyDistanceFromSMA21Pct] = percentChange(closePrice, sma21Value)
 	row[dashboardKeyDistanceFromSMA50Pct] = percentChange(closePrice, sma50Value)
-	row[dashboardKeyDistanceFromSMA200Pct] = percentChange(closePrice, sma200Value)
 	row[dashboardKeyDistanceFromRange20Pct] = percentChange(closePrice, rangeHigh20)
-	row[dashboardKeyDistanceFromRange252Pct] = percentChange(closePrice, rangeHigh252)
+	if sma200Value, ok := optionalDashboardRowFloat(row, dashboardKeySMA200); ok {
+		row[dashboardKeyDistanceFromSMA200Pct] = percentChange(closePrice, sma200Value)
+	}
+	if includeLongRange {
+		rangeHigh252, rangeLow252 := highLowWindow(inputs.Highs, inputs.Lows, candleIndex, dashboardLongRangePeriod)
+		row[dashboardKeyRange252High] = rangeHigh252
+		row[dashboardKeyRange252Low] = rangeLow252
+		row[dashboardKeyDistanceFromRange252Pct] = percentChange(closePrice, rangeHigh252)
+	}
 	return nil
 }
 
@@ -979,6 +1072,54 @@ func dashboardRowFloat(row map[string]any, key string) (float64, error) {
 	return floatValue, nil
 }
 
+func optionalDashboardRowFloat(row map[string]any, key string) (float64, bool) {
+	value, ok := row[key]
+	if !ok {
+		return 0, false
+	}
+	floatValue, ok := value.(float64)
+	return floatValue, ok
+}
+
+func dashboardWarnings(inputs dashboardInputs, rowSet dashboardRows, requestedRows int) []string {
+	var warnings []string
+	candleCount := len(inputs.Candles)
+	if !rowSet.IncludesSMA200 {
+		warnings = append(
+			warnings,
+			fmt.Sprintf(
+				"skipped sma_200, distance_from_sma_200_percent, trend, close_above_sma_200, sma_50_above_sma_200 because only %d candles are available; need %d",
+				candleCount,
+				dashboardSMALongPeriod,
+			),
+		)
+	}
+	if !rowSet.IncludesRange252 {
+		neededCandles := dashboardLongRangePeriod + requestedRows - 1
+		warnings = append(
+			warnings,
+			fmt.Sprintf(
+				"skipped range_252_high, range_252_low, distance_from_range_252_high_percent because only %d candles are available for %d requested output row(s); need %d",
+				candleCount,
+				requestedRows,
+				neededCandles,
+			),
+		)
+	}
+	if requestedRows > 0 && len(rowSet.Rows) < requestedRows {
+		warnings = append(
+			warnings,
+			fmt.Sprintf(
+				"returned %d dashboard row(s) because only %d candles are available; requested %d",
+				len(rowSet.Rows),
+				candleCount,
+				requestedRows,
+			),
+		)
+	}
+	return warnings
+}
+
 func dashboardSignals(latest map[string]any) (map[string]any, error) {
 	closePrice, err := dashboardRowFloat(latest, dashboardKeyClose)
 	if err != nil {
@@ -989,10 +1130,6 @@ func dashboardSignals(latest map[string]any) (map[string]any, error) {
 		return nil, err
 	}
 	sma50, err := dashboardRowFloat(latest, dashboardKeySMA50)
-	if err != nil {
-		return nil, err
-	}
-	sma200, err := dashboardRowFloat(latest, dashboardKeySMA200)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,21 +1149,24 @@ func dashboardSignals(latest map[string]any) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return map[string]any{
-		"trend":                   trendSignal(closePrice, sma21, sma50, sma200),
+	signals := map[string]any{
 		"momentum":                momentumSignal(rsi14, macdHist),
 		fieldVolatility:           volatilitySignal(atrPercent),
 		dashboardKeyVolume:        volumeSignal(relativeVolume),
 		"close_above_sma_21":      closePrice > sma21,
 		"close_above_sma_50":      closePrice > sma50,
-		"close_above_sma_200":     closePrice > sma200,
 		"sma_21_above_sma_50":     sma21 > sma50,
-		"sma_50_above_sma_200":    sma50 > sma200,
 		"rsi_overbought":          rsi14 >= rsiOverboughtThreshold,
 		"rsi_oversold":            rsi14 <= rsiOversoldThreshold,
 		"macd_histogram_positive": macdHist > 0,
-	}, nil
+	}
+	if sma200, ok := optionalDashboardRowFloat(latest, dashboardKeySMA200); ok {
+		signals["trend"] = trendSignal(closePrice, sma21, sma50, sma200)
+		signals["close_above_sma_200"] = closePrice > sma200
+		signals["sma_50_above_sma_200"] = sma50 > sma200
+	}
+
+	return signals, nil
 }
 
 func trendSignal(closePrice, sma21, sma50, sma200 float64) string {

--- a/internal/commands/ta_test.go
+++ b/internal/commands/ta_test.go
@@ -362,6 +362,34 @@ func TestTADashboard_PointsFlag(t *testing.T) {
 	assert.InDelta(t, 101.0, latest["range_252_low"], 0.1, "latest row should use candles 2-253")
 }
 
+func TestTADashboard_PointsAllKeepsFullLongRangeRows(t *testing.T) {
+	// Arrange: --points 0 means all complete dashboard rows. With 260 candles, the
+	// first full 252-range row starts at candle 251 and the latest row still has the
+	// long-window fields, so no skipped-range warning should be emitted.
+	srv := httptest.NewServer(priceHistoryHandler(t, "NET", 260))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "--points", "0", "NET")
+	require.NoError(t, err)
+
+	// Assert
+	_, data := decodeTAEnvelope(t, &buf)
+	values, ok := data["values"].([]any)
+	require.True(t, ok, "values should be an array")
+	require.Len(t, values, 9, "260 candles should produce nine complete 252-range rows")
+
+	first, ok := values[0].(map[string]any)
+	require.True(t, ok, "first value should be an object")
+	latest, ok := data["latest"].(map[string]any)
+	require.True(t, ok, "latest should be an object")
+	assert.Contains(t, first, "range_252_high")
+	assert.Contains(t, latest, "range_252_high")
+	assert.NotContains(t, data, "warnings")
+}
+
 func TestTADashboard_FlatHistoryDoesNotPanic(t *testing.T) {
 	// Arrange
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -392,6 +420,43 @@ func TestTADashboard_FlatHistoryDoesNotPanic(t *testing.T) {
 func TestTADashboard_InsufficientHistory(t *testing.T) {
 	// Arrange
 	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 100))
+	defer srv.Close()
+
+	// Act
+	var buf bytes.Buffer
+	cmd := NewTACmd(testClientWithMarketData(t, srv), &buf)
+	_, err := runTestCommand(t, cmd, "dashboard", "AAPL")
+
+	// Assert: dashboard should keep shorter but still useful histories. Long-window
+	// context is omitted with warnings instead of making the whole command fail.
+	require.NoError(t, err)
+	_, data := decodeTAEnvelope(t, &buf)
+
+	latest, ok := data["latest"].(map[string]any)
+	require.True(t, ok, "latest should be an object")
+	assert.Contains(t, latest, "sma_50")
+	assert.Contains(t, latest, "rsi_14")
+	assert.NotContains(t, latest, "sma_200")
+	assert.NotContains(t, latest, "range_252_high")
+	assert.NotContains(t, latest, "distance_from_sma_200_percent")
+
+	signals, ok := data["signals"].(map[string]any)
+	require.True(t, ok, "signals should be an object")
+	assert.Contains(t, signals, "momentum")
+	assert.NotContains(t, signals, "trend")
+	assert.NotContains(t, signals, "close_above_sma_200")
+
+	warnings, ok := data["warnings"].([]any)
+	require.True(t, ok, "warnings should be an array")
+	require.NotEmpty(t, warnings)
+	assert.Contains(t, warnings[0], "skipped sma_200")
+	assert.Contains(t, warnings[0], "100 candles")
+}
+
+func TestTADashboard_TooFewCoreCandlesStillFails(t *testing.T) {
+	// Arrange: fewer than 50 candles cannot produce the dashboard's core SMA 50
+	// context, so this remains a validation error instead of a sparse shell.
+	srv := httptest.NewServer(priceHistoryHandler(t, "AAPL", 49))
 	defer srv.Close()
 
 	// Act

--- a/internal/ta/interval.go
+++ b/internal/ta/interval.go
@@ -96,6 +96,13 @@ func maxCandlesForInterval(interval string) int {
 	}
 }
 
+// MaxCandlesForInterval returns the theoretical Schwab API candle limit for an
+// interval. Dashboard-style callers use this to cap best-effort history requests
+// before IntervalToHistoryParams applies its hard validation for simple indicators.
+func MaxCandlesForInterval(interval string) int {
+	return maxCandlesForInterval(interval)
+}
+
 // IntervalToHistoryParams maps a human interval string to PriceHistory query params.
 // requiredCandles controls how much history to fetch: the period is scaled up so the
 // API returns at least that many candles. Pass 0 to use the default (minimum) lookback.


### PR DESCRIPTION
Fixes #157

## Summary
- Cap dashboard history requests at Schwab's interval candle limit so intraday analyze requests do not fail before fetching data.
- Return computable dashboard fields when core history exists, omit unavailable long-window fields, and include warnings that explain skipped indicators.
- Preserve warnings in compact analyze output and keep `--points 0` limited to complete long-range rows when available.

## Verification
- `/usr/local/go/bin/go test ./...`
- `make build`
- `make lint`
- `make smoke-ci`
- Local CodeRabbit review: 0 findings