### PR TITLE
Show git SHA for dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 .PHONY: build test lint clean install release smoke smoke-ci
 
+BUILD_VERSION ?= $(shell if git describe --tags --exact-match >/dev/null 2>&1; then git describe --tags --exact-match; else printf 'dev-%s' "$$(git rev-parse --short=7 HEAD)"; fi)
+GO_LDFLAGS ?= -X main.version=$(BUILD_VERSION)
+
 build:
-	go build -o schwab-agent ./cmd/schwab-agent/
+	go build -ldflags "$(GO_LDFLAGS)" -o schwab-agent ./cmd/schwab-agent/
 
 test:
 	go test -v -race -coverprofile=coverage.out ./...
@@ -15,7 +18,7 @@ clean:
 	rm -rf dist/
 
 install:
-	go install ./cmd/schwab-agent/
+	go install -ldflags "$(GO_LDFLAGS)" ./cmd/schwab-agent/
 
 smoke:
 	SMOKE_TIER=all ./scripts/smoke-test.sh

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ cd schwab-agent
 make build
 ```
 
+Local Makefile builds report `dev-<short-git-sha>` from `schwab-agent --version`; release builds report the tagged version.
+
 ## Getting started
 
 ### 1. Create a Schwab developer app

--- a/cmd/schwab-agent/main.go
+++ b/cmd/schwab-agent/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 
@@ -43,13 +44,48 @@ func buildAppWithDeps(w io.Writer, deps commands.RootDeps) *cobra.Command {
 	tokenPath := defaultTokenPath()
 	authDeps := commands.DefaultAuthDeps()
 
-	root := commands.BuildCommandTree(w, configPath, tokenPath, version, deps, authDeps)
+	root := commands.BuildCommandTree(w, configPath, tokenPath, displayVersion(), deps, authDeps)
 
 	// Register --instruction/--order-type flag aliases on qualifying order
 	// commands after the command tree is fully built.
 	commands.RegisterOrderFlagAliasesOnTree(root)
 
 	return root
+}
+
+// displayVersion returns release versions unchanged, but annotates local dev
+// builds with the Git revision embedded by the Go toolchain. That keeps release
+// ldflags authoritative while making ad-hoc binaries traceable.
+func displayVersion() string {
+	if version != "dev" {
+		return version
+	}
+
+	if revision := buildRevision(); revision != "" {
+		return "dev-" + shortRevision(revision)
+	}
+	return version
+}
+
+func buildRevision() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
+		}
+	}
+	return ""
+}
+
+func shortRevision(revision string) string {
+	const shortSHAChars = 7
+	if len(revision) <= shortSHAChars {
+		return revision
+	}
+	return revision[:shortSHAChars]
 }
 
 // defaultConfigPath returns the default config file location.

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -595,3 +595,17 @@ func TestBuildApp_VersionFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "dev")
 }
+
+func TestDisplayVersion_ReleaseVersionUnchanged(t *testing.T) {
+	originalVersion := version
+	t.Cleanup(func() { version = originalVersion })
+
+	version = "v1.2.3"
+
+	assert.Equal(t, "v1.2.3", displayVersion())
+}
+
+func TestShortRevision(t *testing.T) {
+	assert.Equal(t, "abcdef1", shortRevision("abcdef1234567890"))
+	assert.Equal(t, "abc123", shortRevision("abc123"))
+}

--- a/cmd/schwab-agent/main_test.go
+++ b/cmd/schwab-agent/main_test.go
@@ -606,6 +606,36 @@ func TestDisplayVersion_ReleaseVersionUnchanged(t *testing.T) {
 }
 
 func TestShortRevision(t *testing.T) {
-	assert.Equal(t, "abcdef1", shortRevision("abcdef1234567890"))
-	assert.Equal(t, "abc123", shortRevision("abc123"))
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "truncates long revision",
+			in:   "abcdef1234567890",
+			want: "abcdef1",
+		},
+		{
+			name: "leaves exact length revision unchanged",
+			in:   "abcdef1",
+			want: "abcdef1",
+		},
+		{
+			name: "leaves short revision unchanged",
+			in:   "abc123",
+			want: "abc123",
+		},
+		{
+			name: "leaves empty revision unchanged",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shortRevision(tt.in))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Show local development builds as `dev-<short-git-sha>` instead of plain `dev`.
- Keep release ldflags authoritative so tagged builds still report the release version.
- Document the local Makefile version behavior and cover SHA shortening edge cases.

## Verification
- `go test ./cmd/schwab-agent -run 'Test(BuildApp_VersionFlag|DisplayVersion_ReleaseVersionUnchanged|ShortRevision)' -count=1 -v`
- `go test ./...`
- `make build`
- `./schwab-agent --version` -> `schwab-agent version dev-ef89380`
- `make lint`
- `coderabbit review --agent --base origin/main -c .coderabbit.yaml` (1 finding fixed)